### PR TITLE
Flag Toggle for Budget 2025

### DIFF
--- a/src/app/[lang]/(main)/budget/page.tsx
+++ b/src/app/[lang]/(main)/budget/page.tsx
@@ -17,6 +17,8 @@ import { BudgetSankey } from "@/components/Sankey/BudgetSankey";
 import { Trans } from "@lingui/react/macro";
 import { useState, useCallback } from "react";
 import { NewsItem, budgetNewsData } from "@/lib/budgetNewsData";
+import { IS_BUDGET_2025_LIVE } from "@/lib/featureFlags";
+import Link from "next/link";
 
 const StatBox = ({
   title,
@@ -146,26 +148,54 @@ export default function Budget() {
 
   return (
     <Page>
+      {/* Official Budget Banner - Only Show When Budget is Live */}
+      {IS_BUDGET_2025_LIVE && (
+        <div className="bg-indigo-950 text-white py-12 px-4 text-center">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-3xl md:text-5xl font-bold mb-4">
+              <Trans>Official Fall 2025 Federal Budget Released</Trans>
+            </h2>
+            <Link
+              href="/budget"
+              className="inline-block bg-white text-indigo-950 hover:bg-gray-100 font-medium py-3 px-6 transition-colors"
+            >
+              <Trans>View Federal 2025 Budget Details</Trans>
+            </Link>
+          </div>
+        </div>
+      )}
+
       <PageContent>
         <Section>
           <H1>
             <Trans>Federal Fall 2025 Government Budget</Trans>
           </H1>
           <Intro>
-            <Trans>
-              The values you see here are based on the FY 2024 Budget with
-              preliminary updates based on government announcements, memos, and
-              leaks, and are meant to provide a rough idea of the budget. Once
-              the official Fall 2025 Budget is released on November 4th, we will
-              update this page to reflect the official budget.
-            </Trans>
+            {IS_BUDGET_2025_LIVE ? (
+              <Trans>
+                This page presents the official Fall 2025 Federal Budget as
+                released by the Government of Canada on November 4th, 2025. All
+                data is sourced directly from official government publications
+                and public accounts from the Government of Canada.
+              </Trans>
+            ) : (
+              <Trans>
+                The values you see here are based on the FY 2024 Budget with
+                preliminary updates based on government announcements, memos,
+                and leaks, and are meant to provide a rough idea of the budget.
+                Once the official Fall 2025 Budget is released on November 4th,
+                we will update this page to reflect the official budget.
+              </Trans>
+            )}
           </Intro>
         </Section>
         <Section>
           <H2>
             <Trans>Budget Statistics (Projected FY 2025)</Trans>
           </H2>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-8 mb-8">
+          <div
+            className={`grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 ${!IS_BUDGET_2025_LIVE ? "xl:grid-cols-5" : ""} gap-8 mb-8`}
+          >
             <StatBox
               title={<Trans>Total Budget</Trans>}
               value={`$${budgetData.spending.toFixed(1)}B`}
@@ -184,24 +214,28 @@ export default function Budget() {
                 459.5,
               )}
             />
-            <StatBox
-              title={<Trans>Operational Spend</Trans>}
-              value={`$${budgetData.opex2025.toFixed(1)}B`}
-              description={<Trans>Projected operational spending</Trans>}
-              growthPercentage={calculateGrowthPercentage(
-                budgetData.opex2025,
-                budgetData.opex2024,
-              )}
-            />
-            <StatBox
-              title={<Trans>Capital Investments</Trans>}
-              value={`$${budgetData.capex2025.toFixed(1)}B`}
-              description={<Trans>Projected capital investments</Trans>}
-              growthPercentage={calculateGrowthPercentage(
-                budgetData.capex2025,
-                budgetData.capex2024,
-              )}
-            />
+            {!IS_BUDGET_2025_LIVE && (
+              <>
+                <StatBox
+                  title={<Trans>Operational Spend</Trans>}
+                  value={`$${budgetData.opex2025.toFixed(1)}B`}
+                  description={<Trans>Projected operational spending</Trans>}
+                  growthPercentage={calculateGrowthPercentage(
+                    budgetData.opex2025,
+                    budgetData.opex2024,
+                  )}
+                />
+                <StatBox
+                  title={<Trans>Capital Investments</Trans>}
+                  value={`$${budgetData.capex2025.toFixed(1)}B`}
+                  description={<Trans>Projected capital investments</Trans>}
+                  growthPercentage={calculateGrowthPercentage(
+                    budgetData.capex2025,
+                    budgetData.capex2024,
+                  )}
+                />
+              </>
+            )}
             <StatBox
               title={<Trans>Deficit</Trans>}
               value={`$${budgetData.deficit.toFixed(1)}B`}

--- a/src/app/[lang]/(main)/page.tsx
+++ b/src/app/[lang]/(main)/page.tsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 import { FiCornerLeftDown, FiCornerRightDown } from "react-icons/fi";
 import { LuReceipt, LuUsersRound } from "react-icons/lu";
 import { PiBank } from "react-icons/pi";
+import { IS_BUDGET_2025_LIVE } from "@/lib/featureFlags";
 
 export default async function Page(props: PageLangParam) {
   const lang = (await props.params).lang;
@@ -47,11 +48,15 @@ export default async function Page(props: PageLangParam) {
                 <div className="flex gap-4">
                   <Link
                     className="text-white bg-indigo-950 hover:bg-indigo-900 items-center font-medium justify-center py-2 px-4 relative flex w-auto min-w-[7.00rem] max-w-full overflow-hidden"
-                    href="/spending"
+                    href={IS_BUDGET_2025_LIVE ? "/budget" : "/spending"}
                   >
                     <div className="items-center cursor-pointer justify-center relative flex overflow-hidden">
                       <div className="items-center justify-center flex p-1">
-                        <Trans>Explore federal data</Trans>
+                        {IS_BUDGET_2025_LIVE ? (
+                          <Trans>Explore Budget 2025</Trans>
+                        ) : (
+                          <Trans>Explore federal data</Trans>
+                        )}
                       </div>
                     </div>
                   </Link>

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -1,0 +1,17 @@
+/**
+ * Feature Flags Configuration
+ *
+ * Simple Toggles for Enabling/Disabling Features Across the Application.
+ * Change these Values to Enable or Disable Features.
+ */
+
+/**
+ * IS_BUDGET_2025_LIVE
+ *
+ * Controls the Budget 2025 Launch Experience:
+ * - When FALSE (default): Shows Preliminary Budget with Spending Reduction Sliders
+ * - When TRUE: Shows Official Budget Data, Hides Sliders, Updates Messaging
+ *
+ * Set to TRUE on November 4th, 2025 when the Official Budget is Released.
+ */
+export const IS_BUDGET_2025_LIVE = false;


### PR DESCRIPTION
Adding a Toggle Flag for when Budget 2025 is released to change the UX on the Budget page.

<img width="1440" height="784" alt="Screenshot 2025-10-27 at 7 01 21 PM" src="https://github.com/user-attachments/assets/0d5ac22d-08c7-430e-95f1-f1365b8c6393" />
<img width="1440" height="782" alt="Screenshot 2025-10-27 at 7 01 37 PM" src="https://github.com/user-attachments/assets/1810c366-c61a-4bfb-84d1-94e5f2c8153a" />
