### PR TITLE
[#186] Add ReferenceLine to BarChart component and median federal employee salary

### DIFF
--- a/src/lib/chartUtils.ts
+++ b/src/lib/chartUtils.ts
@@ -93,6 +93,23 @@ export const getColorClassName = (
   return chartColors[color]?.[type] ?? fallbackColor[type];
 };
 
+// Get hex color value for SVG elements (Recharts doesn't support Tailwind classes)
+// Source (Shift + Click for nearest hex value): https://tailwindcss.com/docs/colors
+export const getColorHexValue = (color: AvailableChartColorsKeys): string => {
+  const colorMap: Record<AvailableChartColorsKeys, string> = {
+    blue: "#3b82f6",
+    emerald: "#10b981",
+    violet: "#8b5cf6",
+    amber: "#f59e0b",
+    gray: "#6b7280",
+    cyan: "#06b6d4",
+    pink: "#ec4899",
+    lime: "#84cc16",
+    fuchsia: "#c026d3",
+  };
+  return colorMap[color];
+};
+
 // Tremor Raw getYAxisDomain [v0.0.0]
 
 export const getYAxisDomain = (


### PR DESCRIPTION
Addresses #186 

Features:
- Adds [Rechart reference line](https://recharts.github.io/en-US/api/ReferenceLine) to BarChart component
- Adds reference line to LegendItem
- Calculates the median salary bucket for federal employee salary distribution

Screenshot:
<img width="1084" height="607" alt="image" src="https://github.com/user-attachments/assets/9e5a3949-e41f-48ca-a201-bb7b976c4526" />
