### PR TITLE
Remove mention of 'operational' for Toronto. Remove mention of 'budget'

### DIFF
--- a/src/app/[lang]/(main)/[jurisdiction]/page.tsx
+++ b/src/app/[lang]/(main)/[jurisdiction]/page.tsx
@@ -304,6 +304,14 @@ export default async function ProvinceIndex({
               {jurisdiction.financialYear}
             </Trans>
           </H2>
+          <P>
+            <Trans>
+              Look back at what {jurisdiction.name}'s government made and spent.{" "}
+              {["Toronto", "Vancouver"].includes(jurisdiction.name) && (
+                <Trans>Numbers are reported on an accrual basis.</Trans>
+              )}
+            </Trans>
+          </P>
         </Section>
         <div className="sankey-chart-container relative overflow-hidden sm:(mr-0 ml-0) md:(min-h-[776px] min-w-[1280px] w-screen -ml-[50vw] -mr-[50vw] left-1/2 right-1/2)">
           <JurisdictionSankey data={sankey} />


### PR DESCRIPTION
Impacts all Municipal and Provincial pages.

Proposed:
<img width="959" height="1178" alt="image" src="https://github.com/user-attachments/assets/3d0c9078-e088-4757-acd6-f9f90e2ddb24" />

Current:
<img width="896" height="1224" alt="image" src="https://github.com/user-attachments/assets/1fb200f0-8585-488c-8a62-eaca2a89d3f5" />
