### PR TITLE
Add redirect to tax-visualizer

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -26,6 +26,15 @@ const nextConfig: NextConfig = {
 
     return config;
   },
+  async redirects() {
+    return [
+      {
+        source: "/:locale/tax-calculator",
+        destination: "/:locale/tax-visualizer",
+        permanent: true,
+      },
+    ];
+  },
   async rewrites() {
     return [
       {


### PR DESCRIPTION
This redirects `/tax-calculator` to '/tax-visualizer' since the former may still be active on other webpages.