### PR TITLE
fix: implement sticky header for Sankey search bar

### DIFF
--- a/src/components/Sankey/SankeyChart.css
+++ b/src/components/Sankey/SankeyChart.css
@@ -53,17 +53,42 @@
 .sankey-chart-container {
   position: relative;
   background-color: #202122;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  
+  .sankey-chart-wrapper {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+  
+  .sankey-chart-header {
+    position: sticky;
+    top: 0;
+    background-color: #202122;
+    padding: 16px 20px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    z-index: 10;
+    display: flex;
+    justify-content: flex-end;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  }
+  
+  .sankey-chart-content {
+    flex: 1;
+    overflow-y: auto;
+    overflow-x: hidden;
+    position: relative;
+  }
   
   .search-container {
     width: 320px;
-    position: absolute;
-    top: 10px;
-    right: 10px;
-    z-index: 5;
   }
   
   .node-tooltip {
-    z-index: 10;
+    z-index: 20;
     min-width: 200px;
     max-width: 320px;
     position: fixed;
@@ -93,8 +118,8 @@
     padding: 1rem 1.5rem 0px 1rem;
     flex-grow: 1;
     display: flex;
-    overflow: hidden;
     column-gap: .5rem;
+    height: 100%;
   }
   
   .chart {

--- a/src/components/Sankey/SankeyChart.tsx
+++ b/src/components/Sankey/SankeyChart.tsx
@@ -141,8 +141,9 @@ export function SankeyChart(props: SankeyChartProps) {
 	}, [])
 
 	return (
-		<>
-			<div className='search-container'>
+		<div className='sankey-chart-wrapper'>
+			<div className='sankey-chart-header'>
+				<div className='search-container'>
 				<Select
 					instanceId="sankey-search"
 					inputId="sankey-search-input"
@@ -172,9 +173,11 @@ export function SankeyChart(props: SankeyChartProps) {
 						})
 					}}
 				/>
+				</div>
 			</div>
 
-			{hoverNode && (
+			<div className='sankey-chart-content'>
+				{hoverNode && (
 				<div 
 					className='node-tooltip'
 					style={{
@@ -241,7 +244,8 @@ export function SankeyChart(props: SankeyChartProps) {
 					/>
 				</div>
 			)}
-		</>
+			</div>
+		</div>
 	)
 }
 


### PR DESCRIPTION
Fixes the search bar overlap issue by converting it from an absolutely positioned element to a sticky header that remains visible while scrolling. The search bar now stays at the top of the chart container and doesn't cover the Sankey content.

Changes:
- Restructured SankeyChart component to use wrapper/header/content layout
- Converted search bar to sticky header with proper z-index layering
- Added visual styling with border and shadow to differentiate header
- Adjusted overflow behavior to work with new structure
- Increased tooltip z-index to ensure visibility above header

Fixes #123 

<img width="647" height="342" alt="Screenshot 2025-07-12 at 10 58 26 AM" src="https://github.com/user-attachments/assets/35588514-42fa-421f-9a05-b7fcefe7e57f" />