### PR TITLE
Fixes #179: Make Sankey "Learn more" links opt-in (federal only)

### DIFF
--- a/src/app/[lang]/(main)/[jurisdiction]/page.tsx
+++ b/src/app/[lang]/(main)/[jurisdiction]/page.tsx
@@ -315,7 +315,10 @@ export default async function ProvinceIndex({
           </P>
         </Section>
         <div className="sankey-chart-container relative overflow-hidden sm:(mr-0 ml-0) md:(min-h-[776px] min-w-[1280px] w-screen -ml-[50vw] -mr-[50vw] left-1/2 right-1/2)">
-          <JurisdictionSankey data={sankey} />
+          <JurisdictionSankey
+            data={sankey}
+            jurisdictionSlug={jurisdiction.slug}
+          />
           <div className="absolute bottom-3 left-6">
             <ExternalLink
               className="text-xs text-gray-400"

--- a/src/app/[lang]/(mobile)/[jurisdiction]/spending-full-screen/page.tsx
+++ b/src/app/[lang]/(mobile)/[jurisdiction]/spending-full-screen/page.tsx
@@ -19,7 +19,10 @@ export default async function FullPageSpending({
   return (
     <div className="min-h-screen bg-white">
       <div className="sankey-chart-container relative overflow-hidden min-h-screen min-w-[1280px]">
-        <JurisdictionSankey data={sankey} />
+        <JurisdictionSankey
+          data={sankey}
+          jurisdictionSlug={jurisdiction.slug}
+        />
         <div className="absolute bottom-3 left-6">
           <ExternalLink
             className="text-xs text-gray-400"

--- a/src/components/Sankey/DepartmentMiniSankey.tsx
+++ b/src/components/Sankey/DepartmentMiniSankey.tsx
@@ -9,11 +9,21 @@ function formatDepartmentAsSankey(department: Department): SankeyData {
     spending: department.totalSpending,
     revenue: 0,
     spending_data: {
+      id: `${department.slug}-spending-root`,
+      displayName: department.name,
       name: department.name,
       amount: department.totalSpending,
-      children: [...department.spending_data.children],
+      children: department.spending_data.children.map((c, i) => ({
+        id: `${department.slug}-spending-${i}`,
+        displayName: c.name,
+        name: c.name,
+        amount: c.amount,
+        children: [],
+      })),
     },
     revenue_data: {
+      id: `${department.slug}-revenue-root`,
+      displayName: `Revenue`,
       name: `Revenue`,
       amount: 0,
       children: [],

--- a/src/components/Sankey/JurisdictionSankey.tsx
+++ b/src/components/Sankey/JurisdictionSankey.tsx
@@ -2,6 +2,12 @@
 import { SankeyChart } from "./SankeyChart";
 import { SankeyData } from "./SankeyChartD3";
 
-export function JurisdictionSankey({ data }: { data: SankeyData }) {
-  return <SankeyChart data={data} />;
+export function JurisdictionSankey({
+  data,
+  jurisdictionSlug,
+}: {
+  data: SankeyData;
+  jurisdictionSlug?: string;
+}) {
+  return <SankeyChart data={data} jurisdictionSlug={jurisdictionSlug} />;
 }

--- a/src/components/Sankey/SankeyChart.tsx
+++ b/src/components/Sankey/SankeyChart.tsx
@@ -89,8 +89,15 @@ const chartConfig = {
   },
 } as const;
 
-type SankeyChartProps = {
+// showDepartmentLinks: explicit opt-in so only contexts that want department
+// pages (currently the federal chart) render the "Learn more" links. Default
+// is false to avoid showing federal department links on provincial/municipal
+// charts where node labels map to local ministries/programs (which could be
+// incorrect or lead to broken navigation). Callers should pass
+// `showDepartmentLinks={true}` to enable links for that context.
+export type SankeyChartProps = {
   data: SankeyData;
+  showDepartmentLinks?: boolean;
 };
 
 export function SankeyChart(props: SankeyChartProps) {
@@ -277,7 +284,7 @@ export function SankeyChart(props: SankeyChartProps) {
                 )}
               </div>
             </div>
-            {hoverNode.departmentSlug && (
+            {hoverNode.departmentSlug && props.showDepartmentLinks && (
               <div className="node-tooltip-department">
                 <a
                   href={`/${i18n.locale}/spending/${hoverNode.departmentSlug}`}

--- a/src/components/Sankey/SankeyChartSingle.tsx
+++ b/src/components/Sankey/SankeyChartSingle.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useRef } from "react";
 import { SankeyChartD3, SankeyChartD3Props } from "./SankeyChartD3";
 
-export type SankeyChartProps = {
+export type SankeyChartSingleProps = {
   id: string;
 } & SankeyChartD3Props;
 
-export function SankeyChartSingle(props: SankeyChartProps) {
+export function SankeyChartSingle(props: SankeyChartSingleProps) {
   const {
     id,
     data,

--- a/src/components/Sankey/index.tsx
+++ b/src/components/Sankey/index.tsx
@@ -799,5 +799,5 @@ export function Sankey() {
     );
   }, []);
 
-  return <SankeyChart data={data as SankeyData} />;
+  return <SankeyChart data={data as SankeyData} showDepartmentLinks={true} />;
 }


### PR DESCRIPTION
Make department links in the Sankey tooltip explicit by adding a `showDepartmentLinks` boolean prop to `SankeyChart`. The federal (site-level) Sankey enables this prop so "Learn more" appears only on the federal chart. Provincial and municipal charts default to off to avoid linking to incorrect or non-existent department pages.

_Note: This is my first ever PR and contribution to a open-source project please suggest any improvements :)_