### PR TITLE
 Tax Vis : add percentages of total tax amount for split spendings : Issue 136

### DIFF
--- a/src/components/CombinedSpendingChart.tsx
+++ b/src/components/CombinedSpendingChart.tsx
@@ -65,7 +65,7 @@ export function CombinedSpendingChart({
                   {item.name}
                 </div>
                 <div className="text-sm font-semibold text-gray-900 whitespace-nowrap">
-                  {item.formattedTotal} | {percentageOfTotalTax.toFixed(1)}%
+                  {item.formattedTotal} ({percentageOfTotalTax.toFixed(1)}%)
                 </div>
               </div>
               


### PR DESCRIPTION
Closes https://github.com/BuildCanada/CanadaSpends/issues/136
Added percentage amount against each section of taxed item wrt total taxed amount. 
Looks like this : 
<img width="895" height="445" alt="Screenshot 2025-07-16 at 6 25 21 PM" src="https://github.com/user-attachments/assets/807cf1ca-d010-4d14-9406-173580df7ef8" />

I'm welcome to formatting suggestions if any