### PR TITLE
2025-Sep-5-2025-Spending-Update

### DIFF
--- a/src/components/Sankey/BudgetSankey.tsx
+++ b/src/components/Sankey/BudgetSankey.tsx
@@ -483,6 +483,26 @@ export function BudgetSankey({ onDataChange }: BudgetSankeyProps = {}) {
           ],
         },
         {
+          name: t`New Spending`,
+          children: [
+            {
+              name: t`Strategic Response Fund`,
+              amount2024: 0,
+              amount2025: 5,
+            },
+            {
+              name: t`Regional Tariff Response Initiative`,
+              amount2024: 0,
+              amount2025: 1,
+            },
+            {
+              name: t`Biofuel Production Incentive`,
+              amount2024: 0,
+              amount2025: 0.37,
+            },
+          ],
+        },
+        {
           name: t`Safety`,
           children: [
             {

--- a/src/lib/budgetNewsData.ts
+++ b/src/lib/budgetNewsData.ts
@@ -14,6 +14,18 @@ export interface NewsItem {
 // Budget News Data - Easily Configurable and Maintainable
 export const budgetNewsData: NewsItem[] = [
   {
+    id: "cbc-tariff-spending",
+    source: "CBC",
+    date: "Sep 5, 2025",
+    url: "https://www.cbc.ca/news/politics/carney-unveils-new-industrial-strategy-1.7626064",
+    headline:
+      "Carney unveils billions in funding, Buy Canadian policy to combat Trump's tariffs",
+    budgetImpact: "Economy + Innovation & Research",
+    amount: "$6.37B",
+    percentage: 100,
+    isIncrease: true,
+  },
+  {
     id: "cbc-defence",
     source: "CBC",
     date: "Aug 3, 2025",


### PR DESCRIPTION
Previous Spending
<img width="1080" height="417" alt="Screenshot 2025-09-05 at 5 16 01 PM" src="https://github.com/user-attachments/assets/96aa90d7-40f7-413c-9f91-0488afe51b17" />

Spending After Today's Announcement
<img width="1279" height="610" alt="Screenshot 2025-09-05 at 5 23 04 PM" src="https://github.com/user-attachments/assets/eff9e898-195f-4ac1-af02-67097fdd2772" />

Article: https://www.cbc.ca/news/politics/carney-unveils-new-industrial-strategy-1.7626064