### PR TITLE
Added percentage growth text below  high visibility numbers.

### DIFF
--- a/src/app/[lang]/(main)/spending/page.tsx
+++ b/src/app/[lang]/(main)/spending/page.tsx
@@ -23,15 +23,24 @@ const StatBox = ({
   title,
   value,
   description,
+  growthPercentage,
 }: {
   title: React.ReactNode;
   value: string;
   description: React.ReactNode;
+  growthPercentage?: number;
 }) => (
   <div className="flex flex-col mr-8 mb-8">
     <div className="text-sm text-gray-600 mb-1">{title}</div>
     <div className="text-3xl font-bold mb-1">{value}</div>
     <div className="text-sm text-gray-600">{description}</div>
+    {growthPercentage && (
+      <div
+        className={`text-xs font-medium ${growthPercentage > 0 ? "text-green-600" : "text-red-600"}`}
+      >
+        {growthPercentage}% over the last 5 years
+      </div>
+    )}
   </div>
 );
 
@@ -48,6 +57,47 @@ const ageData = [
   { name: "60-64", Count: 84865 },
   { name: "65+", Count: 39494 },
 ];
+
+const calculateGrowthPercentage = (dataType: string) => {
+  const headcountData = [
+    { Year: "2019", Value: 382107 },
+    { Year: "2020", Value: 390798 },
+    { Year: "2021", Value: 413424 },
+    { Year: "2022", Value: 431739 },
+    { Year: "2023", Value: 440985 },
+  ];
+
+  const wagesData = [
+    { Year: "2019", Value: 46.3 },
+    { Year: "2020", Value: 53.0 },
+    { Year: "2021", Value: 60.7 },
+    { Year: "2022", Value: 56.5 },
+    { Year: "2023", Value: 65.3 },
+  ];
+
+  const compensationData = [
+    { Year: "2019", Value: 117522 },
+    { Year: "2020", Value: 123163 },
+    { Year: "2021", Value: 125256 },
+    { Year: "2022", Value: 126634 },
+    { Year: "2023", Value: 136345 },
+  ];
+
+  if (dataType === "headcount") {
+    const oldValue = headcountData[0].Value;
+    const newValue = headcountData[headcountData.length - 1].Value;
+    return Number((((newValue - oldValue) / oldValue) * 100).toFixed(1));
+  } else if (dataType === "wages") {
+    const oldValue = wagesData[0].Value;
+    const newValue = wagesData[wagesData.length - 1].Value;
+    return Number((((newValue - oldValue) / oldValue) * 100).toFixed(1));
+  } else if (dataType === "compensation") {
+    const oldValue = compensationData[0].Value;
+    const newValue = compensationData[compensationData.length - 1].Value;
+    return Number((((newValue - oldValue) / oldValue) * 100).toFixed(1));
+  }
+  return 0;
+};
 
 export default function Spending() {
   const { t } = useLingui();
@@ -91,7 +141,7 @@ export default function Spending() {
         </div>
         <div className="absolute top-0 left-0 w-[100vw] h-full  backdrop-blur-sm z-10 text-white md:hidden flex items-center justify-center">
           <ExternalLink
-            className="rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+            className="rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
             href="/spending-full-screen"
           >
             <Trans>View this chart in full screen</Trans>
@@ -108,18 +158,21 @@ export default function Spending() {
               title={t`Headcount`}
               value="441,000"
               description={t`Total full-time equivalents`}
+              growthPercentage={calculateGrowthPercentage("headcount")}
             />
 
             <StatBox
-              title={t`Departments + Agencies`}
-              value="94"
-              description={t`Federal organizations`}
+              title={t`Compensation per Employee`}
+              value="$136,345"
+              description={t`Average annual salary`}
+              growthPercentage={calculateGrowthPercentage("compensation")}
             />
 
             <StatBox
               title={t`Total Wages`}
               value="$65.3B"
               description={t`Annual payroll`}
+              growthPercentage={calculateGrowthPercentage("wages")}
             />
 
             <div>
@@ -161,14 +214,12 @@ export default function Spending() {
                 </NoSSR>
               </div>
             </div>
-            <div>
-              <h3 className="font-medium mb-2">
-                <Trans>Compensation per Employee</Trans>
-              </h3>
-              <p className="text-sm text-gray-600">
-                <Trans>The average employee makes $136,345/yr</Trans>
-              </p>
-            </div>
+
+            <StatBox
+              title={t`Departments + Agencies`}
+              value="94"
+              description={t`Federal organizations`}
+            />
             <P className="text-sm">
               <Trans>Sources:</Trans>{" "}
               <ExternalLink href="https://www.pbo-dpb.ca/en/additional-analyses--analyses-complementaires/BLOG-2425-009--personnel-expenditure-analysis-tool-update-2023-24-personnel-expenditures--mise-jour-outil-analyse-depenses-personnel-depenses-personnel-2023-2024">

--- a/src/app/[lang]/(main)/spending/page.tsx
+++ b/src/app/[lang]/(main)/spending/page.tsx
@@ -38,6 +38,7 @@ const StatBox = ({
       <div
         className={`text-xs font-medium ${growthPercentage > 0 ? "text-green-600" : "text-red-600"}`}
       >
+        {growthPercentage > 0 ? "+" : ""}
         {growthPercentage}% over the last 5 years
       </div>
     )}


### PR DESCRIPTION
Solution for #112 

Opted for the minimal text below the numbers, as I was worried that including the charts instead would make it too messy. Let me know if you want the charts instead though