### PR TITLE
Ensure url paths are localized

### DIFF
--- a/src/app/[lang]/(main)/[jurisdiction]/page.tsx
+++ b/src/app/[lang]/(main)/[jurisdiction]/page.tsx
@@ -18,6 +18,7 @@ import {
   getJurisdictionData,
   getJurisdictionSlugs,
 } from "@/lib/jurisdictions";
+import { localizedPath } from "@/lib/utils";
 import { Trans } from "@lingui/react/macro";
 
 const HelpIcon = () => (
@@ -329,7 +330,10 @@ export default async function ProvinceIndex({
           <div className="absolute top-0 left-0 w-[100vw] h-full  backdrop-blur-sm z-10 text-white md:hidden flex items-center justify-center">
             <ExternalLink
               className="rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
-              href={`/${jurisdiction.slug}/spending-full-screen`}
+              href={localizedPath(
+                `/${jurisdiction.slug}/spending-full-screen`,
+                lang,
+              )}
             >
               <Trans>View this chart in full screen</Trans>
             </ExternalLink>
@@ -430,8 +434,10 @@ export default async function ProvinceIndex({
               occur despite our best efforts. We aim to make this information
               more accessible and accurate, and we welcome feedback. If you
               notice any issues, please let us know{" "}
-              <InternalLink href="/contact">here</InternalLink> — we appreciate
-              it and will work to address them promptly.
+              <InternalLink href="/contact" lang={lang}>
+                here
+              </InternalLink>{" "}
+              — we appreciate it and will work to address them promptly.
             </Trans>
           </P>
         </Section>

--- a/src/app/[lang]/(main)/budget/page.tsx
+++ b/src/app/[lang]/(main)/budget/page.tsx
@@ -14,11 +14,12 @@ import {
 } from "@/components/Layout";
 import NoSSR from "@/components/NoSSR";
 import { BudgetSankey } from "@/components/Sankey/BudgetSankey";
-import { Trans } from "@lingui/react/macro";
+import { Trans, useLingui } from "@lingui/react/macro";
 import { useState, useCallback } from "react";
 import { NewsItem, budgetNewsData } from "@/lib/budgetNewsData";
 import { IS_BUDGET_2025_LIVE } from "@/lib/featureFlags";
 import Link from "next/link";
+import { localizedPath } from "@/lib/utils";
 
 const StatBox = ({
   title,
@@ -109,6 +110,7 @@ const calculateGrowthPercentage = (
 };
 
 export default function Budget() {
+  const { i18n } = useLingui();
   const [budgetData, setBudgetData] = useState({
     spending: 513.9,
     revenue: 459.5,
@@ -156,7 +158,7 @@ export default function Budget() {
               <Trans>Official Fall 2025 Federal Budget Released</Trans>
             </h2>
             <Link
-              href="/budget"
+              href={localizedPath("/budget", i18n.locale)}
               className="inline-block bg-white text-indigo-950 hover:bg-gray-100 font-medium py-3 px-6 transition-colors"
             >
               <Trans>View Federal 2025 Budget Details</Trans>
@@ -262,7 +264,7 @@ export default function Budget() {
           <div className="absolute top-0 left-0 w-[100vw] h-full  backdrop-blur-sm z-10 text-white md:hidden flex items-center justify-center">
             <ExternalLink
               className="rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
-              href="/budget-full-screen"
+              href={localizedPath("/budget-full-screen", i18n.locale)}
             >
               <Trans>View this chart in full screen</Trans>
             </ExternalLink>
@@ -300,8 +302,10 @@ export default function Budget() {
               the Fall 2025 Budget. We aim to make this information more
               accessible and accurate, and we welcome feedback. If you notice
               any issues, please let us know{" "}
-              <InternalLink href="/contact">here</InternalLink> — we appreciate
-              it and will work to address them promptly.
+              <InternalLink href="/contact" lang={i18n.locale}>
+                here
+              </InternalLink>{" "}
+              — we appreciate it and will work to address them promptly.
             </Trans>
           </P>
         </Section>

--- a/src/app/[lang]/(main)/page.tsx
+++ b/src/app/[lang]/(main)/page.tsx
@@ -8,6 +8,7 @@ import { FiCornerLeftDown, FiCornerRightDown } from "react-icons/fi";
 import { LuReceipt, LuUsersRound } from "react-icons/lu";
 import { PiBank } from "react-icons/pi";
 import { IS_BUDGET_2025_LIVE } from "@/lib/featureFlags";
+import { localizedPath } from "@/lib/utils";
 
 export default async function Page(props: PageLangParam) {
   const lang = (await props.params).lang;
@@ -48,7 +49,10 @@ export default async function Page(props: PageLangParam) {
                 <div className="flex gap-4">
                   <Link
                     className="text-white bg-indigo-950 hover:bg-indigo-900 items-center font-medium justify-center py-2 px-4 relative flex w-auto min-w-[7.00rem] max-w-full overflow-hidden"
-                    href={IS_BUDGET_2025_LIVE ? "/budget" : "/spending"}
+                    href={localizedPath(
+                      IS_BUDGET_2025_LIVE ? "/budget" : "/spending",
+                      lang,
+                    )}
                   >
                     <div className="items-center cursor-pointer justify-center relative flex overflow-hidden">
                       <div className="items-center justify-center flex p-1">
@@ -62,7 +66,7 @@ export default async function Page(props: PageLangParam) {
                   </Link>
                   <Link
                     className="text-indigo-950 bg-white border-indigo-950 border-2 hover:bg-gray-100 items-center font-medium justify-center py-2 px-4 relative flex w-auto min-w-[7.00rem] max-w-full overflow-hidden"
-                    href="/ontario"
+                    href={localizedPath("/ontario", lang)}
                   >
                     <div className="items-center cursor-pointer justify-center relative flex overflow-hidden">
                       <div className="items-center justify-center flex p-1">

--- a/src/app/[lang]/(main)/spending/page.tsx
+++ b/src/app/[lang]/(main)/spending/page.tsx
@@ -18,6 +18,7 @@ import {
 import NoSSR from "@/components/NoSSR";
 import { Sankey } from "@/components/Sankey";
 import { Trans, useLingui } from "@lingui/react/macro";
+import { localizedPath } from "@/lib/utils";
 
 const StatBox = ({
   title,
@@ -101,7 +102,7 @@ const calculateGrowthPercentage = (dataType: string) => {
 };
 
 export default function Spending() {
-  const { t } = useLingui();
+  const { t, i18n } = useLingui();
   return (
     <Page>
       <PageContent>
@@ -143,7 +144,7 @@ export default function Spending() {
         <div className="absolute top-0 left-0 w-[100vw] h-full  backdrop-blur-sm z-10 text-white md:hidden flex items-center justify-center">
           <ExternalLink
             className="rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
-            href="/spending-full-screen"
+            href={localizedPath("/spending-full-screen", i18n.locale)}
           >
             <Trans>View this chart in full screen</Trans>
           </ExternalLink>
@@ -271,8 +272,10 @@ export default function Spending() {
               occur despite our best efforts. We aim to make this information
               more accessible and accurate, and we welcome feedback. If you
               notice any issues, please let us know{" "}
-              <InternalLink href="/contact">here</InternalLink> — we appreciate
-              it and will work to address them promptly.
+              <InternalLink href="/contact" lang={i18n.locale}>
+                here
+              </InternalLink>{" "}
+              — we appreciate it and will work to address them promptly.
             </Trans>
           </P>
         </Section>

--- a/src/app/[lang]/(main)/tax-visualizer/page.tsx
+++ b/src/app/[lang]/(main)/tax-visualizer/page.tsx
@@ -7,6 +7,7 @@ import { StatCard } from "@/components/StatCard";
 import { CombinedSpendingChart } from "@/components/CombinedSpendingChart";
 import { calculateTotalTax, formatCurrency } from "@/lib/taxCalculator";
 import { calculatePersonalTaxBreakdown } from "@/lib/personalTaxBreakdown";
+import { localizedPath } from "@/lib/utils";
 
 type ProvinceData = {
   name: string;
@@ -223,7 +224,7 @@ function TaxBracketsTable({ province }: TaxBracketsTableProps) {
 // Remove the old SpendingVisualization component since we're using the combined chart
 
 export default function TaxCalculatorPage() {
-  const { t } = useLingui();
+  const { t, i18n } = useLingui();
   const [income, setIncome] = useState<number>(100000);
   const [province, setProvince] = useState<string>("ontario");
 
@@ -283,12 +284,18 @@ export default function TaxCalculatorPage() {
                 <p>
                   <Trans>
                     For further breakdowns of spending, see{" "}
-                    <a href="/spending" className="underline">
+                    <a
+                      href={localizedPath("/spending", i18n.locale)}
+                      className="underline"
+                    >
                       Federal
                     </a>{" "}
                     and{" "}
                     <a
-                      href={province === "alberta" ? "/alberta" : "/ontario"}
+                      href={localizedPath(
+                        province === "alberta" ? "/alberta" : "/ontario",
+                        i18n.locale,
+                      )}
                       className="underline"
                     >
                       Provincial

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { cn } from "@/lib/utils";
+import { cn, localizedPath } from "@/lib/utils";
 
 export const Section = ({
   children,
@@ -145,15 +145,22 @@ export const InternalLink = ({
   children,
   href,
   className = "",
+  lang,
 }: {
   children: React.ReactNode;
   href: string;
   className?: string;
-}) => (
-  <Link
-    href={href}
-    className={`text-blue-500 underline hover:text-blue-600 ${className}`}
-  >
-    {children}
-  </Link>
-);
+  lang?: string;
+}) => {
+  // If lang is provided, ensure the href is localized
+  const localizedHref = lang ? localizedPath(href, lang) : href;
+
+  return (
+    <Link
+      href={localizedHref}
+      className={`text-blue-500 underline hover:text-blue-600 ${className}`}
+    >
+      {children}
+    </Link>
+  );
+};

--- a/src/components/MainLayout/index.tsx
+++ b/src/components/MainLayout/index.tsx
@@ -148,7 +148,7 @@ export const MainLayout = ({
                           {provinces.map((provinceSlug) => (
                             <DropdownMenu.Item key={provinceSlug} asChild>
                               <Link
-                                href={`/${provinceSlug}`}
+                                href={`/${i18n.locale}/${provinceSlug}`}
                                 className="px-3 py-2 text-sm hover:bg-gray-100 rounded cursor-pointer"
                               >
                                 {provinceNames[provinceSlug]}
@@ -187,7 +187,7 @@ export const MainLayout = ({
                                         asChild
                                       >
                                         <Link
-                                          href={`/${municipality.slug}`}
+                                          href={`/${i18n.locale}/${municipality.slug}`}
                                           className="px-3 py-2 text-sm hover:bg-gray-100 rounded cursor-pointer"
                                         >
                                           {municipality.name}
@@ -320,8 +320,8 @@ export const MainLayout = ({
             {provinces.map((provinceSlug) => (
               <MobileNavLink
                 key={provinceSlug}
-                href={`/${provinceSlug}`}
-                active={pathname.startsWith(`/${provinceSlug}`)}
+                href={`/${i18n.locale}/${provinceSlug}`}
+                active={pathname.startsWith(`/${i18n.locale}/${provinceSlug}`)}
                 onClick={() => setIsMenuOpen(false)}
               >
                 <span className="pl-8 inline-block">
@@ -342,8 +342,10 @@ export const MainLayout = ({
                 {municipalities.map((municipality) => (
                   <MobileNavLink
                     key={municipality.slug}
-                    href={`/${municipality.slug}`}
-                    active={pathname.startsWith(`/${municipality.slug}`)}
+                    href={`/${i18n.locale}/${municipality.slug}`}
+                    active={pathname.startsWith(
+                      `/${i18n.locale}/${municipality.slug}`,
+                    )}
                     onClick={() => setIsMenuOpen(false)}
                   >
                     <span className="pl-12 inline-block">

--- a/src/lib/jurisdictions.ts
+++ b/src/lib/jurisdictions.ts
@@ -375,6 +375,8 @@ export function getExpandedDepartments(jurisdiction: string): Department[] {
 export function departmentHref(
   jurisdiction: string,
   department: string,
+  locale?: string,
 ): string {
-  return `/${jurisdiction}/departments/${department}`;
+  const path = `/${jurisdiction}/departments/${department}`;
+  return locale ? `/${locale}${path}` : path;
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -33,3 +33,29 @@ export const hasErrorInput = [
   // ring color
   "ring-red-200 dark:ring-red-700/30",
 ];
+
+/**
+ * Generate a localized path by prepending the locale to the path.
+ * If the path already starts with a locale, it will be replaced.
+ * @param path - The path to localize (e.g., "/contact", "/spending")
+ * @param locale - The locale code (e.g., "en", "fr")
+ * @returns The localized path (e.g., "/en/contact", "/fr/spending")
+ */
+export function localizedPath(path: string, locale: string): string {
+  // Remove leading slash for processing
+  const cleanPath = path.startsWith("/") ? path.slice(1) : path;
+
+  // Check if path already starts with a locale
+  const locales = ["en", "fr"];
+  const pathParts = cleanPath.split("/");
+  const firstPart = pathParts[0];
+
+  // If first part is a locale, replace it; otherwise prepend the locale
+  if (locales.includes(firstPart)) {
+    pathParts[0] = locale;
+  } else {
+    pathParts.unshift(locale);
+  }
+
+  return "/" + pathParts.join("/");
+}


### PR DESCRIPTION
## Problem
When users viewed the site in French (with `/fr/` in the URL path), internal links throughout the site were not preserving the locale, causing users to be redirected back to English pages when clicking links.

## Solution
- Added a `localizedPath()` utility function to consistently generate localized paths
- Updated `InternalLink` component to accept an optional `lang` prop that automatically localizes paths
- Fixed all hardcoded internal links across the codebase to preserve the current locale

## Testing
- Verified links preserve locale when navigating from French pages
- Confirmed links work correctly in both English and French locales
- Tested navigation menus, internal links, and external links (which remain unchanged)