### PR TITLE
feat: Add Department links to Federal Sankey diagram spending items

### DIFF
--- a/src/components/Sankey/SankeyChart.css
+++ b/src/components/Sankey/SankeyChart.css
@@ -215,6 +215,54 @@
   .block.highlight:not(.with-background) .label {
     color: #000000 !important;
   }
+
+  /* Debug styles for clickable blocks */
+  .block.clickable {
+    cursor: pointer !important;
+    transition: all 0.2s ease-in-out;
+  }
+
+  .block.clickable * {
+    cursor: pointer !important;
+  }
+
+  .block.clickable:hover {
+    transform: scale(1.02);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  }
+
+  .block.clickable .label-name {
+    transition: all 0.2s ease-in-out;
+    cursor: pointer !important;
+  }
+
+  .block.clickable .label-name a {
+    cursor: pointer !important;
+  }
+
+  .block.clickable .label {
+    cursor: pointer !important;
+  }
+
+  .sankey-chart-container .block.clickable:hover .label-name {
+    text-decoration: underline !important;
+    text-decoration-color: #FF0000 !important;
+    text-underline-offset: 2px !important;
+    text-decoration-thickness: 3px !important;
+    border-bottom: 3px solid #FF0000 !important;
+    cursor: pointer !important;
+    background-color: rgba(255, 0, 0, 0.2) !important;
+  }
+
+  .sankey-chart-container .block.clickable:hover .label-name a {
+    text-decoration: underline !important;
+    text-decoration-color: #FF0000 !important;
+    text-underline-offset: 2px !important;
+    text-decoration-thickness: 3px !important;
+    border-bottom: 3px solid #FF0000 !important;
+    cursor: pointer !important;
+    background-color: rgba(255, 0, 0, 0.2) !important;
+  }
   
   .sankey-chart-svg .link {
     opacity: 0.5;

--- a/src/components/Sankey/SankeyChart.tsx
+++ b/src/components/Sankey/SankeyChart.tsx
@@ -1,4 +1,5 @@
 import { hierarchy } from 'd3'
+import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useState } from 'react'
 import Select from 'react-select'
 import './SankeyChart.css'
@@ -79,6 +80,7 @@ type SankeyChartProps = {
 }
 
 export function SankeyChart(props: SankeyChartProps) {
+	const router = useRouter()
 	const [chartData, setChartData] = useState<SankeyData | null>(null)
 	const [flatData, setFlatData] = useState<FlatDataNodes | null>(null)
 
@@ -88,6 +90,7 @@ export function SankeyChart(props: SankeyChartProps) {
 	// Mouse position as fallback - ensures tooltip still works if blockRect is missing
 	const [mousePosition, setMousePosition] = useState<{ x: number; y: number } | null>(null)
 	const [totalAmount, setTotalAmount] = useState(0)
+	const [tooltipTimeout, setTooltipTimeout] = useState<NodeJS.Timeout | null>(null)
 
 	useEffect(() => {
 		// Transform the data to use ID-based structure
@@ -103,6 +106,15 @@ export function SankeyChart(props: SankeyChartProps) {
 		setFlatData(nodes)
 		setTotalAmount(Math.max(revenueTotal, spendingTotal))
 	}, [props.data])
+
+	// Cleanup timeout on unmount
+	useEffect(() => {
+		return () => {
+			if (tooltipTimeout) {
+				clearTimeout(tooltipTimeout)
+			}
+		}
+	}, [tooltipTimeout])
 
 	const handleSearch = (selected: SearchOptionType | null) => {
 		setSearchedNode(selected)
@@ -136,8 +148,222 @@ export function SankeyChart(props: SankeyChartProps) {
 	}, [])
 
 	const handleMouseOut = useCallback(() => {
+		// Clear any existing timeout
+		if (tooltipTimeout) {
+			clearTimeout(tooltipTimeout)
+		}
+		
+		// Set a delay before hiding tooltip to allow mouse movement to tooltip
+		const timeout = setTimeout(() => {
+			setHoverNode(null)
+			setMousePosition(null)
+		}, 300) // 300ms delay
+		
+		setTooltipTimeout(timeout)
+	}, [tooltipTimeout])
+
+	const handleTooltipMouseEnter = useCallback(() => {
+		// Cancel hiding tooltip when mouse enters tooltip
+		if (tooltipTimeout) {
+			clearTimeout(tooltipTimeout)
+			setTooltipTimeout(null)
+		}
+	}, [tooltipTimeout])
+
+	const handleTooltipMouseLeave = useCallback(() => {
+		// Hide tooltip immediately when mouse leaves tooltip area
 		setHoverNode(null)
 		setMousePosition(null)
+		if (tooltipTimeout) {
+			clearTimeout(tooltipTimeout)
+			setTooltipTimeout(null)
+		}
+	}, [tooltipTimeout])
+
+	const getDepartmentName = (url: string): string => {
+		const departmentNames: Record<string, string> = {
+			'/spending/health-canada': 'Health Canada',
+			'/spending/veterans-affairs': 'Veterans Affairs Canada',
+			'/spending/employment-and-social-development-canada': 'Employment and Social Development Canada',
+			'/spending/housing-infrastructure-communities': 'Housing, Infrastructure and Communities Canada',
+			'/spending/innovation-science-and-industry': 'Innovation, Science and Economic Development Canada',
+			'/spending/national-defence': 'Department of National Defence',
+			'/spending/indigenous-services-and-northern-affairs': 'Indigenous Services Canada and Crown-Indigenous Relations',
+			'/spending/global-affairs-canada': 'Global Affairs Canada',
+			'/spending/public-safety-canada': 'Public Safety Canada',
+			'/spending/transport-canada': 'Transport Canada',
+			'/spending/canada-revenue-agency': 'Canada Revenue Agency',
+			'/spending/immigration-refugees-and-citizenship': 'Immigration, Refugees and Citizenship Canada',
+			'/spending/public-services-and-procurement-canada': 'Public Services and Procurement Canada',
+			'/spending/department-of-finance': 'Department of Finance Canada'
+		}
+		
+		return departmentNames[url] || 'Government Department'
+	}
+
+	const getDepartmentUrl = (nodeName: string): string | undefined => {
+		const normalizedName = (nodeName || '').toLowerCase()
+		
+		// Department mappings based on spending categories
+		const departmentMappings: Record<string, string> = {
+			// Health Canada
+			'health': '/spending/health-canada',
+			'health research': '/spending/health-canada',
+			'health care systems + protection': '/spending/health-canada',
+			'food safety': '/spending/health-canada',
+			'public health + disease prevention': '/spending/health-canada',
+			'health transfer to provinces': '/spending/health-canada',
+			'first nations and inuit health infrastructure support': '/spending/health-canada',
+			'first nations and inuit primary health care': '/spending/health-canada',
+			
+			// Veterans Affairs Canada
+			'support for veterans': '/spending/veterans-affairs',
+			'veteran pensions': '/spending/veterans-affairs',
+			'veteran benefits': '/spending/veterans-affairs',
+			
+			// Employment and Social Development Canada (ESDC)
+			'employment + training': '/spending/employment-and-social-development-canada',
+			'employment insurance': '/spending/employment-and-social-development-canada',
+			'old age security': '/spending/employment-and-social-development-canada',
+			'canada pension plan': '/spending/employment-and-social-development-canada',
+			'social security': '/spending/employment-and-social-development-canada',
+			'retirement benefits': '/spending/employment-and-social-development-canada',
+			'children\'s benefits': '/spending/employment-and-social-development-canada',
+			'covid-19 income support': '/spending/employment-and-social-development-canada',
+			'canada emergency wage subsidy': '/spending/employment-and-social-development-canada',
+			
+			// Housing, Infrastructure and Communities Canada (HICC)
+			'housing assistance': '/spending/housing-infrastructure-communities',
+			'infrastructure investments': '/spending/housing-infrastructure-communities',
+			'community infrastructure grants': '/spending/housing-infrastructure-communities',
+			'interim housing assistance': '/spending/housing-infrastructure-communities',
+			'sustainable bases, it systems, infrastructure': '/spending/housing-infrastructure-communities',
+			
+			// Innovation, Science and Economic Development Canada (ISED)
+			'innovation + research': '/spending/innovation-science-and-industry',
+			'investment, growth and commercialization': '/spending/innovation-science-and-industry',
+			'research': '/spending/innovation-science-and-industry',
+			'statistics canada': '/spending/innovation-science-and-industry',
+			'economic development in southern ontario': '/spending/innovation-science-and-industry',
+			'economic development in atlantic canada': '/spending/innovation-science-and-industry',
+			'economic development in the pacific region': '/spending/innovation-science-and-industry',
+			'western + northern economic development': '/spending/innovation-science-and-industry',
+			'economic development in northern ontario': '/spending/innovation-science-and-industry',
+			'economic development in quebec': '/spending/innovation-science-and-industry',
+			'other boards + councils': '/spending/innovation-science-and-industry',
+			'space': '/spending/innovation-science-and-industry',
+			
+			// National Defence
+			'defence': '/spending/national-defence',
+			'defence team': '/spending/national-defence',
+			'defence operations + internal services': '/spending/national-defence',
+			'other defence': '/spending/national-defence',
+			
+			// Indigenous Services Canada and Crown-Indigenous Relations
+			'indigenous priorities': '/spending/indigenous-services-and-northern-affairs',
+			'indigenous well-being + self determination': '/spending/indigenous-services-and-northern-affairs',
+			'grants to support the new fiscal relationship with first nations': '/spending/indigenous-services-and-northern-affairs',
+			'first nations elementary and secondary educational advancement': '/spending/indigenous-services-and-northern-affairs',
+			'other support for indigenous well-being': '/spending/indigenous-services-and-northern-affairs',
+			'crown-indigenous relations': '/spending/indigenous-services-and-northern-affairs',
+			'other grants and contributions to support crown-indigenous relations': '/spending/indigenous-services-and-northern-affairs',
+			
+			// Global Affairs Canada
+			'international affairs': '/spending/global-affairs-canada',
+			'international diplomacy': '/spending/global-affairs-canada',
+			'other international affairs activities': '/spending/global-affairs-canada',
+			'development, peace + security programming': '/spending/global-affairs-canada',
+			'official languages + culture': '/spending/global-affairs-canada',
+			
+			// Public Safety Canada
+			'public safety': '/spending/public-safety-canada',
+			'corrections': '/spending/public-safety-canada',
+			'other public safety expenses': '/spending/public-safety-canada',
+			'csis': '/spending/public-safety-canada',
+			'rcmp': '/spending/public-safety-canada',
+			'disaster relief': '/spending/public-safety-canada',
+			'community safety': '/spending/public-safety-canada',
+			'justice system': '/spending/public-safety-canada',
+			'communications security establishment': '/spending/public-safety-canada',
+			
+			// Immigration, Refugees and Citizenship Canada (IRCC)
+			'immigration + border security': '/spending/immigration-refugees-and-citizenship',
+			'border security': '/spending/immigration-refugees-and-citizenship',
+			'other immigration services': '/spending/immigration-refugees-and-citizenship',
+			'citizenship + passports': '/spending/immigration-refugees-and-citizenship',
+			'settlement assistance': '/spending/immigration-refugees-and-citizenship',
+			'visitors, international students + temporary workers': '/spending/immigration-refugees-and-citizenship',
+			
+			// Transport Canada
+			'transportation': '/spending/transport-canada',
+			'excise tax — aviation gasoline and jet fuel': '/spending/transport-canada',
+			'coastguard operations': '/spending/transport-canada',
+			
+			// Canada Revenue Agency
+			'revenue canada': '/spending/canada-revenue-agency',
+			'taxation': '/spending/canada-revenue-agency',
+			'tax collection': '/spending/canada-revenue-agency',
+			'carbon tax rebate': '/spending/canada-revenue-agency',
+			
+			// Public Services and Procurement Canada
+			'other public services + procurement': '/spending/public-services-and-procurement-canada',
+			'defence procurement': '/spending/public-services-and-procurement-canada',
+			'government it operations': '/spending/public-services-and-procurement-canada',
+			
+			// Department of Finance Canada
+			'banking + finance': '/spending/department-of-finance',
+			'transfers to provinces': '/spending/department-of-finance',
+			'social transfer to provinces': '/spending/department-of-finance',
+			'equalization payments to provinces': '/spending/department-of-finance',
+			'territorial formula financing': '/spending/department-of-finance',
+			
+			// Environment and Climate Change Canada (missing from URL structure, using closest)
+			'environment and climate change': '/spending/innovation-science-and-industry',
+			'other environment and climate change programs': '/spending/innovation-science-and-industry',
+			'weather services': '/spending/innovation-science-and-industry',
+			'nature conservation': '/spending/innovation-science-and-industry',
+			'national parks': '/spending/innovation-science-and-industry',
+			
+			// Fisheries and Oceans Canada (missing from URL structure, using closest)
+			'fisheries': '/spending/innovation-science-and-industry',
+			'fisheries + aquatic ecosystems': '/spending/innovation-science-and-industry',
+			'other fisheries expenses': '/spending/innovation-science-and-industry',
+			
+			// Agriculture and Agri-Food Canada (missing from URL structure, using closest)
+			'agriculture': '/spending/innovation-science-and-industry',
+			
+			// Natural Resources Canada (missing from URL structure, using closest)
+			'natural resources management': '/spending/innovation-science-and-industry',
+			'innovative and sustainable natural resources development': '/spending/innovation-science-and-industry',
+			'support for global competition': '/spending/innovation-science-and-industry',
+			'nuclear labs + decommissioning': '/spending/innovation-science-and-industry',
+			'natural resources science + risk mitigation': '/spending/innovation-science-and-industry',
+			'other natural resources management support': '/spending/innovation-science-and-industry',
+			
+			// Gender Equality (Status of Women Canada) - part of Women and Gender Equality Canada
+			'gender equality': '/spending/employment-and-social-development-canada',
+			
+			// Additional Treasury Board items (missing from URL structure)
+			'treasury board': '/spending/public-services-and-procurement-canada',
+			'parliament': '/spending/public-services-and-procurement-canada',
+			'privy council office': '/spending/public-services-and-procurement-canada',
+			'office of the secretary to the governor general': '/spending/public-services-and-procurement-canada',
+			'office of the chief electoral officer': '/spending/public-services-and-procurement-canada'
+		}
+
+		// Check for exact or partial matches
+		for (const [key, url] of Object.entries(departmentMappings)) {
+			if (normalizedName.includes(key)) {
+				return url
+			}
+		}
+		
+		return undefined
+	}
+
+	const handleClick = useCallback(() => {
+		// Click functionality removed - links are now only in tooltips
+		return
 	}, [])
 
 	return (
@@ -180,6 +406,8 @@ export function SankeyChart(props: SankeyChartProps) {
 				{hoverNode && (
 				<div 
 					className='node-tooltip'
+					onMouseEnter={handleTooltipMouseEnter}
+					onMouseLeave={handleTooltipMouseLeave}
 					style={{
 						// Horizontal: right of the block, constrained to viewport
 						left: hoverNode.blockRect 
@@ -189,7 +417,9 @@ export function SankeyChart(props: SankeyChartProps) {
 						// Math.max ensures tooltip stays within viewport (min 10px from top)
 						top: hoverNode.blockRect 
 							? `${Math.max(10, hoverNode.blockRect.top - 40)}px`
-							: `${(mousePosition?.y || 0) + 10}px`
+							: `${(mousePosition?.y || 0) + 10}px`,
+						pointerEvents: 'auto', // Enable mouse events on tooltip
+						cursor: 'default'
 					}}
 				>
 					<p className='node-tooltip-name'>{hoverNode.displayName || hoverNode.name}</p>
@@ -198,6 +428,47 @@ export function SankeyChart(props: SankeyChartProps) {
 						<span className='node-tooltip-amount-divider'>&#8226;</span>
 						<span>{hoverNode.percent.toFixed(1)}%</span>
 					</div>
+					{(() => {
+						let url = getDepartmentUrl(hoverNode.displayName || hoverNode.name || '')
+						if (!url && hoverNode.link) {
+							url = hoverNode.link
+						}
+						
+						if (url) {
+							const departmentName = getDepartmentName(url)
+							return (
+								<div style={{ marginTop: '8px', borderTop: '1px solid rgba(255, 255, 255, 0.2)', paddingTop: '8px' }}>
+									<a 
+										href={url}
+										onClick={(e) => {
+											e.preventDefault()
+											router.push(url)
+											setHoverNode(null) // Hide tooltip after click
+										}}
+										style={{
+											color: '#66c4ef',
+											textDecoration: 'none',
+											fontSize: '11px',
+											fontWeight: '600',
+											display: 'flex',
+											alignItems: 'center',
+											gap: '4px',
+											cursor: 'pointer'
+										}}
+										onMouseEnter={(e) => {
+											e.currentTarget.style.textDecoration = 'underline'
+										}}
+										onMouseLeave={(e) => {
+											e.currentTarget.style.textDecoration = 'none'
+										}}
+									>
+										🔗 Visit {departmentName}
+									</a>
+								</div>
+							)
+						}
+						return null
+					})()}
 				</div>
 			)}
 
@@ -212,6 +483,7 @@ export function SankeyChart(props: SankeyChartProps) {
 						amountScalingFactor={amountScalingFactor}
 						onMouseOver={handleMouseOver(chartData.revenue)}
 						onMouseOut={handleMouseOut}
+						onClick={handleClick}
 					/>
 
 					<SankeyChartSingle
@@ -223,6 +495,7 @@ export function SankeyChart(props: SankeyChartProps) {
 						amountScalingFactor={amountScalingFactor}
 						onMouseOver={handleMouseOver(chartData.spending)}
 						onMouseOut={handleMouseOut}
+						onClick={handleClick}
 					/>
 				</div>
 			)}
@@ -241,6 +514,7 @@ export function SankeyChart(props: SankeyChartProps) {
 						amountScalingFactor={amountScalingFactor}
 						difference={0}
 						differenceLabel=''
+						onClick={handleClick}
 					/>
 				</div>
 			)}

--- a/src/components/Sankey/SankeyChartD3.tsx
+++ b/src/components/Sankey/SankeyChartD3.tsx
@@ -13,6 +13,7 @@ export type SankeyNode = {
 	name?: string        // Optional: for backward compatibility
 	amount: number
 	children?: SankeyNode[]
+	link?: string        // Optional: URL link for clickable nodes
 }
 
 export type SankeyData = {
@@ -45,6 +46,7 @@ export type SankeyChartD3Props = {
 	amountScalingFactor?: number
 	onMouseOver?: (node: any) => void
 	onMouseOut?: (node: any) => void
+	onClick?: (node: any) => void
 }
 export class SankeyChartD3 {
 	params: SankeyChartD3Props
@@ -72,7 +74,8 @@ export class SankeyChartD3 {
 				differenceLabel: 'Deficit',
 				amountScalingFactor: 1e9,
 				onMouseOver: () => {},
-				onMouseOut: () => {}
+				onMouseOut: () => {},
+				onClick: () => {}
 			},
 			props
 		)
@@ -114,17 +117,16 @@ export class SankeyChartD3 {
 
 	// Calculates dimensions and sets up the scaling function
 	setChartDimensions() {
-		let { width, height, margin } = this.params
+		const { width, height, margin } = this.params
 
 		if (!width) {
 			const w = this.container.node().getBoundingClientRect().width
 			if (w) {
-				width = w
 				this.params.width = w
 			}
 		}
 
-		this.chartWidth = width - margin.left - margin.right
+		this.chartWidth = (this.params.width || width) - margin.left - margin.right
 		this.chartHeight = height - margin.top - margin.bottom
 
 		this.scale = scaleLinear()
@@ -209,6 +211,13 @@ export class SankeyChartD3 {
 			.attr('class', 'block')
 			.style('position', 'relative')
 			.classed('fake', d => d.fake)
+			.classed('clickable', d => {
+				const hasLink = !!d.link
+				if (hasLink) {
+					console.log('Block with clickable class:', d.displayName, 'link:', d.link)
+				}
+				return hasLink
+			})
 			.classed(
 				'with-background',
 				d => d.amount < 0 || this.scale(d.value) < this.params.shortBlockHeight
@@ -238,6 +247,9 @@ export class SankeyChartD3 {
 			.on('mouseout', (e, d) => {
 				this.highlightNode(null)
 				this.params.onMouseOut(d)
+			})
+			.on('click', (e, d) => {
+				this.params.onClick(d)
 			})
 
 		blocks
@@ -351,7 +363,7 @@ export class SankeyChartD3 {
 			.selectAll('.block:not(.fake)')
 			.classed('highlight', function (x) {
 				if (nodesToHighlight.includes(x.id)) {
-					// @ts-ignore
+					// @ts-expect-error: D3 element typing complexity
 					highlightedNodeElements.push(this.querySelector('.label'))
 					return true
 				}

--- a/src/components/Sankey/SankeyChartSingle.tsx
+++ b/src/components/Sankey/SankeyChartSingle.tsx
@@ -17,7 +17,8 @@ export function SankeyChartSingle(props: SankeyChartProps) {
 		height = 760,
 		amountScalingFactor = 1e9,
 		onMouseOver = () => { },
-		onMouseOut = () => { }
+		onMouseOut = () => { },
+		onClick = () => { }
 	} = props;
 
 	const chartRef = useRef(null)
@@ -37,7 +38,8 @@ export function SankeyChartSingle(props: SankeyChartProps) {
 				amountScalingFactor,
 				colors,
 				onMouseOver,
-				onMouseOut
+				onMouseOut,
+				onClick
 			})
 		},
 		// No need to add other dependencies because the chart is only rendered once

--- a/src/components/Sankey/index.tsx
+++ b/src/components/Sankey/index.tsx
@@ -9,8 +9,131 @@ export function Sankey() {
 	const { t } = useLingui()
 
 	const data = useMemo(() => {
+		// Helper function to add links to nodes based on their names
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const addLinksToNodes = (node: any): any => {
+			const getDepartmentLink = (nodeName: string): string | undefined => {
+				const normalizedName = nodeName.toLowerCase()
+				
+				// Department mappings based on spending categories
+				const departmentMappings: Record<string, string> = {
+					// Health related - exact matches
+					'health research': '/spending/health-canada',
+					'health care systems + protection': '/spending/health-canada',
+					'food safety': '/spending/health-canada',
+					'public health + disease prevention': '/spending/health-canada',
+					'health': '/spending/health-canada',
+					
+					// Veterans - exact matches
+					'support for veterans': '/spending/veterans-affairs',
+					'veteran pensions': '/spending/veterans-affairs',
+					'veteran benefits': '/spending/veterans-affairs',
+					'veterans': '/spending/veterans-affairs',
+					
+					// Revenue Agency - exact matches
+					'revenue canada': '/spending/canada-revenue-agency',
+					'taxation': '/spending/canada-revenue-agency',
+					'tax collection': '/spending/canada-revenue-agency',
+					
+					// Employment and Social Development - exact matches
+					'employment + training': '/spending/employment-and-social-development-canada',
+					'employment insurance': '/spending/employment-and-social-development-canada',
+					'old age security': '/spending/employment-and-social-development-canada',
+					'canada pension plan': '/spending/employment-and-social-development-canada',
+					'employment': '/spending/employment-and-social-development-canada',
+					
+					// Housing and Infrastructure - exact matches
+					'housing assistance': '/spending/housing-infrastructure-communities',
+					'housing': '/spending/housing-infrastructure-communities',
+					'infrastructure': '/spending/housing-infrastructure-communities',
+					'communities': '/spending/housing-infrastructure-communities',
+					
+					// Innovation, Science and Industry - exact matches
+					'innovation + research': '/spending/innovation-science-and-industry',
+					'investment, growth and commercialization': '/spending/innovation-science-and-industry',
+					'research': '/spending/innovation-science-and-industry',
+					'statistics canada': '/spending/innovation-science-and-industry',
+					'innovation': '/spending/innovation-science-and-industry',
+					'science': '/spending/innovation-science-and-industry',
+					'industry': '/spending/innovation-science-and-industry',
+					
+					// Transport - exact matches
+					'aviation': '/spending/transport-canada',
+					'marine': '/spending/transport-canada',
+					'rail': '/spending/transport-canada',
+					'transport': '/spending/transport-canada',
+					'transportation': '/spending/transport-canada',
+					
+					// Global Affairs - exact matches
+					'international': '/spending/global-affairs-canada',
+					'foreign affairs': '/spending/global-affairs-canada',
+					'diplomatic': '/spending/global-affairs-canada',
+					'global affairs': '/spending/global-affairs-canada',
+					
+					// Public Safety - exact matches
+					'public safety': '/spending/public-safety-canada',
+					'policing': '/spending/public-safety-canada',
+					'security': '/spending/public-safety-canada',
+					'corrections': '/spending/public-safety-canada',
+					
+					// Indigenous Services - exact matches
+					'indigenous': '/spending/indigenous-services-and-northern-affairs',
+					'first nations': '/spending/indigenous-services-and-northern-affairs',
+					'northern affairs': '/spending/indigenous-services-and-northern-affairs',
+					
+					// Immigration - exact matches
+					'immigration': '/spending/immigration-refugees-and-citizenship',
+					'refugees': '/spending/immigration-refugees-and-citizenship',
+					'citizenship': '/spending/immigration-refugees-and-citizenship',
+					
+					// Public Services and Procurement - exact matches
+					'procurement': '/spending/public-services-and-procurement-canada',
+					'public services': '/spending/public-services-and-procurement-canada',
+					
+					// Finance - exact matches
+					'finance': '/spending/department-of-finance',
+					'financial': '/spending/department-of-finance',
+					'fiscal': '/spending/department-of-finance',
+					
+					// National Defence - exact matches
+					'national defence': '/spending/national-defence',
+					'defence': '/spending/national-defence',
+					'military': '/spending/national-defence'
+				}
 
-		return JSON.parse(JSON.stringify({
+				// Check for exact matches first
+				if (departmentMappings[normalizedName]) {
+					return departmentMappings[normalizedName]
+				}
+				
+				// Check for partial matches (contains)
+				for (const [key, url] of Object.entries(departmentMappings)) {
+					if (normalizedName.includes(key)) {
+						return url
+					}
+				}
+				
+				return undefined
+			}
+
+			const processedNode = { ...node }
+			
+			// Add link if this node corresponds to a department
+			const link = getDepartmentLink(node.name || '')
+			if (link) {
+				processedNode.link = link
+				console.log(`Added link to node "${node.name}": ${link}`)
+			}
+
+			// Recursively process children
+			if (node.children) {
+				processedNode.children = node.children.map(addLinksToNodes)
+			}
+
+			return processedNode
+		}
+
+		const rawData = {
 			"total": 513.94,
 			"spending": 513.94,
 			"revenue": 459.53,
@@ -795,9 +918,16 @@ export function Sankey() {
 					}
 				]
 			}
-		}))
+		}
 
-	}, [])
+		// Process the data to add links
+		const processedData = JSON.parse(JSON.stringify(rawData))
+		processedData.spending_data = addLinksToNodes(processedData.spending_data)
+		processedData.revenue_data = addLinksToNodes(processedData.revenue_data)
+		
+		return processedData
+
+	}, [t])
 
 
 	return (


### PR DESCRIPTION
- Implement enhanced tooltips with clickable ministry links
- Add comprehensive department mapping for federal spending categories
- Fix incorrect social security mapping (was Public Safety, now ESDC)
- Correct immigration/border security mappings to IRCC
- Add sticky tooltip behavior with 300ms delay for better UX
- Map economic development agencies to ISED
- Add proper ministry name display (e.g., 'Department of National Defence')
- Remove direct click functionality on blocks, keep tooltip-based navigation
- Fix eslint errors and warnings

Closes #108