### PR TITLE
Link relevant departments to main sankey + make tooltip hoverable + make departments searchable

### DIFF
--- a/src/components/Sankey/SankeyChart.css
+++ b/src/components/Sankey/SankeyChart.css
@@ -99,7 +99,7 @@
     border-radius: 4px;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
     border: 1px solid rgba(255, 255, 255, 0.1);
-    pointer-events: none;
+    pointer-events: all;
   }
   
   .node-tooltip-name {
@@ -111,6 +111,22 @@
     display: flex;
     flex-direction: row;
     gap: 8px;
+  }
+  
+  .node-tooltip-department {
+    margin-top: 8px;
+    font-size: 11px;
+  }
+
+  .node-tooltip-link {
+    color: #66c4ef;
+    text-decoration: none;
+    font-size: 11px;
+  }
+  
+  .node-tooltip-link:hover {
+    color: #299ED9;
+    text-decoration: underline;
   }
   
   .charts {

--- a/src/components/Sankey/SankeyChart.tsx
+++ b/src/components/Sankey/SankeyChart.tsx
@@ -6,7 +6,7 @@ import './SankeyChart.css'
 import { SankeyData } from './SankeyChartD3'
 import { SankeyChartSingle } from './SankeyChartSingle'
 import { formatNumber, sortNodesByAmount, transformToIdBased } from './utils'
-import { departmentNames } from '@/lib/sankeyDepartmentMappings'
+import { departmentNames, nodeToDepartment } from '@/lib/sankeyDepartmentMappings'
 
 type FlatDataNodes = ReturnType<typeof getFlatData>['nodes']
 type Node = FlatDataNodes[number] & {
@@ -169,10 +169,24 @@ export function SankeyChart(props: SankeyChartProps) {
 					instanceId="sankey-search"
 					inputId="sankey-search-input"
 					value={searchedNode}
-					options={flatData?.map(d => ({
-						value: d.id!,
-						label: d.displayName || d.name || 'Unknown'
-					})).filter(d => d.value && d.label)}
+					options={flatData?.flatMap(d => {
+						const base = {
+							value: d.id!,
+							label: d.displayName || d.name || 'Unknown'
+						};
+						
+						const deptSlug = nodeToDepartment[d.displayName];
+						if (deptSlug && departmentNames[deptSlug]) {
+							return [
+								base,
+								{
+									value: d.id!,
+									label: departmentNames[deptSlug]
+								}
+							];
+						}
+						return [base];
+					}).filter(d => d.value && d.label)}
 					onChange={handleSearch}
 					isClearable={true}
 					placeholder='Search...'

--- a/src/components/Sankey/SankeyChart.tsx
+++ b/src/components/Sankey/SankeyChart.tsx
@@ -92,7 +92,6 @@ export function SankeyChart(props: SankeyChartProps) {
 	// Mouse position as fallback - ensures tooltip still works if blockRect is missing
 	const [mousePosition, setMousePosition] = useState<{ x: number; y: number } | null>(null)
 	const [totalAmount, setTotalAmount] = useState(0)
-	const [isTooltipHovered, setIsTooltipHovered] = useState(false)
 	const hideTooltipTimeoutRef = useRef<NodeJS.Timeout | null>(null)
 
 	useEffect(() => {
@@ -157,12 +156,10 @@ export function SankeyChart(props: SankeyChartProps) {
 
 	const handleMouseOut = useCallback(() => {
 		hideTooltipTimeoutRef.current = setTimeout(() => {
-			if (!isTooltipHovered) {
-				setHoverNode(null)
-				setMousePosition(null)
-			}
+			setHoverNode(null)
+			setMousePosition(null)
 		}, 100)
-	}, [isTooltipHovered])
+	}, [])
 
 	return (
 		<div className='sankey-chart-wrapper'>
@@ -209,13 +206,8 @@ export function SankeyChart(props: SankeyChartProps) {
 							clearTimeout(hideTooltipTimeoutRef.current)
 							hideTooltipTimeoutRef.current = null
 						}
-						setIsTooltipHovered(true)
 					}}
-					onMouseLeave={() => {
-						setIsTooltipHovered(false)
-						setHoverNode(null)
-						setMousePosition(null)
-					}}
+					onMouseLeave={handleMouseOut}
 					style={{
 						// Horizontal: right of the block, constrained to viewport
 						left: hoverNode.blockRect 

--- a/src/components/Sankey/SankeyChartD3.tsx
+++ b/src/components/Sankey/SankeyChartD3.tsx
@@ -6,6 +6,7 @@ import { curveBumpX, area } from 'd3-shape'
 import { cumsum, pairs, rollups, sum } from 'd3-array'
 import { hierarchy } from 'd3-hierarchy'
 import { formatNumber } from './utils'
+import { nodeToDepartment } from '@/lib/sankeyDepartmentMappings'
 
 export type SankeyNode = {
 	id: string           // Unique identifier for internal operations
@@ -231,9 +232,10 @@ export class SankeyChartD3 {
 			.on('mouseover', (e, d) => {
 				const target = e.currentTarget as HTMLElement
 				const rect = target.getBoundingClientRect()
+				const departmentSlug = nodeToDepartment[d.displayName]
 				
 				this.highlightNode(d)
-				this.params.onMouseOver({ ...d, blockRect: rect }, e)
+				this.params.onMouseOver({ ...d, departmentSlug, blockRect: rect }, e)
 			})
 			.on('mouseout', (e, d) => {
 				this.highlightNode(null)

--- a/src/lib/sankeyDepartmentMappings.ts
+++ b/src/lib/sankeyDepartmentMappings.ts
@@ -12,9 +12,10 @@ export const nodeToDepartment: Record<string, string> = {
   "Public Works + Government Services": "public-services-and-procurement-canada",
   "Innovation + Research": "innovation-science-and-industry",
   "Net Interest on Debt": "department-of-finance",
-  "Transfers to Provinces": "department-of-finance",
+  "Health Transfers to Provinces": "department-of-finance",
   "Employment + Training": "employment-and-social-development-canada",
   "Social Security": "employment-and-social-development-canada",
+  "Indigenous Priorities": "indigenous-services-and-northern-affairs",
   "Indigenous Well-Being + Self Determination": "indigenous-services-and-northern-affairs",
   "Crown-Indigenous Relations": "indigenous-services-and-northern-affairs",
   

--- a/src/lib/sankeyDepartmentMappings.ts
+++ b/src/lib/sankeyDepartmentMappings.ts
@@ -1,0 +1,60 @@
+// Direct mapping: sankey node name → department slug
+export const nodeToDepartment: Record<string, string> = {
+  // Direct department mappings
+  "Revenue Canada": "canada-revenue-agency",
+  "Defence": "national-defence",
+  "International Affairs": "global-affairs-canada",
+  "Immigration + Border Security": "immigration-refugees-and-citizenship",
+  "Support for Veterans": "veterans-affairs",
+  "Transportation": "transport-canada",
+  "Infrastructure Investments": "housing-infrastructure-communities",
+  "Health": "health-canada",
+  "Public Works + Government Services": "public-services-and-procurement-canada",
+  "Innovation + Research": "innovation-science-and-industry",
+  "Net Interest on Debt": "department-of-finance",
+  "Transfers to Provinces": "department-of-finance",
+  "Employment + Training": "employment-and-social-development-canada",
+  "Social Security": "employment-and-social-development-canada",
+  "Indigenous Well-Being + Self Determination": "indigenous-services-and-northern-affairs",
+  "Crown-Indigenous Relations": "indigenous-services-and-northern-affairs",
+  
+  // Public Safety Canada nodes
+  "CSIS": "public-safety-canada",
+  "Corrections": "public-safety-canada",
+  "RCMP": "public-safety-canada",
+  "Disaster Relief": "public-safety-canada",
+  "Community Safety": "public-safety-canada",
+  "Other Public Safety Expenses": "public-safety-canada",
+  
+  // Child nodes that should also map to their parent departments
+  "Border Security": "immigration-refugees-and-citizenship",
+  "Other Immigration Services": "immigration-refugees-and-citizenship",
+  "Settlement Assistance": "immigration-refugees-and-citizenship",
+  "Health Care Systems + Protection": "health-canada",
+  "Food Safety": "health-canada",
+  "Public Health + Disease Prevention": "health-canada",
+  "Government IT Operations": "public-services-and-procurement-canada",
+  "Ready Forces": "national-defence",
+  "Defence Procurement": "national-defence",
+  "Retirement Benefits": "employment-and-social-development-canada",
+  "Employment Insurance": "employment-and-social-development-canada",
+  "Children's Benefits": "employment-and-social-development-canada",
+};
+
+// Department slug → official name
+export const departmentNames: Record<string, string> = {
+  "canada-revenue-agency": "Canada Revenue Agency",
+  "national-defence": "National Defence",
+  "global-affairs-canada": "Global Affairs Canada",
+  "immigration-refugees-and-citizenship": "Immigration, Refugees and Citizenship",
+  "veterans-affairs": "Veterans Affairs",
+  "transport-canada": "Transport Canada",
+  "housing-infrastructure-communities": "Housing, Infrastructure and Communities Canada",
+  "health-canada": "Health Canada",
+  "public-services-and-procurement-canada": "Public Services and Procurement Canada",
+  "innovation-science-and-industry": "Innovation, Science and Industry",
+  "public-safety-canada": "Public Safety Canada",
+  "indigenous-services-and-northern-affairs": "Indigenous Services Canada + Crown-Indigenous Relations and Northern Affairs Canada",
+  "employment-and-social-development-canada": "Employment and Social Development Canada",
+  "department-of-finance": "Finance Canada"
+};


### PR DESCRIPTION
Created a semantic map of sankey nodes to department slug to link them back. 

<img width="482" height="181" alt="Screenshot 2025-07-19 at 7 40 03 PM" src="https://github.com/user-attachments/assets/35cf76b5-decf-4d46-b600-25aa32cc3c32" />

Some of them clearly represent the actual department because the spending is exact (like Defense, Transport Canada, Global Affairs). Some are spuriously mapped based on numbers (like Revenue Canada to the CRA) but I've left them in in the hopes it inspires a better accounting.

Also made the tooltip hoverable so you can actually click the link (helpful if you want to copy the percentage too).

Now that the department name is in the sankey we can also search for it

<img width="1256" height="666" alt="Screenshot 2025-07-19 at 8 40 00 PM" src="https://github.com/user-attachments/assets/c94493fc-f952-4270-b2d1-80741579c4dc" />

A follow up issue to this would be to have the tooltip show up when hovering over the relevant node after you've searched for the department. More generally the numbers for the main and mini sankeys should be reconciled so that they can be linked more accurately. 
