### PR TITLE
Fix truncated text in Sankey chart with hover tooltips

### DIFF
--- a/src/components/Sankey/SankeyChart.css
+++ b/src/components/Sankey/SankeyChart.css
@@ -64,15 +64,17 @@
   
   .node-tooltip {
     z-index: 10;
-    width: 320px;
-    position: absolute;
-    top: 10px;
-    right: 10px;
+    min-width: 200px;
+    max-width: 320px;
+    position: fixed;
     background-color: #000;
     color: var(--color-text-base);
     padding: 10px;
     font-size: 12px;
     border-radius: 4px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    pointer-events: none;
   }
   
   .node-tooltip-name {

--- a/src/components/Sankey/SankeyChartD3.tsx
+++ b/src/components/Sankey/SankeyChartD3.tsx
@@ -229,8 +229,11 @@ export class SankeyChartD3 {
 				return 0
 			})
 			.on('mouseover', (e, d) => {
+				const target = e.currentTarget as HTMLElement
+				const rect = target.getBoundingClientRect()
+				
 				this.highlightNode(d)
-				this.params.onMouseOver(d)
+				this.params.onMouseOver({ ...d, blockRect: rect }, e)
 			})
 			.on('mouseout', (e, d) => {
 				this.highlightNode(null)


### PR DESCRIPTION
- Add dynamic tooltip that displays full text on hover for all blocks
- Position tooltip above hovered blocks to avoid conflict with native tooltips

Fixes #107

<img width="667" alt="Screenshot 2025-07-07 at 11 32 10 PM" src="https://github.com/user-attachments/assets/30706c00-a67a-404f-beed-d10eefa2bbe9" />