### PR TITLE
Fix broken link for minister of revenue

### DIFF
--- a/src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx
+++ b/src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx
@@ -198,7 +198,7 @@ export default async function Department(props: PageLangParam) {
 					<P>
 						<Trans>
 							The Canada Revenue Agency is overseen by the{" "}
-							<ExternalLink href="https://www.canada.ca/en/government/ministers/marie-claude-bibeau.html">
+							<ExternalLink href="https://www.canada.ca/en/government/ministers/francois-philippe-champagne.html">
 								Minister of National Revenue
 							</ExternalLink>
 							, who is responsible for ensuring tax fairness and benefit program


### PR DESCRIPTION
This pull request fixes a broken external link for the Minister of National Revenue on the Canada Revenue Agency spending page