### PR TITLE
French translations: Add 133 missing translation strings

### DIFF
--- a/src/app/[lang]/(main)/[jurisdiction]/page.tsx
+++ b/src/app/[lang]/(main)/[jurisdiction]/page.tsx
@@ -256,7 +256,12 @@ export default async function ProvinceIndex({
           </Tooltip>
         </div>
       ),
-      value: `$${perCapitaSpending.toLocaleString("en-CA")} per resident`,
+      value: (
+        <>
+          ${perCapitaSpending.toLocaleString("en-CA")}{" "}
+          <Trans>per resident</Trans>
+        </>
+      ),
       description: (
         <Trans>
           Annual municipal spending per {jurisdiction.name} resident
@@ -276,7 +281,12 @@ export default async function ProvinceIndex({
           </Tooltip>
         </div>
       ),
-      value: `$${propertyTaxPerCapita.toLocaleString("en-CA")} per resident`,
+      value: (
+        <>
+          ${propertyTaxPerCapita.toLocaleString("en-CA")}{" "}
+          <Trans>per resident</Trans>
+        </>
+      ),
       description: (
         <Trans>Property tax revenue per {jurisdiction.name} resident</Trans>
       ),

--- a/src/locales/en.po
+++ b/src/locales/en.po
@@ -37,23 +37,23 @@ msgid "{0}"
 msgstr "{0}"
 
 #. placeholder {0}: jurisdiction.name
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:389
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:399
 msgid "{0} Government Departments explained"
 msgstr "{0} Government Departments explained"
 
 #. placeholder {0}: jurisdiction.name
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:291
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:301
 msgid "{0} Government Spending"
 msgstr "{0} Government Spending"
 
 #. placeholder {0}: jurisdiction.name
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:359
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:369
 msgid "{0} Government Workforce"
 msgstr "{0} Government Workforce"
 
 #. placeholder {0}: jurisdiction.name
 #. placeholder {1}: jurisdiction.financialYear
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:303
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:313
 msgid "{0}'s Revenue and Spending in Financial Year {1}"
 msgstr "{0}'s Revenue and Spending in Financial Year {1}"
 
@@ -65,8 +65,8 @@ msgstr "{0}'s Revenue and Spending in Financial Year {1}"
 #: src/app/[lang]/(main)/[jurisdiction]/[department]/page.tsx:281
 #: src/app/[lang]/(main)/[jurisdiction]/[department]/page.tsx:320
 #: src/app/[lang]/(main)/[jurisdiction]/[department]/page.tsx:384
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:420
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:462
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:430
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:472
 msgid "{paragraph}"
 msgstr "{paragraph}"
 
@@ -248,7 +248,7 @@ msgstr "All data presented regarding government spending is sourced directly fro
 msgid "All government budget data is sourced from official databases, but due to the complexity of these systems, occasional errors may occur despite our best efforts. This page is also based on government memos and leaks, so it is not an official release of the Fall 2025 Budget. We aim to make this information more accessible and accurate, and we welcome feedback. If you notice any issues, please let us know <0>here</0> — we appreciate it and will work to address them promptly."
 msgstr "All government budget data is sourced from official databases, but due to the complexity of these systems, occasional errors may occur despite our best efforts. This page is also based on government memos and leaks, so it is not an official release of the Fall 2025 Budget. We aim to make this information more accessible and accurate, and we welcome feedback. If you notice any issues, please let us know <0>here</0> — we appreciate it and will work to address them promptly."
 
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:431
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:441
 #: src/app/[lang]/(main)/spending/page.tsx:269
 msgid "All government spending data is sourced from official databases, but due to the complexity of these systems, occasional errors may occur despite our best efforts. We aim to make this information more accessible and accurate, and we welcome feedback. If you notice any issues, please let us know <0>here</0> — we appreciate it and will work to address them promptly."
 msgstr "All government spending data is sourced from official databases, but due to the complexity of these systems, occasional errors may occur despite our best efforts. We aim to make this information more accessible and accurate, and we welcome feedback. If you notice any issues, please let us know <0>here</0> — we appreciate it and will work to address them promptly."
@@ -275,7 +275,7 @@ msgid "Annual interest expense for {0}"
 msgstr "Annual interest expense for {0}"
 
 #. placeholder {0}: jurisdiction.name
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:261
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:266
 msgid "Annual municipal spending per {0} resident"
 msgstr "Annual municipal spending per {0} resident"
 
@@ -770,7 +770,7 @@ msgstr "Estimated income tax paid to federal government"
 msgid "Estimated income tax paid to provincial government"
 msgstr "Estimated income tax paid to provincial government"
 
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:365
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:375
 msgid "Estimated public service workforce"
 msgstr "Estimated public service workforce"
 
@@ -988,7 +988,7 @@ msgid "Finance Canada"
 msgstr "Finance Canada"
 
 #. placeholder {0}: jurisdiction.financialYear
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:344
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:354
 msgid "Financial Position {0}"
 msgstr "Financial Position {0}"
 
@@ -1062,7 +1062,7 @@ msgstr "Get data-driven insights into how governmental revenue and spending affe
 
 #. placeholder {0}: jurisdiction.name
 #. placeholder {1}: jurisdiction.name
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:294
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:304
 msgid "Get data-driven insights into how the {0} government’s revenue and spending affect {1} residents and programs."
 msgstr "Get data-driven insights into how the {0} government’s revenue and spending affect {1} residents and programs."
 
@@ -1126,7 +1126,7 @@ msgstr "Government Departments Explained"
 msgid "Government IT Operations"
 msgstr "Government IT Operations"
 
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:373
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:383
 msgid "Government organizations"
 msgstr "Government organizations"
 
@@ -1580,7 +1580,7 @@ msgstr "Latest Budget News & Impact"
 
 #. placeholder {0}: jurisdiction.name
 #. placeholder {1}: ["Toronto", "Vancouver"].includes(jurisdiction.name) && ( <Trans>Numbers are reported on an accrual basis.</Trans> )
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:309
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:319
 msgid "Look back at what {0}'s government made and spent. {1}"
 msgstr "Look back at what {0}'s government made and spent. {1}"
 
@@ -1637,11 +1637,11 @@ msgstr "Manitoba HTP"
 msgid "Manitoba STP"
 msgstr "Manitoba STP"
 
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:403
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:413
 msgid "Methodology"
 msgstr "Methodology"
 
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:369
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:379
 msgid "Ministries + Agencies"
 msgstr "Ministries + Agencies"
 
@@ -1825,7 +1825,7 @@ msgstr "Nuclear Labs + Decommissioning"
 msgid "Number of Employees"
 msgstr "Number of Employees"
 
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:312
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:322
 msgid "Numbers are reported on an accrual basis."
 msgstr "Numbers are reported on an accrual basis."
 
@@ -2090,6 +2090,11 @@ msgstr "PBO"
 msgid "Per Capita Spending"
 msgstr "Per Capita Spending"
 
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:262
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:287
+msgid "per resident"
+msgstr "per resident"
+
 #: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:147
 msgid "Percentage of federal budget dedicated to Canada Revenue Agency, FYs 1995-2024"
 msgstr "Percentage of federal budget dedicated to Canada Revenue Agency, FYs 1995-2024"
@@ -2185,12 +2190,12 @@ msgstr "Projected capital investments"
 msgid "Projected operational spending"
 msgstr "Projected operational spending"
 
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:273
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:278
 msgid "Property Tax Per Capita"
 msgstr "Property Tax Per Capita"
 
 #. placeholder {0}: jurisdiction.name
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:281
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:291
 msgid "Property tax revenue per {0} resident"
 msgstr "Property tax revenue per {0} resident"
 
@@ -2217,7 +2222,7 @@ msgstr "PSPC spent $8.3 billion in fiscal year (FY) 2024. This was 1.6% of the $
 
 #. placeholder {0}: jurisdiction.name
 #. placeholder {1}: jurisdiction.financialYear
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:379
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:389
 msgid "Public Accounts of {0} FY {1}"
 msgstr "Public Accounts of {0} FY {1}"
 
@@ -2263,7 +2268,7 @@ msgstr "Public Safety Canada spent $13.9 billion in fiscal year (FY) 2024, accou
 msgid "Public Safety, Democratic Institutions and Intergovernmental Affairs Canada (Public Safety Canada) is the federal department responsible for national security, emergency preparedness, and community safety. Established in 2003, it consolidates security, law enforcement, and emergency management functions. It includes the RCMP, CSIS, and CBSA and coordinates federal responses to threats and develops policies on crime prevention, cyber resilience, and disaster preparedness while overseeing intelligence-sharing with domestic and international partners."
 msgstr "Public Safety, Democratic Institutions and Intergovernmental Affairs Canada (Public Safety Canada) is the federal department responsible for national security, emergency preparedness, and community safety. Established in 2003, it consolidates security, law enforcement, and emergency management functions. It includes the RCMP, CSIS, and CBSA and coordinates federal responses to threats and develops policies on crime prevention, cyber resilience, and disaster preparedness while overseeing intelligence-sharing with domestic and international partners."
 
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:363
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:373
 msgid "Public Service Employees"
 msgstr "Public Service Employees"
 
@@ -2448,7 +2453,7 @@ msgstr "Social Security"
 msgid "Social Transfer to Provinces"
 msgstr "Social Transfer to Provinces"
 
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:327
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:337
 msgid "Source"
 msgstr "Source"
 
@@ -2456,13 +2461,13 @@ msgstr "Source"
 msgid "Source:"
 msgstr "Source:"
 
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:428
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:438
 #: src/app/[lang]/(main)/budget/page.tsx:294
 #: src/app/[lang]/(main)/spending/page.tsx:266
 msgid "Sources"
 msgstr "Sources"
 
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:377
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:387
 #: src/app/[lang]/(main)/spending/page.tsx:226
 msgid "Sources:"
 msgstr "Sources:"
@@ -2898,7 +2903,7 @@ msgstr "Veterans Affairs Canada | Canada Spends"
 msgid "View Federal 2025 Budget Details"
 msgstr "View Federal 2025 Budget Details"
 
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:338
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:348
 #: src/app/[lang]/(main)/budget/page.tsx:269
 #: src/app/[lang]/(main)/spending/page.tsx:149
 msgid "View this chart in full screen"

--- a/src/locales/fr.po
+++ b/src/locales/fr.po
@@ -34,28 +34,28 @@ msgstr "(ajusté pour l'inflation en dollars de 2025)"
 #: src/app/[lang]/(main)/[jurisdiction]/[department]/page.tsx:332
 #: src/components/DepartmentList.tsx:68
 msgid "{0}"
-msgstr ""
+msgstr "{0}"
 
 #. placeholder {0}: jurisdiction.name
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:389
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:399
 msgid "{0} Government Departments explained"
-msgstr ""
+msgstr "Ministères du gouvernement de {0} expliqués"
 
 #. placeholder {0}: jurisdiction.name
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:291
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:301
 msgid "{0} Government Spending"
-msgstr ""
+msgstr "Dépenses du gouvernement de {0}"
 
 #. placeholder {0}: jurisdiction.name
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:359
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:369
 msgid "{0} Government Workforce"
-msgstr ""
+msgstr "Effectifs du gouvernement de {0}"
 
 #. placeholder {0}: jurisdiction.name
 #. placeholder {1}: jurisdiction.financialYear
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:303
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:313
 msgid "{0}'s Revenue and Spending in Financial Year {1}"
-msgstr ""
+msgstr "Revenus et dépenses de {0} pour l'exercice financier {1}"
 
 #: src/app/[lang]/(main)/[jurisdiction]/[department]/page.tsx:105
 #: src/app/[lang]/(main)/[jurisdiction]/[department]/page.tsx:142
@@ -65,10 +65,10 @@ msgstr ""
 #: src/app/[lang]/(main)/[jurisdiction]/[department]/page.tsx:281
 #: src/app/[lang]/(main)/[jurisdiction]/[department]/page.tsx:320
 #: src/app/[lang]/(main)/[jurisdiction]/[department]/page.tsx:384
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:420
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:462
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:430
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:472
 msgid "{paragraph}"
-msgstr ""
+msgstr "{paragraph}"
 
 #: src/components/MainLayout/Footer.tsx:80
 msgid "© 2025 Canada Spends. All rights reserved. A Project of <0>Build Canada</0>."
@@ -165,7 +165,7 @@ msgstr "À propos"
 #: src/components/MainLayout/Footer.tsx:26
 #: src/components/MainLayout/index.tsx:243
 msgid "About Us"
-msgstr ""
+msgstr "À propos de nous"
 
 #: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:47
 #: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:47
@@ -206,7 +206,7 @@ msgstr "Ajuster pour l'inflation (dollars de 2025)"
 
 #: src/components/Sankey/BudgetSankey.tsx:626
 msgid "Adjust sliders to see how department spending reductions affect the overall Fall 2025 Budget. The Minister of Finance has asked departments to reduce spending by 7.5% in 2026-27, 10% in 2027-28, and 15% in 2028-29."
-msgstr ""
+msgstr "Ajustez les curseurs pour voir comment les réductions des dépenses ministérielles affectent le budget global de l'automne 2025. Le ministre des Finances a demandé aux ministères de réduire les dépenses de 7,5 % en 2026-27, de 10 % en 2027-28 et de 15 % en 2028-29."
 
 #: src/app/[lang]/(main)/spending/page.tsx:196
 msgid "Age"
@@ -222,7 +222,7 @@ msgstr "Frais des voyageurs aériens"
 
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:100
 msgid "Alberta"
-msgstr ""
+msgstr "Alberta"
 
 #: src/components/Sankey/index.tsx:515
 msgid "Alberta EQP"
@@ -238,7 +238,7 @@ msgstr "TCS Alberta"
 
 #: src/app/[lang]/(main)/articles/page.tsx:68
 msgid "All Articles"
-msgstr ""
+msgstr "Tous les articles"
 
 #: src/app/[lang]/(main)/about/faq.tsx:22
 msgid "All data presented regarding government spending is sourced directly from official government databases. Unless otherwise noted, we have used <0>Public Accounts of Canada</0> data as the primary data source. While we strive to provide accurate, up-to-date information, we cannot guarantee the data's completeness, reliability, or timeliness. We assume no responsibility for any errors, omissions, or outcomes resulting from the use of this information. Please consult the original government sources for official and verified data."
@@ -246,9 +246,9 @@ msgstr "Toutes les données présentées concernant les dépenses gouvernemental
 
 #: src/app/[lang]/(main)/budget/page.tsx:297
 msgid "All government budget data is sourced from official databases, but due to the complexity of these systems, occasional errors may occur despite our best efforts. This page is also based on government memos and leaks, so it is not an official release of the Fall 2025 Budget. We aim to make this information more accessible and accurate, and we welcome feedback. If you notice any issues, please let us know <0>here</0> — we appreciate it and will work to address them promptly."
-msgstr ""
+msgstr "Toutes les données budgétaires gouvernementales proviennent de bases de données officielles, mais en raison de la complexité de ces systèmes, des erreurs occasionnelles peuvent survenir malgré nos meilleurs efforts. Cette page est également basée sur des notes et des fuites gouvernementales, ce n'est donc pas une publication officielle du budget de l'automne 2025. Nous visons à rendre cette information plus accessible et précise, et nous accueillons vos commentaires. Si vous remarquez des problèmes, veuillez nous en informer <0>ici</0> — nous l'apprécions et nous travaillerons à les résoudre rapidement."
 
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:431
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:441
 #: src/app/[lang]/(main)/spending/page.tsx:269
 msgid "All government spending data is sourced from official databases, but due to the complexity of these systems, occasional errors may occur despite our best efforts. We aim to make this information more accessible and accurate, and we welcome feedback. If you notice any issues, please let us know <0>here</0> — we appreciate it and will work to address them promptly."
 msgstr "Toutes les données sur les dépenses gouvernementales proviennent de bases de données officielles, mais en raison de la complexité de ces systèmes, des erreurs occasionnelles peuvent survenir malgré nos meilleurs efforts. Nous visons à rendre cette information plus accessible et précise, et nous accueillons vos commentaires. Si vous remarquez des problèmes, veuillez nous en informer <0>ici</0> — nous l'apprécions et nous travaillerons à les résoudre rapidement."
@@ -263,21 +263,21 @@ msgstr "Toutes les informations proviennent des bases de données publiques et d
 
 #: src/app/[lang]/(main)/budget/page.tsx:63
 msgid "Amount/Change"
-msgstr ""
+msgstr "Montant/Changement"
 
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:68
 msgid "Annual Income (CAD)"
-msgstr ""
+msgstr "Revenu annuel (CAD)"
 
 #. placeholder {0}: jurisdiction.financialYear
 #: src/app/[lang]/(main)/[jurisdiction]/page.tsx:240
 msgid "Annual interest expense for {0}"
-msgstr ""
+msgstr "Dépenses d'intérêts annuelles pour {0}"
 
 #. placeholder {0}: jurisdiction.name
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:261
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:266
 msgid "Annual municipal spending per {0} resident"
-msgstr ""
+msgstr "Dépenses municipales annuelles par résident de {0}"
 
 #: src/app/[lang]/(main)/spending/page.tsx:176
 msgid "Annual payroll"
@@ -289,30 +289,30 @@ msgstr "Êtes-vous DOGE?"
 
 #: src/app/[lang]/(main)/articles/page.tsx:39
 msgid "Articles"
-msgstr ""
+msgstr "Articles"
 
 #: src/app/[lang]/(main)/articles/page.tsx:18
 msgid "Articles | Canada Spends"
-msgstr ""
+msgstr "Articles | Canada Spends"
 
 #. placeholder {0}: jurisdiction.financialYear
 #: src/app/[lang]/(main)/[jurisdiction]/page.tsx:210
 #: src/app/[lang]/(main)/[jurisdiction]/page.tsx:225
 msgid "As of fiscal year end {0}"
-msgstr ""
+msgstr "À la fin de l'exercice financier {0}"
 
 #: src/app/[lang]/(main)/spending/page.tsx:169
 msgid "Average annual compensation"
-msgstr ""
+msgstr "Rémunération annuelle moyenne"
 
 #: src/app/[lang]/(main)/articles/[slug]/page.tsx:165
 msgid "Back to All Articles"
-msgstr ""
+msgstr "Retour à tous les articles"
 
 #. placeholder {0}: jurisdiction.financialYear
 #: src/app/[lang]/(main)/[jurisdiction]/page.tsx:159
 msgid "Balance for {0}"
-msgstr ""
+msgstr "Solde pour {0}"
 
 #: src/components/Sankey/index.tsx:161
 msgid "Banking + Finance"
@@ -341,19 +341,19 @@ msgstr "TCS Colombie-Britannique"
 #: src/components/MainLayout/index.tsx:134
 #: src/components/MainLayout/index.tsx:312
 msgid "Budget"
-msgstr ""
+msgstr "Budget"
 
 #: src/app/[lang]/(main)/budget/page.tsx:60
 msgid "Budget Impact"
-msgstr ""
+msgstr "Impact budgétaire"
 
 #: src/app/[lang]/(main)/budget/page.tsx:196
 msgid "Budget Statistics (Projected FY 2025)"
-msgstr ""
+msgstr "Statistiques budgétaires (exercice 2025 projeté)"
 
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:60
 msgid "Calculate Your Tax Contribution"
-msgstr ""
+msgstr "Calculez votre contribution fiscale"
 
 #: src/app/[lang]/(main)/about/faq.tsx:64
 msgid "Can I donate?"
@@ -365,7 +365,7 @@ msgstr "Puis-je m'impliquer?"
 
 #: src/components/Sankey/BudgetSankey.tsx:410
 msgid "Canada Community-Building Fund"
-msgstr ""
+msgstr "Fonds pour la construction communautaire du Canada"
 
 #: src/components/Sankey/index.tsx:242
 msgid "Canada Emergency Wage Subsidy"
@@ -403,7 +403,7 @@ msgstr "Canada Spends s'appuie principalement sur les données des Comptes publi
 
 #: src/app/[lang]/(main)/about/faq.tsx:67
 msgid "Canada Spends, as a project of Build Canada, is funded through donations from our builder network. Donate"
-msgstr ""
+msgstr "Canada Spends, en tant que projet de Build Canada, est financé par des dons de notre réseau de constructeurs. Faire un don"
 
 #: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:210
 msgid "Canada Student Loans Program: providing financial aid for post-secondary students."
@@ -411,7 +411,7 @@ msgstr "Programme canadien de prêts aux étudiants : fournir une aide financiè
 
 #: src/components/Sankey/BudgetSankey.tsx:405
 msgid "Canada-wide early learning and child care"
-msgstr ""
+msgstr "Apprentissage et garde des jeunes enfants à l'échelle du Canada"
 
 #: src/app/[lang]/(main)/about/page.tsx:33
 msgid "Canada, you need the facts."
@@ -419,7 +419,7 @@ msgstr "Canada, vous avez besoin des faits."
 
 #: src/app/[lang]/(main)/budget/page.tsx:231
 msgid "Capital Investments"
-msgstr ""
+msgstr "Investissements en capital"
 
 #: src/components/Sankey/index.tsx:75
 msgid "Carbon Tax Rebate"
@@ -487,7 +487,7 @@ msgstr "Contributeurs / Supporteurs"
 
 #: src/components/Sankey/BudgetSankey.tsx:487
 msgid "Corporate Income Tax"
-msgstr ""
+msgstr "Impôt sur le revenu des sociétés"
 
 #: src/components/Sankey/index.tsx:750
 msgid "Corporate Income Taxes"
@@ -537,7 +537,7 @@ msgstr "Droits de douane"
 
 #: src/components/Sankey/BudgetSankey.tsx:467
 msgid "Customs Import Duties"
-msgstr ""
+msgstr "Droits de douane à l'importation"
 
 #: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:67
 msgid "Data updated March 20, 2025"
@@ -577,7 +577,7 @@ msgstr "Équipe de la défense"
 
 #: src/app/[lang]/(main)/budget/page.tsx:242
 msgid "Deficit"
-msgstr ""
+msgstr "Déficit"
 
 #: src/app/[lang]/(main)/spending/department-of-finance/MiniSankey.tsx:16
 msgid "Department of Finance"
@@ -597,11 +597,11 @@ msgstr "Ministère de la Défense nationale"
 
 #: src/app/[lang]/(main)/[jurisdiction]/[department]/page.tsx:113
 msgid "Department Spending"
-msgstr ""
+msgstr "Dépenses du ministère"
 
 #: src/components/Sankey/BudgetSankey.tsx:622
 msgid "Department Spending Reductions"
-msgstr ""
+msgstr "Réductions des dépenses ministérielles"
 
 #: src/app/[lang]/(main)/spending/page.tsx:221
 msgid "Departments + Agencies"
@@ -621,7 +621,7 @@ msgstr "Programmation du développement, de la paix et de la sécurité : 5,37 G
 
 #: src/components/Sankey/BudgetSankey.tsx:433
 msgid "Direct program expenses"
-msgstr ""
+msgstr "Dépenses directes des programmes"
 
 #: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:159
 msgid "Direct spending refers to money allocated to government programs, employee salaries, and administrative expenses. Indirect spending includes federal transfers to individuals and provinces."
@@ -665,15 +665,15 @@ msgstr "Économie et niveau de vie"
 
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:136
 msgid "Effective Rate"
-msgstr ""
+msgstr "Taux effectif"
 
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:138
 msgid "Effective tax rate"
-msgstr ""
+msgstr "Taux d'imposition effectif"
 
 #: src/app/[lang]/(main)/contact/page.tsx:44
 msgid "Email us at <0>hi@buildcanada.com</0> or connect with us on X <1>@canada_spends</1> and we'll get back to you as soon as we can."
-msgstr ""
+msgstr "Envoyez-nous un courriel à <0>hi@buildcanada.com</0> ou connectez-vous avec nous sur X <1>@canada_spends</1> et nous vous répondrons dès que possible."
 
 #: src/components/Sankey/index.tsx:619
 msgid "Emergency Management Activities On-Reserve"
@@ -707,7 +707,7 @@ msgstr "Taxes sur l'énergie"
 
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:247
 msgid "Enter your income to see a personalized breakdown of how much you contribute to different government services and programs."
-msgstr ""
+msgstr "Entrez votre revenu pour voir une répartition personnalisée de votre contribution aux différents services et programmes gouvernementaux."
 
 #: src/components/Sankey/index.tsx:165
 msgid "Environment and Climate Change"
@@ -744,15 +744,15 @@ msgstr "La part des dépenses fédérales d'EDSC en 2024 était inférieure à c
 
 #: src/app/[lang]/(main)/budget/page.tsx:244
 msgid "Est. projected budget deficit"
-msgstr ""
+msgstr "Déficit budgétaire projeté estimé"
 
 #: src/app/[lang]/(main)/budget/page.tsx:204
 msgid "Est. projected government budget"
-msgstr ""
+msgstr "Budget gouvernemental projeté estimé"
 
 #: src/app/[lang]/(main)/budget/page.tsx:213
 msgid "Est. projected government revenue"
-msgstr ""
+msgstr "Revenus gouvernementaux projetés estimés"
 
 #: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:56
 msgid "Established in 2005, ESDC is a federal department responsible for supporting Canadians through social programs and workforce development. It administers key programs such as Employment Insurance (EI), the Canada Pension Plan (CPP), Old Age Security (OAS), and skills training initiatives. ESDC also oversees Service Canada, which delivers government services directly to the public."
@@ -760,19 +760,19 @@ msgstr "Établi en 2005, EDSC est un ministère fédéral responsable du soutien
 
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:133
 msgid "Estimated combined tax"
-msgstr ""
+msgstr "Impôt combiné estimé"
 
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:123
 msgid "Estimated income tax paid to federal government"
-msgstr ""
+msgstr "Impôt sur le revenu estimé payé au gouvernement fédéral"
 
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:128
 msgid "Estimated income tax paid to provincial government"
-msgstr ""
+msgstr "Impôt sur le revenu estimé payé au gouvernement provincial"
 
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:365
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:375
 msgid "Estimated public service workforce"
-msgstr ""
+msgstr "Effectifs de la fonction publique estimés"
 
 #: src/app/[lang]/(main)/about/page.tsx:36
 msgid "Every year, hundreds of billions of dollars move through the Government of Canada's budget. This data is technically available but the information is difficult to understand and spread across PDFs and databases that most Canadians don't know about."
@@ -796,23 +796,23 @@ msgstr "Taxe d'accise — Essence"
 
 #: src/app/[lang]/(main)/page.tsx:70
 msgid "Explore Budget 2025"
-msgstr ""
+msgstr "Explorer le budget 2025"
 
 #: src/app/[lang]/(main)/page.tsx:72
 msgid "Explore federal data"
-msgstr ""
+msgstr "Explorer les données fédérales"
 
 #: src/app/[lang]/(main)/spending/page.tsx:241
 msgid "Explore federal employee salary distribution by year and demographic group"
-msgstr ""
+msgstr "Explorez la répartition des salaires des employés fédéraux par année et groupe démographique"
 
 #: src/app/[lang]/(main)/articles/page.tsx:19
 msgid "Explore in-depth articles about Canadian government spending, budget analysis, and public finance. Stay informed about how your tax dollars are used through Canada Spends."
-msgstr ""
+msgstr "Explorez des articles approfondis sur les dépenses gouvernementales canadiennes, l'analyse budgétaire et les finances publiques. Restez informé de l'utilisation de vos dollars d'impôt grâce à Canada Spends."
 
 #: src/app/[lang]/(main)/page.tsx:83
 msgid "Explore Ontario data"
-msgstr ""
+msgstr "Explorer les données de l'Ontario"
 
 #: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:238
 #: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:229
@@ -854,12 +854,12 @@ msgstr "Faits sur les dépenses"
 
 #: src/app/[lang]/(main)/articles/page.tsx:55
 msgid "Featured Articles"
-msgstr ""
+msgstr "Articles en vedette"
 
 #: src/components/MainLayout/index.tsx:125
 #: src/components/MainLayout/index.tsx:302
 msgid "Federal"
-msgstr ""
+msgstr "Fédéral"
 
 #: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:177
 msgid "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, Department of Finance entities with the highest expenditures were the Office of the Superintendent of Financial Institutions, Office of the Auditor General, and the Financial Transactions and Reports Analysis Centre of Canada."
@@ -903,7 +903,7 @@ msgstr "Les ministères fédéraux comprennent souvent plusieurs agences et orga
 
 #: src/app/[lang]/(main)/budget/page.tsx:173
 msgid "Federal Fall 2025 Government Budget"
-msgstr ""
+msgstr "Budget gouvernemental fédéral de l'automne 2025"
 
 #: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:169
 #: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:196
@@ -981,16 +981,16 @@ msgstr "Les dépenses fédérales en matière de sécurité publique fluctuent e
 
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:121
 msgid "Federal Tax"
-msgstr ""
+msgstr "Impôt fédéral"
 
 #: src/hooks/useDepartments.ts:8
 msgid "Finance Canada"
 msgstr "Finance Canada"
 
 #. placeholder {0}: jurisdiction.financialYear
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:344
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:354
 msgid "Financial Position {0}"
-msgstr ""
+msgstr "Situation financière {0}"
 
 #: src/components/Sankey/index.tsx:615
 msgid "First Nations and Inuit Health Infrastructure Support"
@@ -1026,7 +1026,7 @@ msgstr "Par exemple, pendant la pandémie de COVID-19, les programmes de soutien
 
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:285
 msgid "For further breakdowns of spending, see <0>Federal</0> and <1>Provincial</1> spending pages."
-msgstr ""
+msgstr "Pour des répartitions plus détaillées des dépenses, consultez les pages de dépenses <0>fédérales</0> et <1>provinciales</1>."
 
 #: src/app/[lang]/(main)/about/page.tsx:70
 msgid "Frequently Asked Questions"
@@ -1062,14 +1062,14 @@ msgstr "Obtenez des analyses basées sur les données sur la façon dont les rev
 
 #. placeholder {0}: jurisdiction.name
 #. placeholder {1}: jurisdiction.name
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:294
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:304
 msgid "Get data-driven insights into how the {0} government’s revenue and spending affect {1} residents and programs."
-msgstr ""
+msgstr "Obtenez des analyses basées sur les données sur la façon dont les revenus et les dépenses du gouvernement de {0} affectent les résidents et les programmes de {1}."
 
 #: src/components/MainLayout/Footer.tsx:35
 #: src/components/MainLayout/index.tsx:252
 msgid "Get Involved"
-msgstr ""
+msgstr "Impliquez-vous"
 
 #: src/app/[lang]/(main)/page.tsx:42
 #: src/app/[lang]/layout.tsx:23
@@ -1078,7 +1078,7 @@ msgstr "Découvrez les faits sur les dépenses gouvernementales"
 
 #: src/components/MainLayout/Footer.tsx:55
 msgid "Get weekly recaps of current events and updates from our team."
-msgstr ""
+msgstr "Recevez des résumés hebdomadaires des événements actuels et des mises à jour de notre équipe."
 
 #: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:32
@@ -1120,15 +1120,15 @@ msgstr "Explication des ministères gouvernementaux"
 
 #: src/app/[lang]/(main)/budget/page.tsx:288
 msgid "Government Departments Explained"
-msgstr ""
+msgstr "Ministères gouvernementaux expliqués"
 
 #: src/components/Sankey/index.tsx:329
 msgid "Government IT Operations"
 msgstr "Opérations informatiques gouvernementales"
 
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:373
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:383
 msgid "Government organizations"
-msgstr ""
+msgstr "Organisations gouvernementales"
 
 #: src/app/[lang]/(main)/spending/page.tsx:111
 #: src/components/MainLayout/index.tsx:111
@@ -1138,7 +1138,7 @@ msgstr "Dépenses gouvernementales"
 
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:282
 msgid "Government spending is based on 2023-2024 fiscal spending. Attempts have been made to merge similar categories across federal and provincial spending."
-msgstr ""
+msgstr "Les dépenses gouvernementales sont basées sur les dépenses fiscales de 2023-2024. Des tentatives ont été faites pour fusionner des catégories similaires entre les dépenses fédérales et provinciales."
 
 #. js-lingui-explicit-id
 #: src/app/[lang]/(main)/page.tsx:109
@@ -1179,7 +1179,7 @@ msgstr "Santé"
 
 #: src/components/Sankey/BudgetSankey.tsx:400
 msgid "Health agreements with provinces and territories"
-msgstr ""
+msgstr "Accords de santé avec les provinces et les territoires"
 
 #: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:56
@@ -1344,7 +1344,7 @@ msgstr "Immigration, Réfugiés et Citoyenneté Canada | Canada Spends"
 #: src/app/[lang]/(main)/[jurisdiction]/[department]/page.tsx:119
 #: src/app/[lang]/(main)/[jurisdiction]/[department]/page.tsx:126
 msgid "In Financial Year {0},"
-msgstr ""
+msgstr "Au cours de l'exercice financier {0},"
 
 #: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:98
 msgid "In fiscal year (FY) 2024, ISC and CIRNAC collectively spent <0>$63 billion</0>, accounting for <1>12.3% of the total federal budget</1>. The departments play a critical role in addressing socio-economic disparities, facilitating self-governance agreements, and improving service delivery for Indigenous communities across Canada."
@@ -1409,11 +1409,11 @@ msgstr "Au cours de l'exercice 2024, ACC a déclaré des dépenses totales de 6,
 
 #: src/app/[lang]/(main)/articles/page.tsx:42
 msgid "In-depth analysis and insights about Canadian government spending, budget policies, and public finance. Our team at Canada Spends breaks down complex financial data to help you understand how government spending impacts your life."
-msgstr ""
+msgstr "Analyse approfondie et perspectives sur les dépenses gouvernementales canadiennes, les politiques budgétaires et les finances publiques. Notre équipe à Canada Spends décompose les données financières complexes pour vous aider à comprendre comment les dépenses gouvernementales affectent votre vie."
 
 #: src/components/Sankey/BudgetSankey.tsx:479
 msgid "Income Tax Revenues"
-msgstr ""
+msgstr "Revenus de l'impôt sur le revenu"
 
 #: src/app/[lang]/(main)/spending/TenureChart.tsx:8
 msgid "Indeterminate"
@@ -1441,7 +1441,7 @@ msgstr "Bien-être des Autochtones + Autodétermination"
 
 #: src/components/Sankey/BudgetSankey.tsx:482
 msgid "Individual Income Tax"
-msgstr ""
+msgstr "Impôt sur le revenu des particuliers"
 
 #: src/components/Sankey/index.tsx:746
 msgid "Individual Income Taxes"
@@ -1490,7 +1490,7 @@ msgstr "Développement innovant et durable des ressources naturelles"
 
 #: src/app/[lang]/(main)/[jurisdiction]/page.tsx:232
 msgid "Interest on Debt"
-msgstr ""
+msgstr "Intérêts sur la dette"
 
 #: src/components/Sankey/index.tsx:303
 msgid "Interim Housing Assistance"
@@ -1576,13 +1576,13 @@ msgstr "Ententes sur le développement du marché du travail (EDMT) : financemen
 
 #: src/app/[lang]/(main)/budget/page.tsx:275
 msgid "Latest Budget News & Impact"
-msgstr ""
+msgstr "Dernières nouvelles budgétaires et impact"
 
 #. placeholder {0}: jurisdiction.name
 #. placeholder {1}: ["Toronto", "Vancouver"].includes(jurisdiction.name) && ( <Trans>Numbers are reported on an accrual basis.</Trans> )
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:309
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:319
 msgid "Look back at what {0}'s government made and spent. {1}"
-msgstr ""
+msgstr "Regardez en arrière ce que le gouvernement de {0} a gagné et dépensé. {1}"
 
 #: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:147
 msgid "Major international events, trade agreements, foreign aid commitments, and global crises such as the COVID-19 pandemic have influenced fluctuations in spending. In 2020, GAC's budget surged due to emergency international assistance programs, including vaccine distribution and humanitarian relief efforts."
@@ -1637,13 +1637,13 @@ msgstr "TCS Manitoba"
 msgid "Manitoba STP"
 msgstr "TPS Manitoba"
 
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:403
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:413
 msgid "Methodology"
-msgstr ""
+msgstr "Méthodologie"
 
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:369
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:379
 msgid "Ministries + Agencies"
-msgstr ""
+msgstr "Ministères + Organismes"
 
 #: src/components/Sankey/index.tsx:791
 msgid "Miscellaneous revenues"
@@ -1655,7 +1655,7 @@ msgstr "Plus à venir..."
 
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:103
 msgid "More provinces coming soon."
-msgstr ""
+msgstr "Plus de provinces à venir bientôt."
 
 #: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:166
 msgid "Most CRA spending is dedicated to personnel and IT infrastructure supporting tax filing, compliance, and benefit administration."
@@ -1675,7 +1675,7 @@ msgstr "La plupart des dépenses fédérales peuvent être classées comme direc
 #: src/components/MainLayout/index.tsx:164
 #: src/components/MainLayout/index.tsx:335
 msgid "Municipal"
-msgstr ""
+msgstr "Municipal"
 
 #: src/hooks/useDepartments.ts:26
 msgid "National Defence"
@@ -1719,11 +1719,11 @@ msgstr "Pertes actuarielles nettes"
 
 #: src/components/Sankey/BudgetSankey.tsx:448
 msgid "Net actuarial losses (gains)"
-msgstr ""
+msgstr "Pertes actuarielles nettes (gains)"
 
 #: src/app/[lang]/(main)/[jurisdiction]/page.tsx:202
 msgid "Net Debt"
-msgstr ""
+msgstr "Dette nette"
 
 #: src/components/Sankey/index.tsx:779
 msgid "Net Foreign Exchange Revenue"
@@ -1731,7 +1731,7 @@ msgstr "Revenus nets de change"
 
 #: src/components/Sankey/BudgetSankey.tsx:517
 msgid "Net Foreign Exchange Revenue and Return on Investments"
-msgstr ""
+msgstr "Revenus nets de change et rendement des investissements"
 
 #: src/components/Sankey/index.tsx:550
 msgid "Net Interest on Debt"
@@ -1763,11 +1763,11 @@ msgstr "TPS Terre-Neuve-et-Labrador"
 
 #: src/app/[lang]/(main)/budget/page.tsx:57
 msgid "News Source & Date"
-msgstr ""
+msgstr "Source d'actualité et date"
 
 #: src/app/[lang]/(main)/articles/page.tsx:74
 msgid "No articles available yet on Canada Spends. Check back soon!"
-msgstr ""
+msgstr "Aucun article disponible pour le moment sur Canada Spends. Revenez bientôt!"
 
 #: src/app/[lang]/(main)/about/faq.tsx:53
 msgid "No, we are not a lobby group. We are not paid, nor do we represent any special interest groups. Our mission is purely to share data-driven insights on federal government spending."
@@ -1783,7 +1783,7 @@ msgstr "Non partisan"
 
 #: src/components/Sankey/BudgetSankey.tsx:492
 msgid "Non-Resident Income Tax"
-msgstr ""
+msgstr "Impôt sur le revenu des non-résidents"
 
 #: src/components/Sankey/index.tsx:754
 msgid "Non-resident Income Taxes"
@@ -1803,7 +1803,7 @@ msgstr "TPS Territoires du Nord-Ouest"
 
 #: src/app/[lang]/(main)/spending/SalaryDistributionChart.tsx:159
 msgid "Note the different salary ranges prior to 2023. Information for small numbers has been suppressed (values of 0 are actually counts of 1 to 5)."
-msgstr ""
+msgstr "Notez les différentes fourchettes salariales avant 2023. Les informations pour les petits nombres ont été supprimées (les valeurs de 0 représentent en fait des comptes de 1 à 5)."
 
 #: src/components/Sankey/index.tsx:491
 msgid "Nova Scotia EQP"
@@ -1825,9 +1825,9 @@ msgstr "Laboratoires nucléaires + Déclassement"
 msgid "Number of Employees"
 msgstr "Nombre d'employés"
 
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:312
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:322
 msgid "Numbers are reported on an accrual basis."
-msgstr ""
+msgstr "Les chiffres sont rapportés sur une base d'exercice."
 
 #: src/components/Sankey/index.tsx:531
 msgid "Nunavut EQP"
@@ -1849,7 +1849,7 @@ msgstr "Obligations"
 #. placeholder {1}: department.name
 #: src/app/[lang]/(main)/[jurisdiction]/[department]/page.tsx:130
 msgid "of {0} provincial spending was by {1}"
-msgstr ""
+msgstr "des dépenses provinciales de {0} ont été effectuées par {1}"
 
 #: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:91
 msgid "of federal spending was allocated to Indigenous priorities via these Departments. This does not include additional programs in other departments designed specifically for Indigenous beneficiaries."
@@ -1913,7 +1913,7 @@ msgstr "Bureau du secrétaire du gouverneur général"
 
 #: src/app/[lang]/(main)/budget/page.tsx:158
 msgid "Official Fall 2025 Federal Budget Released"
-msgstr ""
+msgstr "Budget fédéral officiel de l'automne 2025 publié"
 
 #: src/components/Sankey/index.tsx:67
 msgid "Official Languages + Culture"
@@ -1925,7 +1925,7 @@ msgstr "Soutien du revenu dans les réserves du Yukon"
 
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:99
 msgid "Ontario"
-msgstr ""
+msgstr "Ontario"
 
 #: src/components/Sankey/index.tsx:503
 msgid "Ontario EQP"
@@ -1941,11 +1941,11 @@ msgstr "TPS Ontario"
 
 #: src/app/[lang]/(main)/budget/page.tsx:222
 msgid "Operational Spend"
-msgstr ""
+msgstr "Dépenses opérationnelles"
 
 #: src/app/[lang]/(main)/about/faq.tsx:90
 msgid "or subscribe to"
-msgstr ""
+msgstr "ou abonnez-vous à"
 
 #: src/app/[lang]/(main)/spending/department-of-finance/MiniSankey.tsx:35
 #: src/components/Sankey/index.tsx:319
@@ -1955,7 +1955,7 @@ msgstr "Autre"
 #. placeholder {0}: jurisdiction.name
 #: src/app/[lang]/(main)/[jurisdiction]/[department]/page.tsx:396
 msgid "Other {0} Government Ministries"
-msgstr ""
+msgstr "Autres ministères du gouvernement de {0}"
 
 #: src/components/Sankey/index.tsx:101
 msgid "Other Boards + Councils"
@@ -1967,7 +1967,7 @@ msgstr "Autre défense"
 
 #: src/components/Sankey/BudgetSankey.tsx:441
 msgid "Other direct program expenses"
-msgstr ""
+msgstr "Autres dépenses directes des programmes"
 
 #: src/components/Sankey/index.tsx:168
 msgid "Other Environment and Climate Change Programs"
@@ -1984,7 +1984,7 @@ msgstr "Autres dépenses"
 
 #: src/components/Sankey/BudgetSankey.tsx:415
 msgid "Other fiscal arrangements"
-msgstr ""
+msgstr "Autres arrangements fiscaux"
 
 #: src/components/Sankey/index.tsx:147
 msgid "Other Fisheries Expenses"
@@ -2016,11 +2016,11 @@ msgstr "Autres revenus non fiscaux"
 
 #: src/components/Sankey/BudgetSankey.tsx:509
 msgid "Other Non-Tax Revenue"
-msgstr ""
+msgstr "Autres revenus non fiscaux"
 
 #: src/components/Sankey/BudgetSankey.tsx:522
 msgid "Other Programs"
-msgstr ""
+msgstr "Autres programmes"
 
 #: src/components/Sankey/index.tsx:278
 msgid "Other Public Safety Expenses"
@@ -2064,7 +2064,7 @@ msgstr "Autres taxes et droits"
 
 #: src/components/Sankey/BudgetSankey.tsx:436
 msgid "Other transfer payments"
-msgstr ""
+msgstr "Autres paiements de transfert"
 
 #: src/app/[lang]/(main)/about/faq.tsx:130
 msgid "Our government is going to have to make hard choices about our nation's spending to ensure we can invest in creating a competitive, resilient, and independent nation. We care about giving Canadians the facts about spending so they can engage in this conversation with elected officials."
@@ -2088,7 +2088,12 @@ msgstr "DPB"
 
 #: src/app/[lang]/(main)/[jurisdiction]/page.tsx:253
 msgid "Per Capita Spending"
-msgstr ""
+msgstr "Dépenses par habitant"
+
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:262
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:287
+msgid "per resident"
+msgstr "par résident"
 
 #: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:147
 msgid "Percentage of federal budget dedicated to Canada Revenue Agency, FYs 1995-2024"
@@ -2132,11 +2137,11 @@ msgstr "Personnel"
 
 #: src/components/Sankey/BudgetSankey.tsx:422
 msgid "Pollution pricing"
-msgstr ""
+msgstr "Tarification de la pollution"
 
 #: src/components/Sankey/BudgetSankey.tsx:504
 msgid "Pollution pricing proceeds"
-msgstr ""
+msgstr "Produits de la tarification de la pollution"
 
 #: src/components/Sankey/index.tsx:623
 msgid "Prevention and Protection Services for Children, Youth, Families and Communities"
@@ -2179,33 +2184,33 @@ msgstr "Services professionnels et spéciaux"
 
 #: src/app/[lang]/(main)/budget/page.tsx:233
 msgid "Projected capital investments"
-msgstr ""
+msgstr "Investissements en capital projetés"
 
 #: src/app/[lang]/(main)/budget/page.tsx:224
 msgid "Projected operational spending"
-msgstr ""
+msgstr "Dépenses opérationnelles projetées"
 
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:273
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:278
 msgid "Property Tax Per Capita"
-msgstr ""
+msgstr "Impôt foncier par habitant"
 
 #. placeholder {0}: jurisdiction.name
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:281
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:291
 msgid "Property tax revenue per {0} resident"
-msgstr ""
+msgstr "Revenus de l'impôt foncier par résident de {0}"
 
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:91
 msgid "Province/Territory"
-msgstr ""
+msgstr "Province/Territoire"
 
 #: src/components/MainLayout/index.tsx:140
 #: src/components/MainLayout/index.tsx:318
 msgid "Provincial"
-msgstr ""
+msgstr "Provincial"
 
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:126
 msgid "Provincial Tax"
-msgstr ""
+msgstr "Impôt provincial"
 
 #: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:91
 msgid "PSPC accounted for 1.6% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
@@ -2217,9 +2222,9 @@ msgstr "SPAC a dépensé 8,3 milliards de dollars au cours de l'exercice 2024. C
 
 #. placeholder {0}: jurisdiction.name
 #. placeholder {1}: jurisdiction.financialYear
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:379
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:389
 msgid "Public Accounts of {0} FY {1}"
-msgstr ""
+msgstr "Comptes publics de {0} exercice {1}"
 
 #: src/app/[lang]/(main)/spending/department-of-finance/MiniSankey.tsx:43
 #: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:59
@@ -2263,9 +2268,9 @@ msgstr "Sécurité publique Canada a dépensé 13,9 milliards de dollars au cour
 msgid "Public Safety, Democratic Institutions and Intergovernmental Affairs Canada (Public Safety Canada) is the federal department responsible for national security, emergency preparedness, and community safety. Established in 2003, it consolidates security, law enforcement, and emergency management functions. It includes the RCMP, CSIS, and CBSA and coordinates federal responses to threats and develops policies on crime prevention, cyber resilience, and disaster preparedness while overseeing intelligence-sharing with domestic and international partners."
 msgstr "Sécurité publique, Institutions démocratiques et Affaires intergouvernementales Canada (Sécurité publique Canada) est le ministère fédéral responsable de la sécurité nationale, de la préparation aux urgences et de la sécurité communautaire. Établi en 2003, il regroupe les fonctions de sécurité, d'application de la loi et de gestion des urgences. Il comprend la GRC, le SCRS et l'ASFC et coordonne les réponses fédérales aux menaces et élabore des politiques sur la prévention du crime, la cyber-résilience et la préparation aux catastrophes tout en supervisant le partage de renseignements avec les partenaires nationaux et internationaux."
 
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:363
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:373
 msgid "Public Service Employees"
-msgstr ""
+msgstr "Employés de la fonction publique"
 
 #: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:68
@@ -2314,7 +2319,7 @@ msgstr "Forces prêtes"
 
 #: src/app/[lang]/(main)/budget/page.tsx:278
 msgid "Recent developments and their projected impact on the Fall 2025 Budget"
-msgstr ""
+msgstr "Développements récents et leur impact projeté sur le budget de l'automne 2025"
 
 #: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:35
 #: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:35
@@ -2380,7 +2385,7 @@ msgstr "Sécurité"
 
 #: src/app/[lang]/(main)/spending/page.tsx:238
 msgid "Salary Distribution"
-msgstr ""
+msgstr "Répartition des salaires"
 
 #: src/app/[lang]/(main)/spending/SalaryDistributionChart.tsx:134
 msgid "Salary Distribution - {selectedYear} ({selectedGroup})"
@@ -2448,21 +2453,21 @@ msgstr "Sécurité sociale"
 msgid "Social Transfer to Provinces"
 msgstr "Transfert social aux provinces"
 
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:327
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:337
 msgid "Source"
-msgstr ""
+msgstr "Source"
 
 #: src/app/[lang]/(main)/spending/page.tsx:251
 msgid "Source:"
-msgstr ""
+msgstr "Source :"
 
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:428
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:438
 #: src/app/[lang]/(main)/budget/page.tsx:294
 #: src/app/[lang]/(main)/spending/page.tsx:266
 msgid "Sources"
 msgstr "Sources"
 
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:377
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:387
 #: src/app/[lang]/(main)/spending/page.tsx:226
 msgid "Sources:"
 msgstr "Sources :"
@@ -2479,7 +2484,7 @@ msgstr "Dépenses"
 #: src/components/MainLayout/index.tsx:218
 #: src/components/MainLayout/index.tsx:370
 msgid "Spending Database"
-msgstr ""
+msgstr "Base de données des dépenses"
 
 #: src/components/Sankey/index.tsx:48
 msgid "Standard of Living"
@@ -2499,7 +2504,7 @@ msgstr "Statistique Canada"
 
 #: src/app/[lang]/(main)/about/faq.tsx:84
 msgid "Stay connected by following us on"
-msgstr ""
+msgstr "Restez connecté en nous suivant sur"
 
 #: src/app/[lang]/(main)/spending/TenureChart.tsx:9
 msgid "Student + Casual"
@@ -2527,7 +2532,7 @@ msgstr "Soutien aux anciens combattants"
 
 #: src/app/[lang]/(main)/[jurisdiction]/page.tsx:152
 msgid "Surplus/Deficit"
-msgstr ""
+msgstr "Excédent/Déficit"
 
 #: src/components/Sankey/index.tsx:567
 msgid "Sustainable Bases, IT Systems, Infrastructure"
@@ -2535,11 +2540,11 @@ msgstr "Bases durables, systèmes TI, infrastructure"
 
 #: src/components/MainLayout/index.tsx:363
 msgid "Tax Calculator"
-msgstr ""
+msgstr "Calculateur d'impôt"
 
 #: src/components/MainLayout/index.tsx:212
 msgid "Tax Visualizer"
-msgstr ""
+msgstr "Visualiseur d'impôt"
 
 #: src/app/[lang]/(main)/spending/TenureChart.tsx:10
 msgid "Term"
@@ -2547,7 +2552,7 @@ msgstr "Durée déterminée"
 
 #: src/components/Sankey/BudgetSankey.tsx:395
 msgid "Territorial Formula Financing"
-msgstr ""
+msgstr "Financement des territoires par formule"
 
 #: src/app/[lang]/(main)/spending/page.tsx:199
 msgid "The average employee is 43.3 years old"
@@ -2699,7 +2704,7 @@ msgstr "Services publics et Approvisionnement Canada (SPAC) est le ministère f�
 
 #: src/app/[lang]/(main)/budget/page.tsx:184
 msgid "The values you see here are based on the FY 2024 Budget with preliminary updates based on government announcements, memos, and leaks, and are meant to provide a rough idea of the budget. Once the official Fall 2025 Budget is released on November 4th, we will update this page to reflect the official budget."
-msgstr ""
+msgstr "Les valeurs que vous voyez ici sont basées sur le budget de l'exercice 2024 avec des mises à jour préliminaires basées sur les annonces gouvernementales, les notes et les fuites, et sont destinées à donner une idée approximative du budget. Une fois le budget officiel de l'automne 2025 publié le 4 novembre, nous mettrons à jour cette page pour refléter le budget officiel."
 
 #: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:222
 #: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:241
@@ -2714,11 +2719,11 @@ msgstr "Ces ministres sont parmi les <0>membres du cabinet</0> qui servent à la
 
 #: src/app/[lang]/(main)/budget/page.tsx:177
 msgid "This page presents the official Fall 2025 Federal Budget as released by the Government of Canada on November 4th, 2025. All data is sourced directly from official government publications and public accounts from the Government of Canada."
-msgstr ""
+msgstr "Cette page présente le budget fédéral officiel de l'automne 2025 tel que publié par le gouvernement du Canada le 4 novembre 2025. Toutes les données proviennent directement des publications officielles du gouvernement et des comptes publics du gouvernement du Canada."
 
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:276
 msgid "This visualization shows how your income tax contributions are allocated across different government programs and services based on current government spending patterns. Amounts under $20 are grouped into \"Other\" for conciseness."
-msgstr ""
+msgstr "Cette visualisation montre comment vos contributions d'impôt sur le revenu sont allouées à différents programmes et services gouvernementaux en fonction des modèles de dépenses gouvernementales actuels. Les montants inférieurs à 20 $ sont regroupés dans \"Autre\" pour plus de concision."
 
 #: src/app/[lang]/(main)/spending/health-canada/page.tsx:61
 msgid "Through the Public Health Agency of Canada (PHAC), Health Canada monitors public health risks, manages disease outbreaks, and promotes health initiatives. It also funds medical research via the Canadian Institutes of Health Research (CIHR) and oversees healthcare services for Indigenous communities."
@@ -2726,15 +2731,15 @@ msgstr "Par l'intermédiaire de l'Agence de la santé publique du Canada (ASPC),
 
 #: src/app/[lang]/(main)/about/faq.tsx:74
 msgid "to help us support our mission."
-msgstr ""
+msgstr "pour nous aider à soutenir notre mission."
 
 #: src/app/[lang]/(main)/budget/page.tsx:202
 msgid "Total Budget"
-msgstr ""
+msgstr "Budget total"
 
 #: src/app/[lang]/(main)/[jurisdiction]/page.tsx:217
 msgid "Total Debt"
-msgstr ""
+msgstr "Dette totale"
 
 #: src/app/[lang]/(main)/spending/page.tsx:162
 msgid "Total full-time equivalents"
@@ -2742,25 +2747,25 @@ msgstr "Équivalents temps plein totaux"
 
 #: src/app/[lang]/(main)/[jurisdiction]/page.tsx:165
 msgid "Total Revenue"
-msgstr ""
+msgstr "Revenus totaux"
 
 #. placeholder {0}: jurisdiction.financialYear
 #: src/app/[lang]/(main)/[jurisdiction]/page.tsx:172
 msgid "Total revenue in {0}"
-msgstr ""
+msgstr "Revenus totaux en {0}"
 
 #: src/app/[lang]/(main)/[jurisdiction]/page.tsx:178
 msgid "Total Spending"
-msgstr ""
+msgstr "Dépenses totales"
 
 #. placeholder {0}: jurisdiction.financialYear
 #: src/app/[lang]/(main)/[jurisdiction]/page.tsx:186
 msgid "Total spending in {0}"
-msgstr ""
+msgstr "Dépenses totales en {0}"
 
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:131
 msgid "Total Tax"
-msgstr ""
+msgstr "Impôt total"
 
 #: src/app/[lang]/(main)/spending/page.tsx:174
 msgid "Total Wages"
@@ -2851,7 +2856,7 @@ msgstr "Type d'emploi"
 
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:273
 msgid "Understanding Your Tax Contribution"
-msgstr ""
+msgstr "Comprendre votre contribution fiscale"
 
 #: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:43
 #: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:43
@@ -2896,9 +2901,9 @@ msgstr "Anciens Combattants Canada | Canada Dépense"
 
 #: src/app/[lang]/(main)/budget/page.tsx:164
 msgid "View Federal 2025 Budget Details"
-msgstr ""
+msgstr "Voir les détails du budget fédéral 2025"
 
-#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:338
+#: src/app/[lang]/(main)/[jurisdiction]/page.tsx:348
 #: src/app/[lang]/(main)/budget/page.tsx:269
 #: src/app/[lang]/(main)/spending/page.tsx:149
 msgid "View this chart in full screen"
@@ -2911,7 +2916,7 @@ msgstr "Visiteurs, étudiants internationaux + travailleurs temporaires"
 #. placeholder {0}: department.name
 #: src/app/[lang]/(main)/[jurisdiction]/[department]/page.tsx:122
 msgid "was spent by {0}"
-msgstr ""
+msgstr "a été dépensé par {0}"
 
 #: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:75
 msgid "was spent by ESDC"
@@ -2995,7 +3000,7 @@ msgstr "Nous transformons des données gouvernementales complexes en information
 
 #: src/app/[lang]/(main)/about/faq.tsx:102
 msgid "We welcome passionate individuals who want to help make a difference. Whether it's by contributing your skills, helping with outreach, or amplifying our work, we'd love to hear from you"
-msgstr ""
+msgstr "Nous accueillons des personnes passionnées qui veulent faire une différence. Que ce soit en contribuant vos compétences, en aidant avec la sensibilisation ou en amplifiant notre travail, nous aimerions avoir de vos nouvelles"
 
 #: src/app/[lang]/(main)/about/faq.tsx:41
 msgid "We were frustrated by the lack of clear, accessible, unbiased data on government spending. We wanted to create a platform that focused on giving Canadians data-driven facts about how their money is being spent without spin."
@@ -3040,7 +3045,7 @@ msgstr "D'où proviennent les données sur votre site web?"
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:245
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:267
 msgid "Where Your Tax Dollars Go"
-msgstr ""
+msgstr "Où vont vos dollars d'impôt"
 
 #: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:139
 msgid "While GAC's spending has increased in real terms, its share of the federal budget has also increased moderately over the past decades. In 2024, GAC accounted for 3.7% of federal spending, compared to 2% in 1995."
@@ -3112,7 +3117,7 @@ msgstr "Vous méritez les faits"
 
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:279
 msgid "Your tax contributions are approximated based on employment income. Deductions such as basic personal amount are estimated and included. Other sources of income, such as self-employment, investment income, and capital gains, are not included in the calculations. Deductions such as RRSP and FHSA contributions are also not included. Tax calculations are based on 2024 federal and provincial tax brackets."
-msgstr ""
+msgstr "Vos contributions fiscales sont approximatives et basées sur le revenu d'emploi. Les déductions telles que le montant personnel de base sont estimées et incluses. D'autres sources de revenus, telles que le travail autonome, les revenus de placement et les gains en capital, ne sont pas incluses dans les calculs. Les déductions telles que les cotisations REER et CELIAPP ne sont également pas incluses. Les calculs d'impôt sont basés sur les tranches d'imposition fédérales et provinciales de 2024."
 
 #: src/components/Sankey/index.tsx:523
 msgid "Yukon EQP"


### PR DESCRIPTION
## Complete French Translation Coverage

Still some text on our pages not yet captured in translation, but this gets us much closer to parity.

### Primary Changes
- **Completed all 133 missing French translations**: Filled in all empty `msgstr` entries in `fr.po` with proper French translations
- **Added translation support for "per resident"**: Replaced hardcoded English text with `<Trans>` components in jurisdiction page stat values
- **Fixed translation matching issue**: Corrected apostrophe character mismatch in French `.po` file to ensure proper translation lookup

### Translation Coverage
- All previously untranslated strings in `fr.po` now have complete French translations
- Includes translations for UI elements, budget terms, government department names, and descriptive content

### Technical Details
- Updated `src/app/[lang]/(main)/[jurisdiction]/page.tsx` to use React fragments with Trans components for stat values
- Added "per resident" / "par résident" translations to both `en.po` and `fr.po` files
- Fixed msgid matching by ensuring French `.po` uses the same curly apostrophe character as the English source

### Testing
| English | French |
|--------|--------|
| <img width="400px" alt="image" src="https://github.com/user-attachments/assets/1bfefb38-75a3-4c51-9d3c-a25da67ba361" /> | <img width="400px" alt="image" src="https://github.com/user-attachments/assets/fe32effc-6971-48f5-b94f-61b2a6a49474" /> |
| <img width="400px" alt="image" src="https://github.com/user-attachments/assets/2b37ff2c-be6d-4b5e-8c1e-9c5a6433956a" /> | <img width="400px" alt="image" src="https://github.com/user-attachments/assets/ec21ce6e-b198-49b4-9b6f-c0c769884bbf" /> |
| <img width="400px" alt="image" src="https://github.com/user-attachments/assets/c260a657-4570-41c3-9daa-5825b78dbd14" /> | <img width="400px" alt="image" src="https://github.com/user-attachments/assets/5164806f-4a6c-4fc1-b8d7-cce822b8f5ff" /> |
