### PR TITLE
Fix exposed security key for Typesense API

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -26,6 +26,15 @@ const nextConfig: NextConfig = {
 
     return config;
   },
+  async redirects() {
+    return [
+      {
+        source: "/:locale/tax-calculator",
+        destination: "/:locale/tax-visualizer",
+        permanent: true,
+      },
+    ];
+  },
   async rewrites() {
     return [
       {


### PR DESCRIPTION
## Description

This pull request addresses a security vulnerability identified in [[Issue #132](https://github.com/BuildCanada/CanadaSpends/issues/132)](https://github.com/BuildCanada/CanadaSpends/issues/132), where the Typesense API key was exposed in the codebase.  Replaced the hardcoded API key with a reference to the environment variable `NEXT_PUBLIC_TYPESENSE_API_KEY` in `src/components/Search.tsx`.

**Action Required:**  
- Delete the previously exposed API key (`YpZamILESYThUVYZZ87dIBuJorHtRPfa`) from the Typesense dashboard to prevent any potential unauthorized access.
- Use `NEXT_PUBLIC_TYPESENSE_API_KEY` in the env file

Closes #132.