### PR TITLE
website: fix typo in Health Canada page Title

### DIFF
--- a/website/src/app/(main)/spending/health-canada/page.tsx
+++ b/website/src/app/(main)/spending/health-canada/page.tsx
@@ -8,7 +8,7 @@ import { StatCard, StatCardContainer } from "@/components/StatCard";
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-	title: 'Health Canada| Canada Spends',
+	title: 'Health Canada | Canada Spends',
 	description: 'A look at how the Health Canada spends its budget',
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refined the formatting of the Health Canada page title by adding proper spacing around the separator for a clearer presentation.
  - Applied a minor formatting adjustment to ensure consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->