### PR TITLE
fix Sankey deficit/surplus calculation

### DIFF
--- a/src/components/Sankey/SankeyChart.tsx
+++ b/src/components/Sankey/SankeyChart.tsx
@@ -35,11 +35,11 @@ interface SearchOptionType {
 
 const getFlatData = (data: SankeyData) => {
   const revenueRoot = hierarchy(data.revenue_data).sum((d) => {
-    return Math.abs(d.amount);
+    return d.amount;
   });
 
   const spendingRoot = hierarchy(data.spending_data).sum((d) => {
-    return Math.abs(d.amount);
+    return d.amount;
   });
 
   return {
@@ -122,6 +122,7 @@ export function SankeyChart(props: SankeyChartProps) {
     const { nodes, revenueTotal, spendingTotal } = getFlatData(transformedData);
 
     setFlatData(nodes);
+
     setTotalAmount(Math.max(revenueTotal, spendingTotal));
   }, [props.data]);
 
@@ -281,7 +282,11 @@ export function SankeyChart(props: SankeyChartProps) {
               {...chartConfig.revenue}
               data={sortNodesByAmount(chartData.revenue_data)}
               totalAmount={totalAmount}
-              difference={chartData.total - chartData.revenue}
+              difference={
+                chartData.spending > chartData.revenue
+                  ? chartData.spending - chartData.revenue // deficit
+                  : 0
+              }
               height={chartHeight}
               amountScalingFactor={amountScalingFactor}
               onMouseOver={handleMouseOver(chartData.revenue)}
@@ -291,7 +296,11 @@ export function SankeyChart(props: SankeyChartProps) {
               {...chartConfig.spending}
               data={sortNodesByAmount(chartData.spending_data)}
               totalAmount={totalAmount}
-              difference={chartData.total - chartData.spending}
+              difference={
+                chartData.revenue > chartData.spending
+                  ? chartData.revenue - chartData.spending // surplus
+                  : 0
+              }
               height={chartHeight}
               amountScalingFactor={amountScalingFactor}
               onMouseOver={handleMouseOver(chartData.spending)}

--- a/src/components/Sankey/SankeyChart.tsx
+++ b/src/components/Sankey/SankeyChart.tsx
@@ -122,7 +122,6 @@ export function SankeyChart(props: SankeyChartProps) {
     const { nodes, revenueTotal, spendingTotal } = getFlatData(transformedData);
 
     setFlatData(nodes);
-
     setTotalAmount(Math.max(revenueTotal, spendingTotal));
   }, [props.data]);
 

--- a/src/components/Sankey/SankeyChartD3.tsx
+++ b/src/components/Sankey/SankeyChartD3.tsx
@@ -600,7 +600,7 @@ export class SankeyChartD3 {
 
     // Compute the sum of the data treating negatives as positives
     const root = hierarchy(clonedData).sum((d) => {
-      return Math.abs(d.amount);
+      return d.amount;
     });
 
     const links = root.links();
@@ -678,14 +678,12 @@ export class SankeyChartD3 {
       };
     });
 
-    const difference = this.params.totalAmount - root.value;
-
     if (this.params.difference > 0) {
       columns[0].groups[0].blocks.push({
         index: columns[0].groups[0].blocks.length,
         amount: this.params.difference,
         realValue: this.params.difference,
-        value: difference,
+        value: this.params.difference,
         id: "difference_block",
         displayName: this.params.differenceLabel,
         name: this.params.differenceLabel,


### PR DESCRIPTION
- We were incorrectly doing an abs on the node values which led to a miscalculation of the total revenue/spending amount
- The deficit/surplus box was also not scaled proportionally to the % it represents which is also fixed

How it looks now:

- Federal
<img width="112" height="522" alt="Screenshot 2025-09-20 at 2 00 02 PM" src="https://github.com/user-attachments/assets/dd093ad6-bb5e-4976-ba16-a7d0b628f7a2" />

- Ontario
<img width="122" height="531" alt="Screenshot 2025-09-20 at 2 00 09 PM" src="https://github.com/user-attachments/assets/ba3846ba-fc59-4409-aa64-34c26f1c5301" />

- Alberta, from data in https://github.com/BuildCanada/CanadaSpends/pull/161 (surplus)
<img width="146" height="538" alt="Screenshot 2025-09-20 at 1 59 44 PM" src="https://github.com/user-attachments/assets/1be052f8-5a7b-4c32-9c57-34b00e2d1a2a" />
