### PR TITLE
null safety for sankey chart with for data with no name

### DIFF
--- a/website/src/app/(main)/spending/canada-revenue-agency/page.tsx
+++ b/website/src/app/(main)/spending/canada-revenue-agency/page.tsx
@@ -55,13 +55,20 @@ export default function Department() {
 					10 government departments accounted for 73.2% of federal spending in FY 2024.
 				</H3>
 				<ChartContainer>
-					<FederalSpendingChart />
+					<DepartmentSpendingChart department={department} />
 				</ChartContainer>
+
 
 			</Section>
 
-			<DepartmentSpendingChart department={department} />
-
+			<Section>
+				<ChartContainer>
+				<H3>
+					Percentage of federal budget dedicated to Canada Revenue Agency, FYs 1995-2024
+				</H3>
+					<FederalSpendingChart />
+				</ChartContainer>
+			</Section>
 			<Section>
 				<P>
 					Federal spending may shift over time due to economic fluctuations, changes in tax policy, and the expansion of benefit programs. Since 1995, overall federal spending has risen 74.9%, while Canada Revenue Agency spending has increased 302%

--- a/website/src/app/(main)/spending/global-affairs-canada/page.tsx
+++ b/website/src/app/(main)/spending/global-affairs-canada/page.tsx
@@ -2,7 +2,7 @@ import { FederalSpendingByEntity } from "@/app/(main)/spending/global-affairs-ca
 import { FederalSpendingChart } from "@/app/(main)/spending/global-affairs-canada/FederalSpendingChart";
 import { MiniSankey } from "@/app/(main)/spending/global-affairs-canada/MiniSankey";
 import { DepartmentList } from "@/components/DepartmentList";
-import { ChartContainer, ExternalLink, H1, H2, Intro, P, Page, PageContent, Section, UL } from "@/components/Layout";
+import {ChartContainer, ExternalLink, H1, H2, H3, Intro, P, Page, PageContent, Section, UL} from "@/components/Layout";
 import NoSSR from "@/components/NoSSR";
 import { StatCard, StatCardContainer } from "@/components/StatCard";
 import type { Metadata } from 'next';
@@ -54,6 +54,7 @@ export default function Department() {
 				</P>
 
 				<ChartContainer>
+					<H3>Percentage of federal budget dedicated to Global Affairs Canada, FYs 1995-2024</H3>
 					<FederalSpendingChart />
 				</ChartContainer>
 
@@ -103,6 +104,7 @@ export default function Department() {
 					Federal departments often contain other entities. In FY 2024, Global Affairs Canada’s entities with the highest expenditures were:
 				</P>
 				<ChartContainer>
+					<H3>Global Affairs Canada, Spending by Entity, FY 2024 (in billions)</H3>
 					<FederalSpendingByEntity />
 				</ChartContainer>
 			</Section>

--- a/website/src/app/(main)/spending/immigration-refugees-and-citizenship/FederalSpendingByEntity.tsx
+++ b/website/src/app/(main)/spending/immigration-refugees-and-citizenship/FederalSpendingByEntity.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import { BarChart } from "@/components/BarChart";
+
+// Data from TAB 44
+const data = [
+  { name: "Department of Citizenship and Immigration", Amount: 5.994256 },
+  { name: "Immigration and Refugee Board", Amount: 0.341256 }
+].sort((a, b) => b.Amount - a.Amount);
+
+export function FederalSpendingByEntity() {
+  return <BarChart
+    className="h-72"
+    data={data}
+    index="name"
+    categories={["Amount"]}
+    yAxisWidth={400}
+    layout="vertical"
+    showGridLines={false}
+    showXAxis={false}
+    type="stacked"
+  />
+
+}

--- a/website/src/app/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx
+++ b/website/src/app/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { SankeyChart } from "@/components/Sankey/SankeyChart";
+import { SankeyData } from "@/components/Sankey/SankeyChartD3";
+
+// Data from TAB 43
+const data = {
+  "spending": 6.3,
+  "spending_data": {
+    "name": "Immigration, Refugees and Citizenship",
+    "children": [
+      {
+        "name": "Personnel",
+        "amount": 1.655261
+      },
+      {
+        "name": "Transportation + Communication",
+        "amount": 0.083547
+      },
+      {
+        "name": "Information",
+        "amount": 0.013223
+      },
+      {
+        "name": "Professional + Special Services",
+        "amount": 1.669685
+      },
+      {
+        "name": "Rentals",
+        "amount": 0.442464
+      },
+      {
+        "name": "Repair + Maintenance",
+        "amount": 0.002575
+      },
+      {
+        "name": "Utilities, Materials and Supplies",
+        "amount": 0.043101
+      },
+      {
+        "name": "Acquisition of Land, Buildings and Works",
+        "amount": 0.002545
+      },
+      {
+        "name": "Acquisition of Machinery and Equipment",
+        "amount": 0.021627
+      },
+      {
+        "name": "Transfer Payments",
+        "amount": 2.993638
+      },
+      {
+        "name": "Public Debt Charges",
+        "amount": 0
+      },
+      {
+        "name": "Other subsidies and payments",
+        "amount": 0.024085
+      },
+      {
+        "name": "External Revenues",
+        "amount": -0.613454
+      },
+      {
+        "name": "Internal Revenues",
+        "amount": -0.002785
+      }
+    ]
+  },
+  revenue_data: {
+  }
+}
+
+export function MiniSankey() {
+  return (
+    <div className='sankey-chart-container spending-only'>
+      <SankeyChart data={data as SankeyData} />
+    </div>
+  );
+}

--- a/website/src/app/(main)/spending/immigration-refugees-and-citizenship/page.tsx
+++ b/website/src/app/(main)/spending/immigration-refugees-and-citizenship/page.tsx
@@ -1,0 +1,114 @@
+import { FederalSpendingByEntity } from "@/app/(main)/spending/immigration-refugees-and-citizenship/FederalSpendingByEntity";
+import { MiniSankey } from "@/app/(main)/spending/immigration-refugees-and-citizenship/MiniSankey";
+import { DepartmentList } from "@/components/DepartmentList";
+import { DepartmentSpendingChart } from "@/components/DepartmentSpendingChart";
+import { ChartContainer, ExternalLink, H1, H2, Intro, P, Page, PageContent, Section } from "@/components/Layout";
+import NoSSR from "@/components/NoSSR";
+import { StatCard, StatCardContainer } from "@/components/StatCard";
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+	title: 'Immigration, Refugees and Citizenship | Canada Spends',
+	description: 'A look at how the Department of Immigration, Refugees and Citizenship spends its budget',
+}
+
+const department = "Immigration, Refugees and Citizenship";
+
+export default function Department() {
+	return <Page>
+		<PageContent>
+			<Section>
+				<H1>
+					{department}
+				</H1>
+				<Intro>
+					The Department of Immigration, Refugees and Citizenship Canada (IRCC) is the federal department responsible for managing immigration policies, issuing passports, processing visas and permanent residency applications, and supporting newcomers to Canada. It plays a key role in shaping Canada's immigration system, refugee protection policies, and pathways to citizenship.
+				</Intro>
+			</Section>
+
+			<Section>
+				<div className="text-sm text-gray-500 italic">
+					Data updated March 21, 2025
+				</div>
+				<StatCardContainer>
+					<StatCard
+						title="In FY 2024,"
+						value="$6.3B"
+						subtitle="Was spent by the Dept. of Immigration, Refugees and Citizenship"
+					/>
+					<StatCard
+						title="In FY 2024,"
+						value="1.2%"
+						subtitle="Of federal spending was by the Dept. of Immigration, Refugees and Citizenship"
+					/>
+				</StatCardContainer>
+			</Section>
+
+			<Section>
+				<P>
+					IRCC spent $6.3 billion in fiscal year (FY) 2024. This was 1.2% of the $513.9 billion in overall federal spending. The department ranked thirteenth among federal departments in total spending.
+				</P>
+
+				<P>
+					IRCC accounted for 1.2% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024
+				</P>
+			</Section>
+
+			<DepartmentSpendingChart department={department} />
+
+			<Section>
+				<P>
+					Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 74.9%, while IRCC spending has increased 428% (adjusted for inflation).
+				</P>
+				<P>
+					The department's spending has grown more than overall spending, which means that the department's share of the federal budget has increased. In FY 2024, IRCC accounted for 1.2% of all federal spending, 0.8 percentage points higher than in 1995.
+				</P>
+				<P>
+					Major legislation, internal or global economic conditions, and acute events like the COVID-19 pandemic can significantly influence government spending year to year. For instance, during the pandemic, the Government of Canada's total expenses rose from $410.2 billion in 2019 to $420 billion in 2020 and further to $720.3 billion in 2021.​
+				</P>
+				<P>
+					Similarly, IRCC's expenditures experienced notable fluctuations during this period, surging from approximately $3.02 billion​ in 2019 to $6.3 billion in 2024.
+				</P>
+			</Section>
+
+			<Section>
+				<H2>
+					How did IRCC spend its budget in FY24?
+				</H2>
+				<P>
+					Federal government spending isolated to FY 2024
+				</P>
+				<ChartContainer>
+					<NoSSR>
+						<MiniSankey />
+					</NoSSR>
+				</ChartContainer>
+			</Section>
+
+			<Section>
+				<P>
+					Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, IRCC reported total expenditures of $6.2 billion, broken out as follows:
+				</P>
+				<ChartContainer>
+					<FederalSpendingByEntity />
+				</ChartContainer>
+			</Section>
+
+			<Section>
+				<H2>Who Leads Immigration, Refugees and Citizenship Canada (IRCC)?</H2>
+				<P>
+					Immigration, Refugees and Citizenship Canada (IRCC) is led by the Minister of Immigration, Refugees and Citizenship, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada.
+				</P>
+				<P>
+					The Minister of Immigration, Refugees and Citizenship is one of the cabinet members who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister appoints a new cabinet. Outgoing ministers continue in their roles until their successors are sworn in.
+				</P>
+			</Section>
+
+			<Section>
+				<H2>Explore other Federal Departments</H2>
+				<DepartmentList current={department} />
+			</Section>
+		</PageContent>
+	</Page>
+
+}

--- a/website/src/app/(main)/spending/indigenous-services-and-northern-affairs/page.tsx
+++ b/website/src/app/(main)/spending/indigenous-services-and-northern-affairs/page.tsx
@@ -9,11 +9,11 @@ import { StatCard, StatCardContainer } from "@/components/StatCard";
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-	title: 'Indigenous Services + Crown-Indigenous Relations and Northern Affairs Canada| Canada Spends',
-	description: 'A look at how the Indigenous Services + Crown-Indigenous Relations and Northern Affairs Canada spends its budget',
+	title: 'Indigenous Services Canada + Crown-Indigenous Relations and Northern Affairs Canada| Canada Spends',
+	description: 'A look at how ISC and CIRNAC spends its budget',
 }
 
-const department = "Indigenous Services + Crown-Indigenous Relations and Northern Affairs Canada";
+const department = "Indigenous Services Canada + Crown-Indigenous Relations and Northern Affairs Canada";
 
 export default function Department() {
 	return <Page>

--- a/website/src/app/(main)/spending/indigenous-services-and-northern-affairs/page.tsx
+++ b/website/src/app/(main)/spending/indigenous-services-and-northern-affairs/page.tsx
@@ -3,7 +3,7 @@ import { FederalSpendingChart } from "@/app/(main)/spending/indigenous-services-
 import { MiniSankey } from "@/app/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey";
 import { DepartmentList } from "@/components/DepartmentList";
 import { DepartmentSpendingChart } from "@/components/DepartmentSpendingChart";
-import { ChartContainer, ExternalLink, H1, H2, Intro, P, Page, PageContent, Section } from "@/components/Layout";
+import {ChartContainer, ExternalLink, H1, H2, H3, Intro, P, Page, PageContent, Section} from "@/components/Layout";
 import NoSSR from "@/components/NoSSR";
 import { StatCard, StatCardContainer } from "@/components/StatCard";
 import type { Metadata } from 'next';
@@ -56,7 +56,7 @@ export default function Department() {
 
 			</Section>
 
-			<DepartmentSpendingChart department={[department, 'Crown-Indigenous Relations and Northern Affairs Canada']} />
+			<DepartmentSpendingChart department={["Indigenous Services Canada", 'Crown-Indigenous Relations and Northern Affairs Canada']} />
 
 			<Section>
 				<P>
@@ -87,6 +87,7 @@ export default function Department() {
 					</NoSSR>
 				</ChartContainer>
 				<ChartContainer>
+					<H3>ISC + CIRNAC, Spending by Entity, FY 2024 (in billions</H3>
 					<FederalSpendingByEntity />
 				</ChartContainer>
 			</Section>

--- a/website/src/app/(main)/spending/indigenous-services-and-northern-affairs/page.tsx
+++ b/website/src/app/(main)/spending/indigenous-services-and-northern-affairs/page.tsx
@@ -9,11 +9,11 @@ import { StatCard, StatCardContainer } from "@/components/StatCard";
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-	title: 'Indigenous Services Canada| Canada Spends',
-	description: 'A look at how the Indigenous Services Canada spends its budget',
+	title: 'Indigenous Services + Crown-Indigenous Relations and Northern Affairs Canada| Canada Spends',
+	description: 'A look at how the Indigenous Services + Crown-Indigenous Relations and Northern Affairs Canada spends its budget',
 }
 
-const department = "Indigenous Services Canada";
+const department = "Indigenous Services + Crown-Indigenous Relations and Northern Affairs Canada";
 
 export default function Department() {
 	return <Page>

--- a/website/src/app/(main)/spending/innovation-science-and-industry/FederalSpendingByEntity.tsx
+++ b/website/src/app/(main)/spending/innovation-science-and-industry/FederalSpendingByEntity.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import { BarChart } from "@/components/BarChart";
+
+// Data from TAB 41
+const data = [
+  { name: "Department of Industry", Amount: 4.348247 },
+  { name: "Canada Space Agency", Amount: 0.450747 },
+  { name: "Canadian Tourism Commission", Amount: 0.122662 },
+  { name: "Copyright Board", Amount: 0.004075 },
+  { name: "Federal Economic Development Agency for Southern Ontario", Amount: 0.462032 },
+  { name: "National Research Council of Canada", Amount: 1.525981 },
+  { name: "Natural Sciences and Engineering Research Council", Amount: 1.383259 },
+  { name: "Social Sciences and Humanities Research Council", Amount: 1.160335 },
+  { name: "Standards Council of Canada", Amount: 0.02042 },
+  { name: "Statistics Canada", Amount: 0.740709 }
+].sort((a, b) => b.Amount - a.Amount);
+
+export function FederalSpendingByEntity() {
+  return <BarChart
+    className="h-72"
+    data={data}
+    index="name"
+    categories={["Amount"]}
+    yAxisWidth={400}
+    layout="vertical"
+    showGridLines={false}
+    showXAxis={false}
+    type="stacked"
+  />
+
+}

--- a/website/src/app/(main)/spending/innovation-science-and-industry/MiniSankey.tsx
+++ b/website/src/app/(main)/spending/innovation-science-and-industry/MiniSankey.tsx
@@ -54,6 +54,10 @@ const data = {
         "amount": 0.178779
       },
       {
+        "name": "Public Debt Charges",
+        "amount": 0
+      },
+      {
         "name": "External Revenues",
         "amount": -0.312511
       },

--- a/website/src/app/(main)/spending/innovation-science-and-industry/MiniSankey.tsx
+++ b/website/src/app/(main)/spending/innovation-science-and-industry/MiniSankey.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { SankeyChart } from "@/components/Sankey/SankeyChart";
+import { SankeyData } from "@/components/Sankey/SankeyChartD3";
+
+// Data from TAB 40
+const data = {
+  "spending": 10.2,
+  "spending_data": {
+    "name": "Innovation, Science and Industry",
+    "children": [
+      {
+        "name": "Personnel",
+        "amount": 2.407587
+      },
+      {
+        "name": "Transportation + Communication",
+        "amount": 0.056864
+      },
+      {
+        "name": "Information",
+        "amount": 0.034491
+      },
+      {
+        "name": "Professional + Special Services",
+        "amount": 0.57466
+      },
+      {
+        "name": "Rentals",
+        "amount": 0.095712
+      },
+      {
+        "name": "Repair + Maintenance",
+        "amount": 0.046201
+      },
+      {
+        "name": "Utilities, Materials and Supplies",
+        "amount": 0.053107
+      },
+      {
+        "name": "Acquisition of Land, Buildings and Works",
+        "amount": 0.033147
+      },
+      {
+        "name": "Acquisition of Machinery and Equipment",
+        "amount": 0.126316
+      },
+      {
+        "name": "Transfer Payments",
+        "amount": 7.068773
+      },
+      {
+        "name": "Other subsidies and payments",
+        "amount": 0.178779
+      },
+      {
+        "name": "External Revenues",
+        "amount": -0.312511
+      },
+      {
+        "name": "Internal Revenues",
+        "amount": -0.144659
+      }
+    ]
+  },
+  revenue_data: {
+  }
+}
+
+export function MiniSankey() {
+  return (
+    <div className='sankey-chart-container spending-only'>
+      <SankeyChart data={data as SankeyData} />
+    </div>
+  );
+}

--- a/website/src/app/(main)/spending/innovation-science-and-industry/page.tsx
+++ b/website/src/app/(main)/spending/innovation-science-and-industry/page.tsx
@@ -1,0 +1,114 @@
+import { FederalSpendingByEntity } from "@/app/(main)/spending/innovation-science-and-industry/FederalSpendingByEntity";
+import { MiniSankey } from "@/app/(main)/spending/innovation-science-and-industry/MiniSankey";
+import { DepartmentList } from "@/components/DepartmentList";
+import { DepartmentSpendingChart } from "@/components/DepartmentSpendingChart";
+import { ChartContainer, ExternalLink, H1, H2, Intro, P, Page, PageContent, Section } from "@/components/Layout";
+import NoSSR from "@/components/NoSSR";
+import { StatCard, StatCardContainer } from "@/components/StatCard";
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+	title: 'Innovation, Science and Industry | Canada Spends',
+	description: 'A look at how the Department of Innovation, Science and Industry spends its budget',
+}
+
+const department = "Innovation, Science and Industry";
+
+export default function Department() {
+	return <Page>
+		<PageContent>
+			<Section>
+				<H1>
+					{department}
+				</H1>
+				<Intro>
+					The Department of Innovation, Science and Industry (ISED) is the federal department responsible for fostering economic growth, technological advancement, and scientific research in Canada. It plays a key role in supporting businesses, funding research and development, and shaping policies that aim to enhance innovation, industrial competitiveness, and the prosperity of the Canadian economy.
+				</Intro>
+			</Section>
+
+			<Section>
+				<div className="text-sm text-gray-500 italic">
+					Data updated March 21, 2025
+				</div>
+				<StatCardContainer>
+					<StatCard
+						title="In FY 2024,"
+						value="$10.2B"
+						subtitle="Was spent by the Dept. of Innovation, Science and Industry"
+					/>
+					<StatCard
+						title="In FY 2024,"
+						value="2%"
+						subtitle="Of federal spending was by the Dept. of Innovation, Science and Industry"
+					/>
+				</StatCardContainer>
+			</Section>
+
+			<Section>
+				<P>
+					ISED spent $10.2 billion in fiscal year (FY) 2024. This was 2% of the $513.9 billion in overall federal spending. The department ranked eleventh among federal departments in total spending.
+				</P>
+
+				<P>
+					While not in the top 10 departments by spend, ISED accounted for 2% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024
+				</P>
+			</Section>
+
+			<DepartmentSpendingChart department={department} />
+
+			<Section>
+				<P>
+					Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 74.9%, while ISED spending has increased 90.3%.
+				</P>
+				<P>
+					The department's spending has grown more than overall spending, which means that the department's share of the federal budget has increased. In FY 2024, ISED accounted for 2% of all federal spending, 0.17 percentage points higher than in 1995.
+				</P>
+				<P>
+					Major legislation, internal or global economic conditions, and acute events like the COVID-19 pandemic can significantly influence government spending year to year. For instance, during the pandemic, the Government of Canada's total expenses rose from $410.2 billion in 2019 to $420 billion in 2020 and further to $720.3 billion in 2021.​
+				</P>
+				<P>
+					Similarly, ISED's expenditures have increased during this period, growing from approximately $6.5 billion​ in 2019 (adjusted for inflation) to $10.2 billion in 2024.
+				</P>
+			</Section>
+
+			<Section>
+				<H2>
+					How did ISED spend its budget in FY 24?
+				</H2>
+				<P>
+					Federal government spending isolated to FY 2024
+				</P>
+				<ChartContainer>
+					<NoSSR>
+						<MiniSankey />
+					</NoSSR>
+				</ChartContainer>
+			</Section>
+
+			<Section>
+				<P>
+					Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, ISED's budget was split across the following entities:
+				</P>
+				<ChartContainer>
+					<FederalSpendingByEntity />
+				</ChartContainer>
+			</Section>
+
+			<Section>
+				<H2>Who Leads Innovation, Science and Industry Canada (ISED)?</H2>
+				<P>
+					Innovation, Science and Industry Canada (ISED) is led by the Minister of Innovation, Science and Industry, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada.
+				</P>
+				<P>
+					The Minister of Innovation, Science and Industry is one of the cabinet members who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister appoints a new cabinet. Outgoing ministers continue in their roles until their successors are sworn in.
+				</P>
+			</Section>
+
+			<Section>
+				<H2>Explore other Federal Departments</H2>
+				<DepartmentList current={department} />
+			</Section>
+		</PageContent>
+	</Page>
+
+}

--- a/website/src/app/(main)/spending/national-defence/page.tsx
+++ b/website/src/app/(main)/spending/national-defence/page.tsx
@@ -58,7 +58,11 @@ export default function Department() {
 
 			</Section>
 
-			<DepartmentSpendingChart department={department} />
+			<ChartContainer>
+				<H3>Percentage of federal budget dedicated to Defence, FYs 1995-2024</H3>
+				<DepartmentSpendingChart department={department} />
+			</ChartContainer>
+
 
 			<Section>
 				<P>
@@ -83,6 +87,7 @@ export default function Department() {
 					In FY 2024, 45.6% of DND spending was allocated to personnel salaries, benefits, and pensions. 14.7% was directed to procurement of machinery and equipment.
 				</H3>
 				<ChartContainer>
+					<H3>National Defence, Spending by Entity, FY 2024 (in billions)</H3>
 					<FederalSpendingByEntity />
 				</ChartContainer>
 

--- a/website/src/app/(main)/spending/public-services-and-procurement-canada/FederalSpendingByEntity.tsx
+++ b/website/src/app/(main)/spending/public-services-and-procurement-canada/FederalSpendingByEntity.tsx
@@ -4,11 +4,10 @@ import { BarChart } from "@/components/BarChart";
 
 // This is placeholder data - Replace with real data from TAB 38
 const data = [
-  { name: "Real Property Services", Amount: 3.5 },
-  { name: "Procurement Services", Amount: 2.1 },
-  { name: "Public Service Pay Centre", Amount: 1.2 },
-  { name: "Translation Bureau", Amount: 0.8 },
-  { name: "Pension Centre", Amount: 0.7 }
+  { name: "Department of Public Works and Government Services", Amount: 5.375281 },
+  { name: "Canada Post Corporation", Amount: 0.02221 },
+  { name: "National Capital Commission", Amount: 0.096902 },
+  { name: "Shared Services Canada", Amount: 2.790789 },
 ].sort((a, b) => b.Amount - a.Amount);
 
 export function FederalSpendingByEntity() {

--- a/website/src/app/(main)/spending/public-services-and-procurement-canada/FederalSpendingByEntity.tsx
+++ b/website/src/app/(main)/spending/public-services-and-procurement-canada/FederalSpendingByEntity.tsx
@@ -1,0 +1,27 @@
+"use client"
+
+import { BarChart } from "@/components/BarChart";
+
+// This is placeholder data - Replace with real data from TAB 38
+const data = [
+  { name: "Real Property Services", Amount: 3.5 },
+  { name: "Procurement Services", Amount: 2.1 },
+  { name: "Public Service Pay Centre", Amount: 1.2 },
+  { name: "Translation Bureau", Amount: 0.8 },
+  { name: "Pension Centre", Amount: 0.7 }
+].sort((a, b) => b.Amount - a.Amount);
+
+export function FederalSpendingByEntity() {
+  return <BarChart
+    className="h-72"
+    data={data}
+    index="name"
+    categories={["Amount"]}
+    yAxisWidth={400}
+    layout="vertical"
+    showGridLines={false}
+    showXAxis={false}
+    type="stacked"
+  />
+
+}

--- a/website/src/app/(main)/spending/public-services-and-procurement-canada/FederalSpendingChart.tsx
+++ b/website/src/app/(main)/spending/public-services-and-procurement-canada/FederalSpendingChart.tsx
@@ -1,0 +1,144 @@
+"use client"
+
+import { LineChart } from "@/components/LineChart"
+
+// This is placeholder data - Replace with real data from TAB 36
+const chartdata = [
+  // Use this format for historical spending data
+  {
+    Year: "1995",
+    Percentage: 0.026
+  },
+  {
+    Year: "1996",
+    Percentage: 0.025
+  },
+  {
+    Year: "1997",
+    Percentage: 0.024
+  },
+  {
+    Year: "1998",
+    Percentage: 0.023
+  },
+  {
+    Year: "1999",
+    Percentage: 0.022
+  },
+  {
+    Year: "2000",
+    Percentage: 0.021
+  },
+  {
+    Year: "2001",
+    Percentage: 0.020
+  },
+  {
+    Year: "2002",
+    Percentage: 0.019
+  },
+  {
+    Year: "2003",
+    Percentage: 0.018
+  },
+  {
+    Year: "2004",
+    Percentage: 0.017
+  },
+  {
+    Year: "2005",
+    Percentage: 0.019
+  },
+  {
+    Year: "2006",
+    Percentage: 0.018
+  },
+  {
+    Year: "2007",
+    Percentage: 0.017
+  },
+  {
+    Year: "2008",
+    Percentage: 0.018
+  },
+  {
+    Year: "2009",
+    Percentage: 0.019
+  },
+  {
+    Year: "2010",
+    Percentage: 0.018
+  },
+  {
+    Year: "2011",
+    Percentage: 0.017
+  },
+  {
+    Year: "2012",
+    Percentage: 0.018
+  },
+  {
+    Year: "2013",
+    Percentage: 0.017
+  },
+  {
+    Year: "2014",
+    Percentage: 0.016
+  },
+  {
+    Year: "2015",
+    Percentage: 0.016
+  },
+  {
+    Year: "2016",
+    Percentage: 0.017
+  },
+  {
+    Year: "2017",
+    Percentage: 0.016
+  },
+  {
+    Year: "2018",
+    Percentage: 0.017
+  },
+  {
+    Year: "2019",
+    Percentage: 0.017
+  },
+  {
+    Year: "2020",
+    Percentage: 0.016
+  },
+  {
+    Year: "2021",
+    Percentage: 0.014
+  },
+  {
+    Year: "2022",
+    Percentage: 0.015
+  },
+  {
+    Year: "2023",
+    Percentage: 0.015
+  },
+  {
+    Year: "2024",
+    Percentage: 0.016
+  }
+]
+
+export const FederalSpendingChart = () => {
+  return <LineChart
+    data={chartdata}
+    index="Year"
+    categories={["Percentage"]}
+    showLegend={false}
+    valueFormatter={(number: number) =>
+      Intl.NumberFormat('en-US', {
+        style: 'percent',
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 2,
+      }).format(number)
+    }
+  />
+}

--- a/website/src/app/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx
+++ b/website/src/app/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx
@@ -3,7 +3,7 @@
 import { SankeyChart } from "@/components/Sankey/SankeyChart";
 import { SankeyData } from "@/components/Sankey/SankeyChartD3";
 
-// This is placeholder data - Replace with real data from TAB 37
+// Real data from TAB 37
 const data = {
   "spending": 8.3,
   "spending_data": {
@@ -11,59 +11,65 @@ const data = {
     "children": [
       {
         "name": "Personnel",
-        "amount": 2.1
+        "amount": 3.318286
       },
       {
         "name": "Transportation + Communication",
-        "amount": 0.25
+        "amount": 0.711299
       },
       {
         "name": "Information",
-        "amount": 0.05
+        "amount": 0.021606
       },
       {
         "name": "Professional + Special Services",
-        "amount": 1.8
+        "amount": 3.051013
       },
       {
         "name": "Rentals",
-        "amount": 0.7
+        "amount": 1.96169
       },
       {
         "name": "Repair + Maintenance",
-        "amount": 0.9
+        "amount": 1.613194
       },
       {
         "name": "Utilities, Materials and Supplies",
-        "amount": 0.3
+        "amount": 0.116031
       },
       {
-        "name": "Acquisition of Lands, Buildings and Works",
-        "amount": 0.4
+        "name": "Acquisition of Land, Buildings and Works",
+        "amount": 1.281844
       },
       {
         "name": "Acquisition of Machinery and Equipment",
-        "amount": 0.15
+        "amount": 0.545773
       },
       {
         "name": "Transfer Payments",
-        "amount": 1.5
+        "amount": 0.051293
+      },
+      {
+        "name": "Public Debt Charges",
+        "amount": 0.107187
       },
       {
         "name": "Other subsidies and payments",
-        "amount": 0.2
+        "amount": 0.546409
       },
       {
         "name": "External Revenues",
-        "amount": -0.05
+        "amount": -0.265103
       },
       {
         "name": "Internal Revenues",
-        "amount": 0.0
+        "amount": -4.77534
       }
+
     ]
   },
-  revenue_data: {}
+  revenue_data: {
+  }
 }
 
 export function MiniSankey() {

--- a/website/src/app/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx
+++ b/website/src/app/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { SankeyChart } from "@/components/Sankey/SankeyChart";
+import { SankeyData } from "@/components/Sankey/SankeyChartD3";
+
+// This is placeholder data - Replace with real data from TAB 37
+const data = {
+  "spending": 8.3,
+  "spending_data": {
+    "name": "Public Services and Procurement Canada",
+    "children": [
+      {
+        "name": "Personnel",
+        "amount": 2.1
+      },
+      {
+        "name": "Transportation + Communication",
+        "amount": 0.25
+      },
+      {
+        "name": "Information",
+        "amount": 0.05
+      },
+      {
+        "name": "Professional + Special Services",
+        "amount": 1.8
+      },
+      {
+        "name": "Rentals",
+        "amount": 0.7
+      },
+      {
+        "name": "Repair + Maintenance",
+        "amount": 0.9
+      },
+      {
+        "name": "Utilities, Materials and Supplies",
+        "amount": 0.3
+      },
+      {
+        "name": "Acquisition of Lands, Buildings and Works",
+        "amount": 0.4
+      },
+      {
+        "name": "Acquisition of Machinery and Equipment",
+        "amount": 0.15
+      },
+      {
+        "name": "Transfer Payments",
+        "amount": 1.5
+      },
+      {
+        "name": "Other subsidies and payments",
+        "amount": 0.2
+      },
+      {
+        "name": "External Revenues",
+        "amount": -0.05
+      },
+      {
+        "name": "Internal Revenues",
+        "amount": 0.0
+      }
+    ]
+  },
+  revenue_data: {}
+}
+
+export function MiniSankey() {
+  return (
+    <div className='sankey-chart-container spending-only'>
+      <SankeyChart data={data as SankeyData} />
+    </div>
+  );
+}

--- a/website/src/app/(main)/spending/public-services-and-procurement-canada/page.tsx
+++ b/website/src/app/(main)/spending/public-services-and-procurement-canada/page.tsx
@@ -1,0 +1,120 @@
+import { FederalSpendingChart } from "@/app/(main)/spending/public-services-and-procurement-canada/FederalSpendingChart";
+import { MiniSankey } from "@/app/(main)/spending/public-services-and-procurement-canada/MiniSankey";
+import { FederalSpendingByEntity } from "@/app/(main)/spending/public-services-and-procurement-canada/FederalSpendingByEntity";
+import { DepartmentList } from "@/components/DepartmentList";
+import { DepartmentSpendingChart } from "@/components/DepartmentSpendingChart";
+import { ChartContainer, ExternalLink, H1, H2, Intro, P, Page, PageContent, Section } from "@/components/Layout";
+import NoSSR from "@/components/NoSSR";
+import { StatCard, StatCardContainer } from "@/components/StatCard";
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+	title: 'Public Services and Procurement Canada | Canada Spends',
+	description: 'A look at how Public Services and Procurement Canada spends its budget',
+}
+
+const department = "Public Services and Procurement Canada";
+
+export default function Department() {
+	return <Page>
+		<PageContent>
+			<Section>
+				<H1>
+					{department}
+				</H1>
+				<Intro>
+					The Public Services and Procurement Canada (PSPC) is the federal department responsible for providing centralized procurement, real estate management, pay and pension administration for federal employees, and translation services to the Government of Canada. It ensures that government departments have the goods, services, and infrastructure they need to operate efficiently while maintaining transparency, fairness, and value for taxpayers.
+				</Intro>
+			</Section>
+
+			<Section>
+				<div className="text-sm text-gray-500 italic">
+					Data updated March 21, 2025
+				</div>
+				<StatCardContainer>
+					<StatCard
+						title="In FY 2024,"
+						value="$8.3B"
+						subtitle="Was spent by Public Services and Procurement Canada"
+					/>
+					<StatCard
+						title="In FY 2024,"
+						value="1.6%"
+						subtitle="Of federal spending was by Public Services and Procurement Canada"
+					/>
+				</StatCardContainer>
+			</Section>
+
+			<Section>
+				<P>
+					PSPC spent $8.3 billion in fiscal year (FY) 2024. This was 1.6% of the $513.9 billion in overall federal spending. The department ranked twelfth among federal departments in total spending.
+				</P>
+
+				<P>
+					PSPC accounted for 1.6% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024
+				</P>
+			</Section>
+
+			<DepartmentSpendingChart department={department} />
+
+			<Section>
+				<P>
+					Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 74.9%, while PSPC spending has increased by 7.1% when adjusted for inflation.
+				</P>
+				<P>
+					The department's spending has increased less than overall spending has grown and the department's share of the federal budget has decreased over time. In FY 2024, PSPC accounted for 1.6% of all federal spending, 1 percentage point lower than in 1995.
+				</P>
+				<P>
+					Major legislation, internal or global economic conditions, and acute events like the COVID-19 pandemic can significantly influence government spending year to year. For instance, during the pandemic, the Government of Canada's total expenses rose from $410.2 billion in 2019 to $420 billion in 2020 and further to $720.3 billion in 2021.​
+				</P>
+				<P>
+					Similarly, PSPC's expenditures experienced notable fluctuations during this period, decreasing from approximately $6.8 billion​ in 2019 (adjusted for inflation) to $5.3 billion in 2021 before increasing again in 2024.
+				</P>
+
+				<ChartContainer>
+					<FederalSpendingChart />
+				</ChartContainer>
+
+			</Section>
+
+			<Section>
+				<H2>
+					How did PSPC spend its budget in FY24?
+				</H2>
+				<P>
+					Federal government spending isolated to FY 2024
+				</P>
+				<ChartContainer>
+					<NoSSR>
+						<MiniSankey />
+					</NoSSR>
+				</ChartContainer>
+			</Section>
+
+			<Section>
+				<P>
+					Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, PSPC's budget was split across the following entities:
+				</P>
+				<ChartContainer>
+					<FederalSpendingByEntity />
+				</ChartContainer>
+			</Section>
+
+			<Section>
+				<H2>Who Leads Public Services and Procurement Canada (PSPC)?</H2>
+				<P>
+					Public Services and Procurement Canada (PSPC) is led by the Minister of Government Transformation, Public Services and Procurement, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada.
+				</P>
+				<P>
+					The Minister of Public Services and Procurement is one of the cabinet members who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister appoints a new cabinet. Outgoing ministers continue in their roles until their successors are sworn in.
+				</P>
+			</Section>
+
+			<Section>
+				<H2>Explore other Federal Departments</H2>
+				<DepartmentList current={department} />
+			</Section>
+		</PageContent>
+	</Page>
+
+}

--- a/website/src/app/(main)/spending/public-services-and-procurement-canada/page.tsx
+++ b/website/src/app/(main)/spending/public-services-and-procurement-canada/page.tsx
@@ -71,9 +71,9 @@ export default function Department() {
 					Similarly, PSPC's expenditures experienced notable fluctuations during this period, decreasing from approximately $6.8 billion​ in 2019 (adjusted for inflation) to $5.3 billion in 2021 before increasing again in 2024.
 				</P>
 
-				<ChartContainer>
-					<FederalSpendingChart />
-				</ChartContainer>
+				{/*<ChartContainer>*/}
+				{/*	<FederalSpendingChart />*/}
+				{/*</ChartContainer>*/}
 
 			</Section>
 

--- a/website/src/app/(main)/spending/transport-canada/FederalSpendingByEntity.tsx
+++ b/website/src/app/(main)/spending/transport-canada/FederalSpendingByEntity.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import { BarChart } from "@/components/BarChart";
+
+// Data from TAB 50
+const data = [
+  { name: "Department of Transport", Amount: 3.019244 },
+  { name: "Canadian Air Transport Security Authority", Amount: 0.971163 },
+  { name: "Canadian Transportation Agency", Amount: 0.055276 },
+  { name: "Marine Atlantic Inc.", Amount: 0.191685 },
+  { name: "The Federal Bridge Corporation Limited", Amount: 0.007045 },
+  { name: "VIA HFR - VIA TGF Inc", Amount: 0.049503 },
+  { name: "VIA Rail Canada Inc", Amount: 0.80395 }
+].sort((a, b) => b.Amount - a.Amount);
+
+export function FederalSpendingByEntity() {
+  return <BarChart
+    className="h-72"
+    data={data}
+    index="name"
+    categories={["Amount"]}
+    yAxisWidth={400}
+    layout="vertical"
+    showGridLines={false}
+    showXAxis={false}
+    type="stacked"
+  />
+
+}

--- a/website/src/app/(main)/spending/transport-canada/MiniSankey.tsx
+++ b/website/src/app/(main)/spending/transport-canada/MiniSankey.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { SankeyChart } from "@/components/Sankey/SankeyChart";
+import { SankeyData } from "@/components/Sankey/SankeyChartD3";
+
+// Data from TAB 49
+const data = {
+  "spending": 5.1,
+  "spending_data": {
+    "name": "Transport Canada",
+    "children": [
+      {
+        "name": "Personnel",
+        "amount": 0.921121
+      },
+      {
+        "name": "Transportation + Communication",
+        "amount": 0.029554
+      },
+      {
+        "name": "Information",
+        "amount": 0.011927
+      },
+      {
+        "name": "Professional + Special Services",
+        "amount": 0.277502
+      },
+      {
+        "name": "Rentals",
+        "amount": 0.025239
+      },
+      {
+        "name": "Repair + Maintenance",
+        "amount": 0.022232
+      },
+      {
+        "name": "Utilities, Materials and Supplies",
+        "amount": 0.017928
+      },
+      {
+        "name": "Acquisition of Land, Buildings and Works",
+        "amount": 0.116258
+      },
+      {
+        "name": "Acquisition of Machinery and Equipment",
+        "amount": 0.070631
+      },
+      {
+        "name": "Transfer Payments",
+        "amount": 1.652903
+      },
+      {
+        "name": "Public Debt Charges",
+        "amount": 0
+      },
+      {
+        "name": "Other subsidies and payments",
+        "amount": 2.050805
+      },
+      {
+        "name": "External Revenues",
+        "amount": -0.046939
+      },
+      {
+        "name": "Internal Revenues",
+        "amount": -0.051295
+      }
+    ]
+  },
+  revenue_data: {
+  }
+}
+
+export function MiniSankey() {
+  return (
+    <div className='sankey-chart-container spending-only'>
+      <SankeyChart data={data as SankeyData} />
+    </div>
+  );
+}

--- a/website/src/app/(main)/spending/transport-canada/page.tsx
+++ b/website/src/app/(main)/spending/transport-canada/page.tsx
@@ -1,0 +1,117 @@
+import { FederalSpendingByEntity } from "@/app/(main)/spending/transport-canada/FederalSpendingByEntity";
+import { MiniSankey } from "@/app/(main)/spending/transport-canada/MiniSankey";
+import { DepartmentList } from "@/components/DepartmentList";
+import { DepartmentSpendingChart } from "@/components/DepartmentSpendingChart";
+import { ChartContainer, ExternalLink, H1, H2, Intro, P, Page, PageContent, Section } from "@/components/Layout";
+import NoSSR from "@/components/NoSSR";
+import { StatCard, StatCardContainer } from "@/components/StatCard";
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+	title: 'Transport Canada | Canada Spends',
+	description: 'A look at how the Department of Transport spends its budget',
+}
+
+const department = "Transport Canada";
+
+export default function Department() {
+	return <Page>
+		<PageContent>
+			<Section>
+				<H1>
+					{department}
+				</H1>
+				<Intro>
+					The Department of Transport (Transport Canada) is the federal department responsible for developing and enforcing transportation policies, regulations, and infrastructure projects to ensure safe and efficient movement of people and goods across Canada. It oversees aviation, rail, marine, and road transportation systems, working to enhance national connectivity and economic growth.
+				</Intro>
+			</Section>
+
+			<Section>
+				<div className="text-sm text-gray-500 italic">
+					Data updated March 21, 2025
+				</div>
+				<StatCardContainer>
+					<StatCard
+						title="In FY 2024,"
+						value="$5.1B"
+						subtitle="Was spent by the Dept. of Transport"
+					/>
+					<StatCard
+						title="In FY 2024,"
+						value="1%"
+						subtitle="Of federal spending was by the Dept. of Transport"
+					/>
+				</StatCardContainer>
+			</Section>
+
+			<Section>
+				<P>
+					Transport Canada spent $5.1 billion in fiscal year (FY) 2024. This was 1% of the $513.9 billion in overall federal spending. The department ranked fourteenth among federal departments in total spending.
+				</P>
+
+				<P>
+					Transport Canada accounted for 1% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024
+				</P>
+			</Section>
+
+			<DepartmentSpendingChart department={department} />
+
+			<Section>
+				<P>
+					Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 74.9%, while Transport spending has remained relatively flat.
+				</P>
+				<P>
+					In FY 2024, Transport Canada accounted for 1% of all federal spending, 0.74% percentage points lower than in 1995.
+				</P>
+				<P>
+					Major legislation, internal or global economic conditions, and acute events like the COVID-19 pandemic can significantly influence government spending year to year. For instance, during the pandemic, the Government of Canada's total expenses rose from $410.2 billion in 2019 to $420 billion in 2020 and further to $720.3 billion in 2021.​
+				</P>
+				<P>
+					Similarly, Transport Canada's expenditures experienced fluctuations during this period, increasing from approximately $3.2 billion​ in 2019 (adjusted for inflation) to $5.1B in 2024.
+				</P>
+			</Section>
+
+			<Section>
+				<H2>
+					How did Transport Canada spend its budget in FY24?
+				</H2>
+				<P>
+					Federal government spending isolated to FY 2024
+				</P>
+				<ChartContainer>
+					<NoSSR>
+						<MiniSankey />
+					</NoSSR>
+				</ChartContainer>
+			</Section>
+
+			<Section>
+				<P>
+					Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, Transport Canada reported total expenditures of $5.1 billion across the following entities:
+				</P>
+				<ChartContainer>
+					<FederalSpendingByEntity />
+				</ChartContainer>
+			</Section>
+
+			<Section>
+				<H2>Who Leads Transport Canada?</H2>
+				<P>
+					Transport Canada is led by the Minister of Transport, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada.
+				</P>
+				<P>
+					The Minister of Transport is one of the cabinet members who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister appoints a new cabinet. Outgoing ministers continue in their roles until their successors are sworn in.
+				</P>
+				<P>
+					The Minister is responsible for overseeing Canada's transportation policies, ensuring safety regulations, investing in infrastructure, and leading climate initiatives related to aviation, rail, marine, and road transportation.
+				</P>
+			</Section>
+
+			<Section>
+				<H2>Explore other Federal Departments</H2>
+				<DepartmentList current={department} />
+			</Section>
+		</PageContent>
+	</Page>
+
+}

--- a/website/src/app/(main)/spending/veterans-affairs/FederalSpendingByEntity.tsx
+++ b/website/src/app/(main)/spending/veterans-affairs/FederalSpendingByEntity.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import { BarChart } from "@/components/BarChart";
+
+// Data from TAB 47
+const data = [
+  { name: "Department of Veterans Affairs", Amount: 6.053066 },
+  { name: "Veterans Review and Appeal Board", Amount: 0.018124 }
+].sort((a, b) => b.Amount - a.Amount);
+
+export function FederalSpendingByEntity() {
+  return <BarChart
+    className="h-72"
+    data={data}
+    index="name"
+    categories={["Amount"]}
+    yAxisWidth={400}
+    layout="vertical"
+    showGridLines={false}
+    showXAxis={false}
+    type="stacked"
+  />
+
+}

--- a/website/src/app/(main)/spending/veterans-affairs/MiniSankey.tsx
+++ b/website/src/app/(main)/spending/veterans-affairs/MiniSankey.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { SankeyChart } from "@/components/Sankey/SankeyChart";
+import { SankeyData } from "@/components/Sankey/SankeyChartD3";
+
+// Data from TAB 46
+const data = {
+  "spending": 6.1,
+  "spending_data": {
+    "name": "Veterans Affairs",
+    "children": [
+      {
+        "name": "Personnel",
+        "amount": 0.423984
+      },
+      {
+        "name": "Transportation + Communication",
+        "amount": 0.037427
+      },
+      {
+        "name": "Information",
+        "amount": 0.007986
+      },
+      {
+        "name": "Professional + Special Services",
+        "amount": 0.584234
+      },
+      {
+        "name": "Rentals",
+        "amount": 0.026549
+      },
+      {
+        "name": "Repair + Maintenance",
+        "amount": 0.005666
+      },
+      {
+        "name": "Utilities, Materials and Supplies",
+        "amount": 0.340309
+      },
+      {
+        "name": "Acquisition of Land, Buildings and Works",
+        "amount": 0.001577
+      },
+      {
+        "name": "Acquisition of Machinery and Equipment",
+        "amount": 0.005062
+      },
+      {
+        "name": "Transfer Payments",
+        "amount": 4.636714
+      },
+      {
+        "name": "Public Debt Charges",
+        "amount": 0
+      },
+      {
+        "name": "Other subsidies and payments",
+        "amount": 0.001682
+      }
+    ]
+  },
+  revenue_data: {
+  }
+}
+
+export function MiniSankey() {
+  return (
+    <div className='sankey-chart-container spending-only'>
+      <SankeyChart data={data as SankeyData} />
+    </div>
+  );
+}

--- a/website/src/app/(main)/spending/veterans-affairs/page.tsx
+++ b/website/src/app/(main)/spending/veterans-affairs/page.tsx
@@ -1,0 +1,117 @@
+import { FederalSpendingByEntity } from "@/app/(main)/spending/veterans-affairs/FederalSpendingByEntity";
+import { MiniSankey } from "@/app/(main)/spending/veterans-affairs/MiniSankey";
+import { DepartmentList } from "@/components/DepartmentList";
+import { DepartmentSpendingChart } from "@/components/DepartmentSpendingChart";
+import { ChartContainer, ExternalLink, H1, H2, Intro, P, Page, PageContent, Section } from "@/components/Layout";
+import NoSSR from "@/components/NoSSR";
+import { StatCard, StatCardContainer } from "@/components/StatCard";
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+	title: 'Veterans Affairs | Canada Spends',
+	description: 'A look at how the Department of Veterans Affairs spends its budget',
+}
+
+const department = "Veterans Affairs";
+
+export default function Department() {
+	return <Page>
+		<PageContent>
+			<Section>
+				<H1>
+					{department}
+				</H1>
+				<Intro>
+					The Department of Veterans Affairs Canada (VAC) is the federal department responsible for supporting and serving Canadian veterans, active-duty military personnel, and their families. It provides financial assistance, healthcare support, rehabilitation services, and recognition programs to honor the contributions of those who have served in the Canadian Armed Forces. Additionally, the department is responsible for remembrance initiatives that preserve Canada's military history.
+				</Intro>
+			</Section>
+
+			<Section>
+				<div className="text-sm text-gray-500 italic">
+					Data updated March 21, 2025
+				</div>
+				<StatCardContainer>
+					<StatCard
+						title="In FY 2024,"
+						value="$6.1B"
+						subtitle="Was spent by the Dept. of Veterans Affairs"
+					/>
+					<StatCard
+						title="In FY 2024,"
+						value="1.2%"
+						subtitle="Of federal spending was by the Dept. of Veterans Affairs"
+					/>
+				</StatCardContainer>
+			</Section>
+
+			<Section>
+				<P>
+					VAC spent $6.1 billion in fiscal year (FY) 2024. This was 1.2% of the $513.9 billion in overall federal spending. The department ranked thirteenth among federal departments in total spending.
+				</P>
+
+				<P>
+					VAC accounted for 1.2% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024
+				</P>
+			</Section>
+
+			<DepartmentSpendingChart department={department} />
+
+			<Section>
+				<P>
+					Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 77%, while VAC spending has increased 51%.
+				</P>
+				<P>
+					The department's spending has grown less than overall spending, which means that the department's share of the federal budget has increased. In FY 2024, VAC accounted for 1.1% of all federal spending, about the same share as in 1995.
+				</P>
+				<P>
+					Major legislation, internal or global economic conditions, and acute events like the COVID-19 pandemic can significantly influence government spending year to year. For instance, during the pandemic, the Government of Canada's total expenses rose from $410.2 billion in 2019 to $420 billion in 2020 and further to $720.3 billion in 2021.​
+				</P>
+				<P>
+					VAC's expenditures also grew slightly during this period, increasing from approximately $5.5B​ in 2019 when adjusted for inflation to $6.3B in 2024.
+				</P>
+			</Section>
+
+			<Section>
+				<H2>
+					How did VAC spend its budget in FY24?
+				</H2>
+				<P>
+					Federal government spending isolated to FY 2024
+				</P>
+				<ChartContainer>
+					<NoSSR>
+						<MiniSankey />
+					</NoSSR>
+				</ChartContainer>
+			</Section>
+
+			<Section>
+				<P>
+					In FY 2024, VAC reported total expenditures of $6.07 billion across two entities:
+				</P>
+				<ChartContainer>
+					<FederalSpendingByEntity />
+				</ChartContainer>
+			</Section>
+
+			<Section>
+				<H2>Who Leads Veterans Affairs Canada (VAC)?</H2>
+				<P>
+					Veterans Affairs Canada (VAC) is led by the Minister of Veterans Affairs, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada.
+				</P>
+				<P>
+					The Minister of Veterans Affairs is one of the cabinet members who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister appoints a new cabinet. Outgoing ministers continue in their roles until their successors are sworn in.
+				</P>
+				<P>
+					The Minister is responsible for overseeing benefits and services for veterans, ensuring their well-being, and leading national remembrance initiatives.
+				</P>
+			</Section>
+
+			<Section>
+				<H2>Explore other Federal Departments</H2>
+				<DepartmentList current={department} />
+			</Section>
+		</PageContent>
+	</Page>
+
+}

--- a/website/src/components/DepartmentList.tsx
+++ b/website/src/components/DepartmentList.tsx
@@ -27,7 +27,7 @@ export const departments = [
     Percentage: 18.38
   },
   {
-    name: "Indigenous Services Canada",
+    name: "Indigenous Services + Crown-Indigenous Relations and Northern Affairs Canada",
     slug: "indigenous-services-and-northern-affairs",
     href: "/spending/indigenous-services-and-northern-affairs",
     Percentage: 9.06
@@ -85,7 +85,13 @@ export const departments = [
     slug: "public-services-and-procurement-canada",
     href: "/spending/public-services-and-procurement-canada",
     Percentage: 1.6
-  }
+  },
+    {
+    name: "Immigration, Refugees and Citizenship",
+    slug: "immigration-refugees-and-citizenship",
+    href: "/spending/immigration-refugees-and-citizenship",
+    Percentage: 1.2
+  },
 ].sort((a, b) => b.Percentage - a.Percentage)
 
 const BrowsableDepartment = departments.filter(d => !!d.href && !!d.slug) as {

--- a/website/src/components/DepartmentList.tsx
+++ b/website/src/components/DepartmentList.tsx
@@ -52,7 +52,7 @@ export const departments = [
   },
   {
     name: "Crown-Indigenous Relations and Northern Affairs Canada",
-    slug: "indigenous-services-and-northern-affairs",
+    slug: "cirnac",
     href: "/spending/indigenous-services-and-northern-affairs",
     Percentage: 3.19
   },

--- a/website/src/components/DepartmentList.tsx
+++ b/website/src/components/DepartmentList.tsx
@@ -71,6 +71,12 @@ export const departments = [
     slug: "health-canada",
     href: "/spending/health-canada",
     Percentage: 2.67
+  },
+  {
+    name: "Public Services and Procurement Canada",
+    slug: "public-services-and-procurement-canada",
+    href: "/spending/public-services-and-procurement-canada",
+    Percentage: 1.6
   }
 ].sort((a, b) => b.Percentage - a.Percentage)
 

--- a/website/src/components/DepartmentList.tsx
+++ b/website/src/components/DepartmentList.tsx
@@ -27,7 +27,7 @@ export const departments = [
     Percentage: 18.38
   },
   {
-    name: "Indigenous Services + Crown-Indigenous Relations and Northern Affairs Canada",
+    name: "Indigenous Services Canada",
     slug: "indigenous-services-and-northern-affairs",
     href: "/spending/indigenous-services-and-northern-affairs",
     Percentage: 9.06
@@ -52,8 +52,8 @@ export const departments = [
   },
   {
     name: "Crown-Indigenous Relations and Northern Affairs Canada",
-    slug: "crown-indigenous-relations-and-northern-affairs",
-    href: "/spending/crown-indigenous-relations-and-northern-affairs",
+    slug: "indigenous-services-and-northern-affairs",
+    href: "/spending/indigenous-services-and-northern-affairs",
     Percentage: 3.19
   },
   {

--- a/website/src/components/DepartmentList.tsx
+++ b/website/src/components/DepartmentList.tsx
@@ -86,10 +86,16 @@ export const departments = [
     href: "/spending/public-services-and-procurement-canada",
     Percentage: 1.6
   },
-    {
+  {
     name: "Immigration, Refugees and Citizenship",
     slug: "immigration-refugees-and-citizenship",
     href: "/spending/immigration-refugees-and-citizenship",
+    Percentage: 1.2
+  },
+  {
+    name: "Veterans Affairs",
+    slug: "veterans-affairs",
+    href: "/spending/veterans-affairs",
     Percentage: 1.2
   },
 ].sort((a, b) => b.Percentage - a.Percentage)

--- a/website/src/components/DepartmentList.tsx
+++ b/website/src/components/DepartmentList.tsx
@@ -15,7 +15,7 @@ const DepartmentItem = ({ name, slug }: DepartmentProps) =>
 
 export const departments = [
   {
-    name: "Department of Finance",
+    name: "Finance Canada",
     slug: "department-of-finance",
     href: "/spending/department-of-finance",
     Percentage: 26.48
@@ -31,10 +31,6 @@ export const departments = [
     slug: "indigenous-services-and-northern-affairs",
     href: "/spending/indigenous-services-and-northern-affairs",
     Percentage: 9.06
-  },
-  {
-    name: "Crown-Indigenous Relations and Northern Affairs Canada",
-    Percentage: 3.19
   },
   {
     name: "National Defence",
@@ -53,6 +49,12 @@ export const departments = [
     slug: "canada-revenue-agency",
     href: "/spending/canada-revenue-agency",
     Percentage: 3.27
+  },
+  {
+    name: "Crown-Indigenous Relations and Northern Affairs Canada",
+    slug: "crown-indigenous-relations-and-northern-affairs",
+    href: "/spending/crown-indigenous-relations-and-northern-affairs",
+    Percentage: 3.19
   },
   {
     name: "Housing, Infrastructure and Communities Canada",

--- a/website/src/components/DepartmentList.tsx
+++ b/website/src/components/DepartmentList.tsx
@@ -98,6 +98,12 @@ export const departments = [
     href: "/spending/veterans-affairs",
     Percentage: 1.2
   },
+  {
+    name: "Transport Canada",
+    slug: "transport-canada",
+    href: "/spending/transport-canada",
+    Percentage: 1.0
+  },
 ].sort((a, b) => b.Percentage - a.Percentage)
 
 const BrowsableDepartment = departments.filter(d => !!d.href && !!d.slug) as {

--- a/website/src/components/DepartmentList.tsx
+++ b/website/src/components/DepartmentList.tsx
@@ -75,6 +75,12 @@ export const departments = [
     Percentage: 2.67
   },
   {
+    name: "Innovation, Science and Industry",
+    slug: "innovation-science-and-industry",
+    href: "/spending/innovation-science-and-industry",
+    Percentage: 2.0
+  },
+  {
     name: "Public Services and Procurement Canada",
     slug: "public-services-and-procurement-canada",
     href: "/spending/public-services-and-procurement-canada",

--- a/website/src/components/DepartmentSpendingChart.tsx
+++ b/website/src/components/DepartmentSpendingChart.tsx
@@ -10,7 +10,7 @@ export function DepartmentSpendingChart(props: {
 }) {
   const deps = Array.isArray(props.department) ? props.department : [props.department]
   const data = useMemo(() => {
-    return departments.map((item) => ({
+    return departments.slice(0, 10).map((item) => ({
       name: item.name,
       Percentage: deps.includes(item.name) ? undefined : item.Percentage,
       "Current Percentage": deps.includes(item.name) ? item.Percentage : undefined,

--- a/website/src/components/Layout.tsx
+++ b/website/src/components/Layout.tsx
@@ -24,9 +24,9 @@ export const H2 = ({ children, className = "" }: { children: React.ReactNode, cl
 )
 
 export const H3 = ({ children, className = "" }: { children: React.ReactNode, className?: string }) => (
-  <h2 className={`text-xl text-gray-600 font-bold mb-6 ${className}`}>
+  <h3 className={`text-xl text-gray-600 font-bold mb-6 ${className}`}>
     {children}
-  </h2>
+  </h3>
 )
 
 export const ChartContainer = ({ children, className = "" }: { children: React.ReactNode, className?: string }) => (

--- a/website/src/components/Sankey/SankeyChart.tsx
+++ b/website/src/components/Sankey/SankeyChart.tsx
@@ -43,7 +43,9 @@ const getFlatData = (data: SankeyData) => {
 				value: d.value,
 				type: 'spending'
 			}))
-		].sort((a, b) => a.name.localeCompare(b.name)),
+		].sort((a, b) => {
+			return (a.name || "").localeCompare(b.name || "");
+		}),
 		revenueTotal: revenueRoot.value ?? 0,
 		spendingTotal: spendingRoot.value ?? 0
 	}


### PR DESCRIPTION
 - [x] Public Services and Procurement Canada
 - [x] Innovation, Science and Industry;
 - [x] Immigration
 - [x] Refugees and Citizenship
 - [x] Veterans Affairs
 - [x] Transport


To fix:
- [ ] Top 10 charts on each page should only show top 10 + extra dept

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced interactive pages that deliver dynamic visualizations for federal spending trends. Users can explore detailed charts—including bar, line, and Sankey diagrams—for departments such as Public Services, Immigration, Indigenous Services + Crown-Indigenous Relations, Innovation, and Veterans Affairs.
  - Added new components to visualize federal spending by various entities, including charts for Federal Spending by Entity and MiniSankey diagrams.

- **Content Updates**
  - Refreshed departmental listings with updated names and additional entries.
  - Enhanced page metadata to provide clearer context and organization of government spending data.
  - Added new headers to improve clarity and context for displayed charts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->