### PR TITLE
Update menu items to Government Spending and Search Database

### DIFF
--- a/website/src/components/MainLayout/index.tsx
+++ b/website/src/components/MainLayout/index.tsx
@@ -40,10 +40,10 @@ export const MainLayout = ({ children }: { children: React.ReactNode }) => {
 						</Link>
 						<div className="items-stretch justify-end flex min-h-full gap-6">
 							<NavLink href={`/${i18n.locale}/spending`} >
-								<Trans>Spending</Trans>
+								<Trans>Government Spending</Trans>
 							</NavLink>
 								<NavLink href={`/${i18n.locale}/search`} >
-									<Trans>Search</Trans>
+									<Trans>Spending Database</Trans>
 								</NavLink>
 							<NavLink href={`/${i18n.locale}/about`} >
 								<Trans>About</Trans>


### PR DESCRIPTION
Updated menu changes per Lucy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated navigation labels for clearer guidance:
    - The Spending page is now labeled as **Government Spending**.
    - The Search page is now labeled as **Spending Database**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->