### PR TITLE
Add sub-band and self-governed status display in First Nations table

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -48,6 +48,16 @@ const nextConfig: NextConfig = {
         destination: "/:locale/tax-visualizer",
         permanent: true,
       },
+      {
+        source: "/:locale/first_nations",
+        destination: "/:locale/first-nations",
+        permanent: true,
+      },
+      {
+        source: "/:locale/first_nations/:path*",
+        destination: "/:locale/first-nations/:path*",
+        permanent: true,
+      },
     ];
 
     // ========================================================================

--- a/src/components/first-nations/FinancialPositionStats.tsx
+++ b/src/components/first-nations/FinancialPositionStats.tsx
@@ -122,8 +122,7 @@ export function FinancialPositionStats({
 
   const totalLiabilities = findLineItem(
     (item) =>
-      item.is_subtotal &&
-      item.name?.toLowerCase().includes("total financial liabilities"),
+      item.is_subtotal && item.name?.toLowerCase() === "total liabilities",
   );
 
   const netDebt = findLineItem((item) =>
@@ -143,7 +142,15 @@ export function FinancialPositionStats({
   const accumulatedSurplus = findLineItem(
     (item) =>
       item.name?.toLowerCase().includes("accumulated surplus") &&
-      !item.is_total,
+      item.is_total &&
+      item.major_category === "net_assets",
+  );
+
+  const tangibleCapitalAssets = findLineItem(
+    (item) =>
+      item.name?.toLowerCase().includes("tangible capital assets") &&
+      !item.is_total &&
+      !item.is_subtotal,
   );
 
   const stats: {
@@ -269,6 +276,29 @@ export function FinancialPositionStats({
       ),
       value: formatCurrency(getValue(netAssets.values, fullYear)),
       description: <Trans>Total net assets</Trans>,
+    });
+  }
+
+  if (tangibleCapitalAssets) {
+    stats.push({
+      key: "tangible-capital-assets",
+      title: (
+        <div className="flex items-center">
+          <Trans>Tangible Capital Assets</Trans>
+          <Tooltip
+            text={
+              <Trans>
+                Land, buildings, equipment, vehicles, and infrastructure owned
+                by the First Nation.
+              </Trans>
+            }
+          >
+            <HelpIcon />
+          </Tooltip>
+        </div>
+      ),
+      value: formatCurrency(getValue(tangibleCapitalAssets.values, fullYear)),
+      description: <Trans>As of fiscal year end {fiscalYear}</Trans>,
     });
   }
 

--- a/src/components/first-nations/FirstNationsPageContent.tsx
+++ b/src/components/first-nations/FirstNationsPageContent.tsx
@@ -17,6 +17,8 @@ import { ClaimsTable } from "./ClaimsTable";
 import { FinancialPositionStats } from "./FinancialPositionStats";
 import { FirstNationsNotes } from "./FirstNationsNotes";
 import { FirstNationsYearSelector } from "./FirstNationsYearSelector";
+// TODO: Re-enable when @buildcanada/charts library is fixed
+// import { PopulationCharts } from "./PopulationCharts";
 import { RemunerationTable } from "./RemunerationTable";
 import {
   FullReportLink,
@@ -92,6 +94,27 @@ function formatFiscalYear(year: string): string {
   // Fiscal year ends in March, so FY 2024 = April 2023 - March 2024
   const startYear = yearNum - 1;
   return `${startYear}-${String(yearNum).slice(-2)}`;
+}
+
+const PROVINCE_NAMES: Record<string, string> = {
+  AB: "Alberta",
+  BC: "British Columbia",
+  MB: "Manitoba",
+  NB: "New Brunswick",
+  NL: "Newfoundland and Labrador",
+  NS: "Nova Scotia",
+  NT: "Northwest Territories",
+  NU: "Nunavut",
+  ON: "Ontario",
+  PE: "Prince Edward Island",
+  QC: "Quebec",
+  SK: "Saskatchewan",
+  YT: "Yukon",
+};
+
+function getProvinceName(code?: string): string {
+  if (!code) return "Canada";
+  return PROVINCE_NAMES[code.toUpperCase()] || code;
 }
 
 function formatCurrency(value: number): string {
@@ -262,6 +285,18 @@ export function FirstNationsPageContent({
           <Intro>
             <Trans>
               Financial data for {firstNation.name} for fiscal year {fiscalYear}
+              . {firstNation.name} is a First Nation in{" "}
+              {getProvinceName(firstNation.province)}
+              {firstNation.populationRegistered != null &&
+                firstNation.populationOnReserve != null && (
+                  <>
+                    {" "}
+                    with a registered population of{" "}
+                    {firstNation.populationRegistered.toLocaleString()} and an
+                    on-reserve population of{" "}
+                    {firstNation.populationOnReserve.toLocaleString()}
+                  </>
+                )}
               . Information is extracted from publicly available annual reports
               published under the First Nations Financial Transparency Act.
             </Trans>

--- a/src/components/first-nations/FirstNationsSearch.tsx
+++ b/src/components/first-nations/FirstNationsSearch.tsx
@@ -251,7 +251,7 @@ export function FirstNationsSearch({
             ref={tableContainerRef}
             className="relative w-screen -ml-[50vw] left-1/2 right-1/2 overflow-auto border-y border-gray-200 flex justify-center"
           >
-            <table className="divide-y divide-gray-200">
+            <table className="divide-y divide-gray-200 table-fixed">
               <thead className="bg-gray-50 sticky top-0 z-20 shadow-sm">
                 <tr>
                   <th
@@ -270,7 +270,7 @@ export function FirstNationsSearch({
                     <th
                       key={year}
                       scope="col"
-                      className="px-3 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider min-w-[80px]"
+                      className="px-3 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider w-[80px]"
                     >
                       {formatFiscalYearShort(year)}
                     </th>

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -8,6 +8,11 @@ export interface ExtractionAvailabilityResponse {
   province: string;
   fiscal_years: number[];
   chunk_types_by_year: Record<string, string[]>;
+  membership_authority?: string;
+  is_sub_band?: boolean;
+  is_self_governed?: boolean;
+  parent_band_bcid?: string;
+  parent_band_name?: string;
 }
 
 // Internal type used by components
@@ -19,6 +24,12 @@ export interface FirstNationInfo {
   availableChunkTypes: Record<string, string[]>; // year -> chunk_types
   populationYear?: number;
   populationOnReserve?: number;
+  populationRegistered?: number;
+  membershipAuthority?: string;
+  isSubBand?: boolean;
+  isSelfGoverned?: boolean;
+  parentBandBcid?: string;
+  parentBandName?: string;
 }
 
 // Population API response types

--- a/src/locales/en.po
+++ b/src/locales/en.po
@@ -218,11 +218,11 @@ msgstr "About Us"
 msgid "Above {0}"
 msgstr "Above {0}"
 
-#: src/components/first-nations/FinancialPositionStats.tsx:182
+#: src/components/first-nations/FinancialPositionStats.tsx:194
 msgid "Accounts payable, long-term debt, and other obligations owed to external parties."
 msgstr "Accounts payable, long-term debt, and other obligations owed to external parties."
 
-#: src/components/first-nations/FinancialPositionStats.tsx:275
+#: src/components/first-nations/FinancialPositionStats.tsx:310
 msgid "Accumulated Surplus"
 msgstr "Accumulated Surplus"
 
@@ -304,7 +304,7 @@ msgstr "All Articles"
 msgid "All data presented regarding government spending is sourced directly from official government databases. Unless otherwise noted, we have used <0>Public Accounts of Canada</0> data as the primary data source. While we strive to provide accurate, up-to-date information, we cannot guarantee the data's completeness, reliability, or timeliness. We assume no responsibility for any errors, omissions, or outcomes resulting from the use of this information. Please consult the original government sources for official and verified data."
 msgstr "All data presented regarding government spending is sourced directly from official government databases. Unless otherwise noted, we have used <0>Public Accounts of Canada</0> data as the primary data source. While we strive to provide accurate, up-to-date information, we cannot guarantee the data's completeness, reliability, or timeliness. We assume no responsibility for any errors, omissions, or outcomes resulting from the use of this information. Please consult the original government sources for official and verified data."
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:245
+#: src/components/first-nations/FirstNationsPageContent.tsx:264
 msgid "All expenses incurred during the fiscal year including program delivery, administration, and capital costs."
 msgstr "All expenses incurred during the fiscal year including program delivery, administration, and capital costs."
 
@@ -331,11 +331,11 @@ msgstr "All program and operating spending recorded for the fiscal year."
 msgid "All revenue collected during the fiscal year, including taxes, transfers, and other sources."
 msgstr "All revenue collected during the fiscal year, including taxes, transfers, and other sources."
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:225
+#: src/components/first-nations/FirstNationsPageContent.tsx:244
 msgid "All revenue collected during the fiscal year, including transfers, own-source revenue, and other funding."
 msgstr "All revenue collected during the fiscal year, including transfers, own-source revenue, and other funding."
 
-#: src/app/[lang]/(main)/page.tsx:154
+#: src/app/[lang]/(main)/page.tsx:146
 msgid "All the information comes from public databases and reports by the Government of Canada. We show our sources, so you know exactly where it comes from."
 msgstr "All the information comes from public databases and reports by the Government of Canada. We show our sources, so you know exactly where it comes from."
 
@@ -402,13 +402,14 @@ msgstr "Articles | Canada Spends"
 msgid "As of fiscal year end {0}"
 msgstr "As of fiscal year end {0}"
 
-#: src/components/first-nations/FinancialPositionStats.tsx:170
-#: src/components/first-nations/FinancialPositionStats.tsx:193
-#: src/components/first-nations/FinancialPositionStats.tsx:243
+#: src/components/first-nations/FinancialPositionStats.tsx:182
+#: src/components/first-nations/FinancialPositionStats.tsx:205
+#: src/components/first-nations/FinancialPositionStats.tsx:255
+#: src/components/first-nations/FinancialPositionStats.tsx:301
 msgid "As of fiscal year end {fiscalYear}"
 msgstr "As of fiscal year end {fiscalYear}"
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:342
+#: src/components/first-nations/FirstNationsPageContent.tsx:373
 msgid "Assets, liabilities, and net financial position as of the end of fiscal year {fiscalYear}."
 msgstr "Assets, liabilities, and net financial position as of the end of fiscal year {fiscalYear}."
 
@@ -430,7 +431,7 @@ msgstr "Back to All Articles"
 msgid "Balance for {0}"
 msgstr "Balance for {0}"
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:216
+#: src/components/first-nations/FirstNationsPageContent.tsx:235
 msgid "Balance for FY {fiscalYear}"
 msgstr "Balance for FY {fiscalYear}"
 
@@ -438,7 +439,7 @@ msgstr "Balance for FY {fiscalYear}"
 msgid "Banking + Finance"
 msgstr "Banking + Finance"
 
-#: src/app/[lang]/(main)/page.tsx:151
+#: src/app/[lang]/(main)/page.tsx:143
 msgid "Based on Data"
 msgstr "Based on Data"
 
@@ -526,7 +527,7 @@ msgid "Canada social transfer"
 msgstr "Canada social transfer"
 
 #. js-lingui-explicit-id
-#: src/app/[lang]/(main)/page.tsx:118
+#: src/app/[lang]/(main)/page.tsx:110
 msgid "facts-2"
 msgstr "Canada Spends changes this. We take raw federal spending data and turn it into accurate, straightforward facts so you can understand how your money is used."
 
@@ -583,7 +584,7 @@ msgstr "Carbon Tax Rebate"
 msgid "Carbon Taxes"
 msgstr "Carbon Taxes"
 
-#: src/components/first-nations/FinancialPositionStats.tsx:159
+#: src/components/first-nations/FinancialPositionStats.tsx:171
 msgid "Cash, investments, accounts receivable, and other assets that can be converted to cash."
 msgstr "Cash, investments, accounts receivable, and other assets that can be converted to cash."
 
@@ -665,10 +666,6 @@ msgstr "Connect with us"
 #: src/components/MainLayout/Footer.tsx:54
 msgid "Contact"
 msgstr "Contact"
-
-#: src/components/first-nations/RemunerationTable.tsx:77
-msgid "Contract"
-msgstr "Contract"
 
 #: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:253
 msgid "Contributing Organization"
@@ -1034,26 +1031,30 @@ msgstr "Executing Agency/Partner"
 msgid "Expected Results"
 msgstr "Expected Results"
 
-#: src/app/[lang]/(main)/page.tsx:70
-msgid "Explore Budget 2025"
-msgstr "Explore Budget 2025"
+#: src/components/first-nations/RemunerationTable.tsx:259
+msgid "Expenses"
+msgstr "Expenses"
 
 #: src/app/[lang]/(main)/federal/budget/layout.tsx:17
 msgid "Explore Canada's federal budget with interactive visualizations and detailed analysis of government revenue and expenditures."
 msgstr "Explore Canada's federal budget with interactive visualizations and detailed analysis of government revenue and expenditures."
-
-#: src/app/[lang]/(main)/page.tsx:72
-msgid "Explore federal data"
-msgstr "Explore federal data"
 
 #: src/app/[lang]/(main)/federal/spending/page.tsx:250
 #: src/app/[lang]/(main)/spending/page.tsx:241
 msgid "Explore federal employee salary distribution by year and demographic group"
 msgstr "Explore federal employee salary distribution by year and demographic group"
 
-#: src/app/[lang]/(main)/first-nations/page.tsx:33
+#: src/app/[lang]/(main)/page.tsx:65
+msgid "Explore Federal Spending"
+msgstr "Explore Federal Spending"
+
+#: src/app/[lang]/(main)/first-nations/page.tsx:36
 msgid "Explore financial data from First Nations across Canada. Data is extracted from annual reports published under the First Nations Financial Transparency Act (FNFTA), including statements of operations, financial position, and remuneration."
 msgstr "Explore financial data from First Nations across Canada. Data is extracted from annual reports published under the First Nations Financial Transparency Act (FNFTA), including statements of operations, financial position, and remuneration."
+
+#: src/app/[lang]/(main)/page.tsx:75
+msgid "Explore First Nations"
+msgstr "Explore First Nations"
 
 #: src/app/[lang]/(main)/federal/spending/layout.tsx:17
 msgid "Explore how the Canadian federal government spends your tax dollars across departments and programs."
@@ -1062,10 +1063,6 @@ msgstr "Explore how the Canadian federal government spends your tax dollars acro
 #: src/app/[lang]/(main)/articles/page.tsx:19
 msgid "Explore in-depth articles about Canadian government spending, budget analysis, and public finance. Stay informed about how your tax dollars are used through Canada Spends."
 msgstr "Explore in-depth articles about Canadian government spending, budget analysis, and public finance. Stay informed about how your tax dollars are used through Canada Spends."
-
-#: src/app/[lang]/(main)/page.tsx:83
-msgid "Explore Ontario data"
-msgstr "Explore Ontario data"
 
 #: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:239
 #: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:230
@@ -1106,7 +1103,7 @@ msgstr "External ID"
 msgid "External Revenues"
 msgstr "External Revenues"
 
-#: src/app/[lang]/(main)/page.tsx:136
+#: src/app/[lang]/(main)/page.tsx:128
 msgid "Facts about Spending"
 msgstr "Facts about Spending"
 
@@ -1271,23 +1268,26 @@ msgid "Finance Type"
 msgstr "Finance Type"
 
 #. placeholder {0}: firstNation.name
-#: src/components/first-nations/FirstNationsPageContent.tsx:267
-msgid "Financial data for {0} for fiscal year {fiscalYear}. Information is extracted from publicly available annual reports published under the First Nations Financial Transparency Act."
-msgstr "Financial data for {0} for fiscal year {fiscalYear}. Information is extracted from publicly available annual reports published under the First Nations Financial Transparency Act."
+#. placeholder {1}: firstNation.name
+#. placeholder {2}: getProvinceName(firstNation.province)
+#. placeholder {3}: firstNation.populationRegistered != null && firstNation.populationOnReserve != null && ( <> {" "} with a registered population of{" "} {firstNation.populationRegistered.toLocaleString()} and an on-reserve population of{" "} {firstNation.populationOnReserve.toLocaleString()} </> )
+#: src/components/first-nations/FirstNationsPageContent.tsx:286
+msgid "Financial data for {0} for fiscal year {fiscalYear}. {1} is a First Nation in {2}{3}. Information is extracted from publicly available annual reports published under the First Nations Financial Transparency Act."
+msgstr "Financial data for {0} for fiscal year {fiscalYear}. {1} is a First Nation in {2}{3}. Information is extracted from publicly available annual reports published under the First Nations Financial Transparency Act."
 
 #: src/app/[lang]/(main)/first-nations/[bcid]/page.tsx:72
 msgid "Financial data from annual reports published under the First Nations Financial Transparency Act will appear here once available."
 msgstr "Financial data from annual reports published under the First Nations Financial Transparency Act will appear here once available."
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:458
+#: src/components/first-nations/FirstNationsPageContent.tsx:476
 msgid "Financial data is sourced from annual reports published under the First Nations Financial Transparency Act (FNFTA). Data is extracted using automated processes and may contain errors. If you notice any issues, please contact us."
 msgstr "Financial data is sourced from annual reports published under the First Nations Financial Transparency Act (FNFTA). Data is extracted using automated processes and may contain errors. If you notice any issues, please contact us."
 
-#: src/components/first-nations/FinancialPositionStats.tsx:220
+#: src/components/first-nations/FinancialPositionStats.tsx:232
 msgid "Financial liabilities less financial assets"
 msgstr "Financial liabilities less financial assets"
 
-#: src/components/first-nations/FinancialPositionStats.tsx:206
+#: src/components/first-nations/FinancialPositionStats.tsx:218
 msgid "Financial liabilities minus financial assets. A negative value indicates net financial assets."
 msgstr "Financial liabilities minus financial assets. A negative value indicates net financial assets."
 
@@ -1296,7 +1296,7 @@ msgstr "Financial liabilities minus financial assets. A negative value indicates
 msgid "Financial Position {0}"
 msgstr "Financial Position {0}"
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:312
+#: src/components/first-nations/FirstNationsPageContent.tsx:343
 msgid "Financial Summary FY {fiscalYear}"
 msgstr "Financial Summary FY {fiscalYear}"
 
@@ -1325,7 +1325,7 @@ msgstr "First Nations and Inuit Primary Health Care"
 msgid "First Nations Elementary and Secondary Educational Advancement"
 msgstr "First Nations Elementary and Secondary Educational Advancement"
 
-#: src/app/[lang]/(main)/first-nations/page.tsx:30
+#: src/app/[lang]/(main)/first-nations/page.tsx:33
 msgid "First Nations Financial Data"
 msgstr "First Nations Financial Data"
 
@@ -1416,7 +1416,7 @@ msgstr "Get data-driven insights into how the {0} government’s revenue and spe
 msgid "Get Involved"
 msgstr "Get Involved"
 
-#: src/app/[lang]/(main)/page.tsx:42
+#: src/app/[lang]/(main)/page.tsx:41
 #: src/app/[lang]/layout.tsx:22
 msgid "Get The Facts About Government Spending"
 msgstr "Get The Facts About Government Spending"
@@ -1493,7 +1493,7 @@ msgid "Government spending is based on 2023-2024 fiscal spending. Attempts have 
 msgstr "Government spending is based on 2023-2024 fiscal spending. Attempts have been made to merge similar categories across federal and provincial spending."
 
 #. js-lingui-explicit-id
-#: src/app/[lang]/(main)/page.tsx:109
+#: src/app/[lang]/(main)/page.tsx:101
 msgid "facts-1"
 msgstr "Government spending shouldn’t be a black box. Every year, the federal government spends hundreds of billions of dollars but most Canadians have no clue where it all goes. The data is available, but it’s buried on obscure websites and impossible to navigate."
 
@@ -1509,6 +1509,10 @@ msgstr "Government Workforce"
 #: src/app/[lang]/(main)/spending/layout.tsx:16
 msgid "Government Workforce & Spending Data | See the Breakdown"
 msgstr "Government Workforce & Spending Data | See the Breakdown"
+
+#: src/components/first-nations/RemunerationTable.tsx:285
+msgid "Grand Total"
+msgstr "Grand Total"
 
 #: src/components/Sankey/index.tsx:599
 msgid "Grants to Support the New Fiscal Relationship with First Nations"
@@ -1594,13 +1598,9 @@ msgid "HICC spent $14.5 billion in fiscal year (FY) 2024. This was 2.8% of the $
 msgstr "HICC spent $14.5 billion in fiscal year (FY) 2024. This was 2.8% of the $513.9 billion in overall federal spending. The department ranked eighth among federal departments in total spending."
 
 #. placeholder {0}: firstNation.name
-#: src/components/first-nations/FirstNationsPageContent.tsx:390
+#: src/components/first-nations/FirstNationsPageContent.tsx:408
 msgid "Historical and ongoing land claims involving {0}."
 msgstr "Historical and ongoing land claims involving {0}."
-
-#: src/components/first-nations/RemunerationTable.tsx:69
-msgid "Honorarium"
-msgstr "Honorarium"
 
 #: src/components/Sankey/index.tsx:59
 msgid "Housing Assistance"
@@ -1977,9 +1977,13 @@ msgstr "Keywords"
 msgid "Labour Market Development Agreements (LMDAs): federal funding to provinces for job training and employment support."
 msgstr "Labour Market Development Agreements (LMDAs): federal funding to provinces for job training and employment support."
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:377
+#: src/components/first-nations/FirstNationsPageContent.tsx:395
 msgid "Land Claims"
 msgstr "Land Claims"
+
+#: src/components/first-nations/FinancialPositionStats.tsx:290
+msgid "Land, buildings, equipment, vehicles, and infrastructure owned by the First Nation."
+msgstr "Land, buildings, equipment, vehicles, and infrastructure owned by the First Nation."
 
 #: src/components/first-nations/ClaimsTable.tsx:142
 msgid "Last Update"
@@ -2077,6 +2081,10 @@ msgstr "Ministry"
 msgid "Miscellaneous revenues"
 msgstr "Miscellaneous revenues"
 
+#: src/components/first-nations/RemunerationTable.tsx:122
+msgid "Months"
+msgstr "Months"
+
 #: src/components/DepartmentList.tsx:45
 msgid "More coming soon..."
 msgstr "More coming soon..."
@@ -2101,7 +2109,7 @@ msgstr "Most federal spending can be categorized as direct or indirect. Direct s
 msgid "Municipal"
 msgstr "Municipal"
 
-#: src/components/first-nations/RemunerationTable.tsx:54
+#: src/components/first-nations/RemunerationTable.tsx:114
 msgid "Name"
 msgstr "Name"
 
@@ -2149,11 +2157,11 @@ msgstr "Net actuarial losses"
 msgid "Net actuarial losses (gains)"
 msgstr "Net actuarial losses (gains)"
 
-#: src/components/first-nations/FinancialPositionStats.tsx:252
+#: src/components/first-nations/FinancialPositionStats.tsx:264
 msgid "Net Assets"
 msgstr "Net Assets"
 
-#: src/components/first-nations/FinancialPositionStats.tsx:203
+#: src/components/first-nations/FinancialPositionStats.tsx:215
 #: src/components/JurisdictionPageContent.tsx:210
 msgid "Net Debt"
 msgstr "Net Debt"
@@ -2216,7 +2224,7 @@ msgstr "No content available."
 msgid "No financial data is currently available for {0}."
 msgstr "No financial data is currently available for {0}."
 
-#: src/components/first-nations/FinancialPositionStats.tsx:295
+#: src/components/first-nations/FinancialPositionStats.tsx:330
 msgid "No financial position data available."
 msgstr "No financial position data available."
 
@@ -2232,7 +2240,7 @@ msgstr "No form of electronic communication can be made 100% secure. While we ta
 msgid "No notes available."
 msgstr "No notes available."
 
-#: src/components/first-nations/RemunerationTable.tsx:26
+#: src/components/first-nations/RemunerationTable.tsx:60
 msgid "No remuneration data available."
 msgstr "No remuneration data available."
 
@@ -2244,11 +2252,11 @@ msgstr "No, we are not a lobby group. We are not paid, nor do we represent any s
 msgid "No, we're not copying the DOGE playbook from the US."
 msgstr "No, we're not copying the DOGE playbook from the US."
 
-#: src/components/first-nations/FinancialPositionStats.tsx:229
+#: src/components/first-nations/FinancialPositionStats.tsx:241
 msgid "Non-Financial Assets"
 msgstr "Non-Financial Assets"
 
-#: src/app/[lang]/(main)/page.tsx:166
+#: src/app/[lang]/(main)/page.tsx:158
 msgid "Non-Partisan"
 msgstr "Non-Partisan"
 
@@ -2276,7 +2284,7 @@ msgstr "Northwest Territories STP"
 msgid "Note the different salary ranges prior to 2023. Information for small numbers has been suppressed (values of 0 are actually counts of 1 to 5)."
 msgstr "Note the different salary ranges prior to 2023. Information for small numbers has been suppressed (values of 0 are actually counts of 1 to 5)."
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:436
+#: src/components/first-nations/FirstNationsPageContent.tsx:454
 msgid "Notes to Financial Statements"
 msgstr "Notes to Financial Statements"
 
@@ -2647,22 +2655,18 @@ msgstr "Pollution pricing"
 msgid "Pollution pricing proceeds"
 msgstr "Pollution pricing proceeds"
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:363
-msgid "Population Trends"
-msgstr "Population Trends"
-
 #. placeholder {0}: populationData[0]?.year
 #. placeholder {1}: populationData[populationData.length - 1]?.year
-#: src/components/first-nations/PopulationCharts.tsx:124
+#: src/components/first-nations/PopulationCharts.tsx:125
 msgid "Population trends for {bandName} from {0} to {1}."
 msgstr "Population trends for {bandName} from {0} to {1}."
 
-#: src/components/first-nations/RemunerationTable.tsx:48
+#: src/components/first-nations/RemunerationTable.tsx:107
 msgid "Position"
 msgstr "Position"
 
 #. placeholder {0}: data.auditor_name
-#: src/components/first-nations/RemunerationTable.tsx:142
+#: src/components/first-nations/RemunerationTable.tsx:305
 msgid "Prepared by: {0}"
 msgstr "Prepared by: {0}"
 
@@ -2901,7 +2905,11 @@ msgstr "Recipient Class"
 msgid "Regions"
 msgstr "Regions"
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:405
+#: src/components/first-nations/RemunerationTable.tsx:233
+msgid "Remuneration"
+msgstr "Remuneration"
+
+#: src/components/first-nations/FirstNationsPageContent.tsx:423
 msgid "Remuneration and Expenses"
 msgstr "Remuneration and Expenses"
 
@@ -2973,7 +2981,7 @@ msgstr "Return on Investments"
 msgid "Revenue"
 msgstr "Revenue"
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:281
+#: src/components/first-nations/FirstNationsPageContent.tsx:312
 msgid "Revenue and Expenses FY {fiscalYear}"
 msgstr "Revenue and Expenses FY {fiscalYear}"
 
@@ -2985,13 +2993,9 @@ msgstr "Revenue Canada"
 msgid "Safety"
 msgstr "Safety"
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:417
+#: src/components/first-nations/FirstNationsPageContent.tsx:435
 msgid "Salaries, honoraria, travel, and other expenses paid to elected officials and senior employees during fiscal year {fiscalYear}."
 msgstr "Salaries, honoraria, travel, and other expenses paid to elected officials and senior employees during fiscal year {fiscalYear}."
-
-#: src/components/first-nations/RemunerationTable.tsx:61
-msgid "Salary"
-msgstr "Salary"
 
 #: src/app/[lang]/(main)/federal/spending/page.tsx:247
 #: src/app/[lang]/(main)/spending/page.tsx:238
@@ -3107,7 +3111,7 @@ msgstr "Source:"
 #: src/app/[lang]/(main)/federal/budget/page.tsx:304
 #: src/app/[lang]/(main)/federal/spending/page.tsx:275
 #: src/app/[lang]/(main)/spending/page.tsx:266
-#: src/components/first-nations/FirstNationsPageContent.tsx:455
+#: src/components/first-nations/FirstNationsPageContent.tsx:473
 #: src/components/JurisdictionPageContent.tsx:504
 msgid "Sources"
 msgstr "Sources"
@@ -3157,11 +3161,11 @@ msgstr "Standard of Living and Assistance to Address Inequalities"
 msgid "Start Date"
 msgstr "Start Date"
 
-#: src/app/[lang]/(main)/page.tsx:94
+#: src/app/[lang]/(main)/page.tsx:86
 msgid "Start reading"
 msgstr "Start reading"
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:332
+#: src/components/first-nations/FirstNationsPageContent.tsx:363
 msgid "Statement of Financial Position"
 msgstr "Statement of Financial Position"
 
@@ -3194,6 +3198,14 @@ msgstr "Submit anonymous tips securely using our encrypted whistleblower platfor
 msgid "Subscribe to our newsletter"
 msgstr "Subscribe to our newsletter"
 
+#: src/components/first-nations/RemunerationTable.tsx:270
+msgid "Subtotal - Expenses"
+msgstr "Subtotal - Expenses"
+
+#: src/components/first-nations/RemunerationTable.tsx:244
+msgid "Subtotal - Remuneration"
+msgstr "Subtotal - Remuneration"
+
 #: src/app/[lang]/(main)/search/[database]/[id]/DetailsPage.tsx:71
 msgid "Summary"
 msgstr "Summary"
@@ -3214,7 +3226,7 @@ msgstr "Support for Global Competition"
 msgid "Support for Veterans"
 msgstr "Support for Veterans"
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:202
+#: src/components/first-nations/FirstNationsPageContent.tsx:221
 #: src/components/JurisdictionPageContent.tsx:140
 msgid "Surplus/Deficit"
 msgstr "Surplus/Deficit"
@@ -3223,7 +3235,11 @@ msgstr "Surplus/Deficit"
 msgid "Sustainable Bases, IT Systems, Infrastructure"
 msgstr "Sustainable Bases, IT Systems, Infrastructure"
 
-#: src/components/first-nations/FinancialPositionStats.tsx:232
+#: src/components/first-nations/FinancialPositionStats.tsx:287
+msgid "Tangible Capital Assets"
+msgstr "Tangible Capital Assets"
+
+#: src/components/first-nations/FinancialPositionStats.tsx:244
 msgid "Tangible capital assets such as land, buildings, equipment, and infrastructure."
 msgstr "Tangible capital assets such as land, buildings, equipment, and infrastructure."
 
@@ -3298,7 +3314,7 @@ msgstr "The Canada Revenue Agency spent $16.8 billion in fiscal year (FY) 2024, 
 msgid "The CRA accounted for 3.2% of all federal spending in FY 2024"
 msgstr "The CRA accounted for 3.2% of all federal spending in FY 2024"
 
-#: src/components/first-nations/FinancialPositionStats.tsx:278
+#: src/components/first-nations/FinancialPositionStats.tsx:313
 msgid "The cumulative surplus accumulated over time from operations."
 msgstr "The cumulative surplus accumulated over time from operations."
 
@@ -3386,7 +3402,7 @@ msgstr "The department's spending has increased less than overall spending has g
 msgid "The difference between revenue and spending. A surplus indicates revenue exceeded spending."
 msgstr "The difference between revenue and spending. A surplus indicates revenue exceeded spending."
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:205
+#: src/components/first-nations/FirstNationsPageContent.tsx:224
 msgid "The difference between total revenue and total expenses. A surplus indicates revenue exceeded expenses."
 msgstr "The difference between total revenue and total expenses. A surplus indicates revenue exceeded expenses."
 
@@ -3458,11 +3474,11 @@ msgstr "These Ministers are some of the <0>cabinet members</0> who serve at the 
 msgid "This page presents the official Fall 2025 Federal Budget as released by the Government of Canada on November 4th, 2025. All data is sourced directly from official government publications and public accounts from the Government of Canada."
 msgstr "This page presents the official Fall 2025 Federal Budget as released by the Government of Canada on November 4th, 2025. All data is sourced directly from official government publications and public accounts from the Government of Canada."
 
-#: src/components/first-nations/RemunerationTable.tsx:135
+#: src/components/first-nations/RemunerationTable.tsx:298
 msgid "This schedule has been audited."
 msgstr "This schedule has been audited."
 
-#: src/components/first-nations/RemunerationTable.tsx:137
+#: src/components/first-nations/RemunerationTable.tsx:300
 msgid "This schedule is unaudited."
 msgstr "This schedule is unaudited."
 
@@ -3482,7 +3498,8 @@ msgstr "to help us support our mission."
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:398
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:509
 #: src/components/first-nations/ClaimsTable.tsx:300
-#: src/components/first-nations/RemunerationTable.tsx:92
+#: src/components/first-nations/RemunerationTable.tsx:139
+#: src/components/first-nations/RemunerationTable.tsx:208
 #: src/components/JurisdictionComparisonChart.tsx:282
 msgid "Total"
 msgstr "Total"
@@ -3491,11 +3508,11 @@ msgstr "Total"
 msgid "Total {provinceName} Tax"
 msgstr "Total {provinceName} Tax"
 
-#: src/components/first-nations/FinancialPositionStats.tsx:288
+#: src/components/first-nations/FinancialPositionStats.tsx:323
 msgid "Total accumulated surplus"
 msgstr "Total accumulated surplus"
 
-#: src/components/first-nations/FinancialPositionStats.tsx:255
+#: src/components/first-nations/FinancialPositionStats.tsx:267
 msgid "Total assets minus total liabilities. This represents the First Nation's overall financial position."
 msgstr "Total assets minus total liabilities. This represents the First Nation's overall financial position."
 
@@ -3512,11 +3529,11 @@ msgstr "Total Debt"
 msgid "Total Debt is the government's complete outstanding debt. This is the figure on which interest payments are calculated."
 msgstr "Total Debt is the government's complete outstanding debt. This is the figure on which interest payments are calculated."
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:242
+#: src/components/first-nations/FirstNationsPageContent.tsx:261
 msgid "Total Expenses"
 msgstr "Total Expenses"
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:256
+#: src/components/first-nations/FirstNationsPageContent.tsx:275
 msgid "Total expenses in FY {fiscalYear}"
 msgstr "Total expenses in FY {fiscalYear}"
 
@@ -3524,7 +3541,7 @@ msgstr "Total expenses in FY {fiscalYear}"
 msgid "Total Federal Tax"
 msgstr "Total Federal Tax"
 
-#: src/components/first-nations/FinancialPositionStats.tsx:156
+#: src/components/first-nations/FinancialPositionStats.tsx:168
 msgid "Total Financial Assets"
 msgstr "Total Financial Assets"
 
@@ -3533,11 +3550,11 @@ msgstr "Total Financial Assets"
 msgid "Total full-time equivalents"
 msgstr "Total full-time equivalents"
 
-#: src/components/first-nations/FinancialPositionStats.tsx:179
+#: src/components/first-nations/FinancialPositionStats.tsx:191
 msgid "Total Liabilities"
 msgstr "Total Liabilities"
 
-#: src/components/first-nations/FinancialPositionStats.tsx:266
+#: src/components/first-nations/FinancialPositionStats.tsx:278
 msgid "Total net assets"
 msgstr "Total net assets"
 
@@ -3549,7 +3566,7 @@ msgstr "Total Payments"
 msgid "Total property tax revenue divided by population. Primary revenue source for municipalities."
 msgstr "Total property tax revenue divided by population. Primary revenue source for municipalities."
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:222
+#: src/components/first-nations/FirstNationsPageContent.tsx:241
 #: src/components/JurisdictionPageContent.tsx:160
 msgid "Total Revenue"
 msgstr "Total Revenue"
@@ -3559,7 +3576,7 @@ msgstr "Total Revenue"
 msgid "Total revenue in {0}"
 msgstr "Total revenue in {0}"
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:236
+#: src/components/first-nations/FirstNationsPageContent.tsx:255
 msgid "Total revenue in FY {fiscalYear}"
 msgstr "Total revenue in FY {fiscalYear}"
 
@@ -3659,10 +3676,6 @@ msgstr "Transportation + Communication"
 msgid "Transportation and Communication"
 msgstr "Transportation and Communication"
 
-#: src/components/first-nations/RemunerationTable.tsx:85
-msgid "Travel"
-msgstr "Travel"
-
 #: src/app/[lang]/(main)/federal/spending/page.tsx:241
 #: src/app/[lang]/(main)/federal/spending/page.tsx:262
 #: src/app/[lang]/(main)/spending/page.tsx:232
@@ -3759,7 +3772,7 @@ msgid "Visitors, International Students + Temporary Workers"
 msgstr "Visitors, International Students + Temporary Workers"
 
 #. placeholder {0}: firstNation.name
-#: src/components/first-nations/FirstNationsPageContent.tsx:291
+#: src/components/first-nations/FirstNationsPageContent.tsx:322
 msgid "Visual breakdown of {0}'s revenue sources and how funds were spent during fiscal year {fiscalYear}."
 msgstr "Visual breakdown of {0}'s revenue sources and how funds were spent during fiscal year {fiscalYear}."
 
@@ -3849,11 +3862,11 @@ msgstr "We don't tell you what to think—we give you the facts. Meet the team m
 msgid "We love to hear from the community."
 msgstr "We love to hear from the community."
 
-#: src/app/[lang]/(main)/page.tsx:53
+#: src/app/[lang]/(main)/page.tsx:52
 msgid "We share clear insights to level up transparency"
 msgstr "We share clear insights to level up transparency"
 
-#: src/app/[lang]/(main)/page.tsx:139
+#: src/app/[lang]/(main)/page.tsx:131
 msgid "We turn complex government data into clear insights. We explain federal spending so every Canadian can understand where their money goes."
 msgstr "We turn complex government data into clear insights. We explain federal spending so every Canadian can understand where their money goes."
 
@@ -3865,7 +3878,7 @@ msgstr "We welcome passionate individuals who want to help make a difference. Wh
 msgid "We were frustrated by the lack of clear, accessible, unbiased data on government spending. We wanted to create a platform that focused on giving Canadians data-driven facts about how their money is being spent without spin."
 msgstr "We were frustrated by the lack of clear, accessible, unbiased data on government spending. We wanted to create a platform that focused on giving Canadians data-driven facts about how their money is being spent without spin."
 
-#: src/app/[lang]/(main)/page.tsx:169
+#: src/app/[lang]/(main)/page.tsx:161
 msgid "We're strictly non-partisan—we don't judge policies or debate spending decisions. Our only goal is to ensure that every Canadian understands how the federal government spends money."
 msgstr "We're strictly non-partisan—we don't judge policies or debate spending decisions. Our only goal is to ensure that every Canadian understands how the federal government spends money."
 
@@ -4001,7 +4014,7 @@ msgstr "Year"
 msgid "You can access our whistleblower platform directly through your web browser at:"
 msgstr "You can access our whistleblower platform directly through your web browser at:"
 
-#: src/app/[lang]/(main)/page.tsx:106
+#: src/app/[lang]/(main)/page.tsx:98
 msgid "You deserve the facts"
 msgstr "You deserve the facts"
 

--- a/src/locales/en.po
+++ b/src/locales/en.po
@@ -276,7 +276,7 @@ msgstr "Age"
 msgid "Agriculture"
 msgstr "Agriculture"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:266
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:270
 msgid "Aid Type"
 msgstr "Aid Type"
 
@@ -371,7 +371,7 @@ msgstr "Annual municipal spending per {0} resident"
 msgid "Annual payroll"
 msgstr "Annual payroll"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:90
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:94
 msgid "Application ID"
 msgstr "Application ID"
 
@@ -384,7 +384,7 @@ msgstr "Applied to provincial tax of {0}"
 msgid "Are you DOGE?"
 msgstr "Are you DOGE?"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:176
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:180
 msgid "Area of Research"
 msgstr "Area of Research"
 
@@ -418,7 +418,7 @@ msgstr "Assets, liabilities, and net financial position as of the end of fiscal 
 msgid "Average annual compensation"
 msgstr "Average annual compensation"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:67
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:71
 msgid "Awarded"
 msgstr "Awarded"
 
@@ -609,7 +609,7 @@ msgstr "Claim"
 msgid "Claims Settlements"
 msgstr "Claims Settlements"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:166
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:170
 msgid "Co-Applicant(s)"
 msgstr "Co-Applicant(s)"
 
@@ -617,7 +617,7 @@ msgstr "Co-Applicant(s)"
 msgid "Coastguard Operations"
 msgstr "Coastguard Operations"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:268
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:272
 msgid "Collaboration Type"
 msgstr "Collaboration Type"
 
@@ -646,9 +646,9 @@ msgstr "Compare your total tax burden across all Canadian provinces and territor
 msgid "Compensation per Employee"
 msgstr "Compensation per Employee"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:77
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:124
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:170
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:81
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:128
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:174
 msgid "Competition Year"
 msgstr "Competition Year"
 
@@ -667,7 +667,7 @@ msgstr "Connect with us"
 msgid "Contact"
 msgstr "Contact"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:253
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:257
 msgid "Contributing Organization"
 msgstr "Contributing Organization"
 
@@ -691,7 +691,7 @@ msgstr "Corporate Income Taxes"
 msgid "Corrections"
 msgstr "Corrections"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:243
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:247
 msgid "Countries"
 msgstr "Countries"
 
@@ -778,8 +778,8 @@ msgstr "Defence Team"
 msgid "Deficit"
 msgstr "Deficit"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:74
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:322
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:78
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:326
 msgid "Department"
 msgstr "Department"
 
@@ -837,7 +837,7 @@ msgstr "Direct spending refers to money allocated to government programs, employ
 msgid "Disaster Relief"
 msgstr "Disaster Relief"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:174
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:178
 msgid "Discipline"
 msgstr "Discipline"
 
@@ -853,7 +853,7 @@ msgstr "Do not discuss your submission with anyone or search for related topics 
 msgid "Download and install the <0>Tor Browser</0> from the official Tor Project website."
 msgstr "Download and install the <0>Tor Browser</0> from the official Tor Project website."
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:122
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:126
 msgid "Duration"
 msgstr "Duration"
 
@@ -923,7 +923,7 @@ msgstr "Employment Insurance"
 msgid "Employment Insurance Premiums"
 msgstr "Employment Insurance Premiums"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:240
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:244
 msgid "End Date"
 msgstr "End Date"
 
@@ -1023,11 +1023,11 @@ msgstr "Excise Tax — Aviation Gasoline and Jet Fuel"
 msgid "Excise Tax — Gasoline"
 msgstr "Excise Tax — Gasoline"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:245
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:249
 msgid "Executing Agency/Partner"
 msgstr "Executing Agency/Partner"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:258
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:262
 msgid "Expected Results"
 msgstr "Expected Results"
 
@@ -1086,7 +1086,7 @@ msgstr "Explore other Federal Departments"
 msgid "Explore revenue and spending categories or filter by agency for deeper insights."
 msgstr "Explore revenue and spending categories or filter by agency for deeper insights."
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:133
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:137
 msgid "External ID"
 msgstr "External ID"
 
@@ -1263,7 +1263,7 @@ msgstr "Federal Total"
 msgid "Finance Canada"
 msgstr "Finance Canada"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:271
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:275
 msgid "Finance Type"
 msgstr "Finance Type"
 
@@ -1333,9 +1333,9 @@ msgstr "First Nations Financial Data"
 msgid "Fiscal arrangements"
 msgstr "Fiscal arrangements"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:80
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:173
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:326
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:84
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:177
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:330
 msgid "Fiscal Year"
 msgstr "Fiscal Year"
 
@@ -1870,12 +1870,12 @@ msgstr "Innovation, Science and Industry Canada | Canada Spends"
 msgid "Innovative and Sustainable Natural Resources Development"
 msgstr "Innovative and Sustainable Natural Resources Development"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:68
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:72
 msgid "Installment"
 msgstr "Installment"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:73
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:120
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:77
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:124
 msgid "Institution"
 msgstr "Institution"
 
@@ -1998,7 +1998,7 @@ msgstr "Latest Budget News & Impact"
 msgid "Learn more about the technology at <0>globaleaks.org</0>."
 msgstr "Learn more about the technology at <0>globaleaks.org</0>."
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:332
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:336
 msgid "Location"
 msgstr "Location"
 
@@ -2061,7 +2061,7 @@ msgstr "Manitoba HTP"
 msgid "Manitoba STP"
 msgstr "Manitoba STP"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:249
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:253
 msgid "Maximum Contribution"
 msgstr "Maximum Contribution"
 
@@ -2073,7 +2073,7 @@ msgstr "Methodology"
 msgid "Ministries + Agencies"
 msgstr "Ministries + Agencies"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:325
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:329
 msgid "Ministry"
 msgstr "Ministry"
 
@@ -2441,7 +2441,7 @@ msgstr "Operational Spend"
 msgid "or subscribe to"
 msgstr "or subscribe to"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:164
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:168
 msgid "Organization"
 msgstr "Organization"
 
@@ -2577,7 +2577,7 @@ msgstr "Out of Court Settlement"
 msgid "Parliament"
 msgstr "Parliament"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:334
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:338
 msgid "Payment Amount"
 msgstr "Payment Amount"
 
@@ -2655,11 +2655,9 @@ msgstr "Pollution pricing"
 msgid "Pollution pricing proceeds"
 msgstr "Pollution pricing proceeds"
 
-#. placeholder {0}: populationData[0]?.year
-#. placeholder {1}: populationData[populationData.length - 1]?.year
 #: src/components/first-nations/PopulationCharts.tsx:125
-msgid "Population trends for {bandName} from {0} to {1}."
-msgstr "Population trends for {bandName} from {0} to {1}."
+#~ msgid "Population trends for {bandName} from {0} to {1}."
+#~ msgstr "Population trends for {bandName} from {0} to {1}."
 
 #: src/components/first-nations/RemunerationTable.tsx:107
 msgid "Position"
@@ -2686,12 +2684,12 @@ msgstr "Prince Edward Island HTP"
 msgid "Prince Edward Island STP"
 msgstr "Prince Edward Island STP"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:161
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:165
 msgid "Principal Applicant"
 msgstr "Principal Applicant"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:70
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:117
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:74
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:121
 msgid "Principal Investigator"
 msgstr "Principal Investigator"
 
@@ -2718,15 +2716,15 @@ msgstr "Professional + Special Services"
 msgid "Professional and Special Services"
 msgstr "Professional and Special Services"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:276
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:280
 msgid "Program Name"
 msgstr "Program Name"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:127
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:131
 msgid "Program Type"
 msgstr "Program Type"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:231
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:235
 msgid "Project Number"
 msgstr "Project Number"
 
@@ -2753,8 +2751,8 @@ msgstr "Property tax revenue per {0} resident"
 msgid "Prov."
 msgstr "Prov."
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:75
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:121
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:79
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:125
 msgid "Province"
 msgstr "Province"
 
@@ -2893,15 +2891,15 @@ msgstr "Ready Forces"
 msgid "Recent developments and their projected impact on the Fall 2025 Budget"
 msgstr "Recent developments and their projected impact on the Fall 2025 Budget"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:331
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:335
 msgid "Recipient"
 msgstr "Recipient"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:328
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:332
 msgid "Recipient Class"
 msgstr "Recipient Class"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:282
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:286
 msgid "Regions"
 msgstr "Regions"
 
@@ -2948,7 +2946,7 @@ msgstr "Repair + Maintenance"
 msgid "Repair and Maintenance"
 msgstr "Repair and Maintenance"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:273
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:277
 msgid "Reporting Organization"
 msgstr "Reporting Organization"
 
@@ -2956,12 +2954,12 @@ msgstr "Reporting Organization"
 msgid "Research"
 msgstr "Research"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:86
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:130
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:90
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:134
 msgid "Research Subject"
 msgstr "Research Subject"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:263
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:267
 msgid "Results Achieved"
 msgstr "Results Achieved"
 
@@ -3042,11 +3040,11 @@ msgstr "See how Canada's government spends tax dollars—track workforce data, s
 msgid "See how your taxes are spent across federal and provincial programs. Interactive calculator for Canadian taxpayers."
 msgstr "See how your taxes are spent across federal and provincial programs. Interactive calculator for Canadian taxpayers."
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:82
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:86
 msgid "Selection Committee"
 msgstr "Selection Committee"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:278
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:282
 msgid "Selection Mechanism"
 msgstr "Selection Mechanism"
 
@@ -3157,7 +3155,7 @@ msgstr "Standard of Living"
 msgid "Standard of Living and Assistance to Address Inequalities"
 msgstr "Standard of Living and Assistance to Address Inequalities"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:236
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:240
 msgid "Start Date"
 msgstr "Start Date"
 
@@ -3173,7 +3171,7 @@ msgstr "Statement of Financial Position"
 msgid "Statistics Canada"
 msgstr "Statistics Canada"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:234
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:238
 #: src/components/first-nations/ClaimsTable.tsx:136
 msgid "Status"
 msgstr "Status"
@@ -3454,7 +3452,7 @@ msgstr "The Public Services and Procurement Canada (PSPC) is the federal departm
 msgid "The values you see here are based on the FY 2024 Budget with preliminary updates based on government announcements, memos, and leaks, and are meant to provide a rough idea of the budget. Once the official Fall 2025 Budget is released on November 4th, we will update this page to reflect the official budget."
 msgstr "The values you see here are based on the FY 2024 Budget with preliminary updates based on government announcements, memos, and leaks, and are meant to provide a rough idea of the budget. Once the official Fall 2025 Budget is released on November 4th, we will update this page to reflect the official budget."
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:128
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:132
 msgid "Theme"
 msgstr "Theme"
 

--- a/src/locales/fr.po
+++ b/src/locales/fr.po
@@ -218,11 +218,11 @@ msgstr "À propos de nous"
 msgid "Above {0}"
 msgstr "Au-dessus de {0}"
 
-#: src/components/first-nations/FinancialPositionStats.tsx:182
+#: src/components/first-nations/FinancialPositionStats.tsx:194
 msgid "Accounts payable, long-term debt, and other obligations owed to external parties."
 msgstr "Comptes créditeurs, dette à long terme et autres obligations envers des tiers."
 
-#: src/components/first-nations/FinancialPositionStats.tsx:275
+#: src/components/first-nations/FinancialPositionStats.tsx:310
 msgid "Accumulated Surplus"
 msgstr "Excédent accumulé"
 
@@ -304,7 +304,7 @@ msgstr "Tous les articles"
 msgid "All data presented regarding government spending is sourced directly from official government databases. Unless otherwise noted, we have used <0>Public Accounts of Canada</0> data as the primary data source. While we strive to provide accurate, up-to-date information, we cannot guarantee the data's completeness, reliability, or timeliness. We assume no responsibility for any errors, omissions, or outcomes resulting from the use of this information. Please consult the original government sources for official and verified data."
 msgstr "Toutes les données présentées concernant les dépenses gouvernementales proviennent directement des bases de données officielles du gouvernement. Sauf indication contraire, nous avons utilisé les données des <0>Comptes publics du Canada</0> comme source principale. Bien que nous nous efforcions de fournir des informations précises et à jour, nous ne pouvons garantir l'exhaustivité, la fiabilité ou l'actualité des données. Nous n'assumons aucune responsabilité pour les erreurs, omissions ou résultats découlant de l'utilisation de ces informations. Veuillez consulter les sources gouvernementales originales pour des données officielles et vérifiées."
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:245
+#: src/components/first-nations/FirstNationsPageContent.tsx:264
 msgid "All expenses incurred during the fiscal year including program delivery, administration, and capital costs."
 msgstr "Toutes les dépenses engagées au cours de l'exercice financier, y compris la prestation de programmes, l'administration et les coûts d'immobilisations."
 
@@ -331,11 +331,11 @@ msgstr "Toutes les dépenses de programmes et d'exploitation enregistrées pour 
 msgid "All revenue collected during the fiscal year, including taxes, transfers, and other sources."
 msgstr "Tous les revenus collectés pendant l'exercice financier, y compris les impôts, les transferts et d'autres sources."
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:225
+#: src/components/first-nations/FirstNationsPageContent.tsx:244
 msgid "All revenue collected during the fiscal year, including transfers, own-source revenue, and other funding."
 msgstr "Tous les revenus perçus au cours de l'exercice financier, y compris les transferts, les revenus de sources propres et d'autres financements."
 
-#: src/app/[lang]/(main)/page.tsx:154
+#: src/app/[lang]/(main)/page.tsx:146
 msgid "All the information comes from public databases and reports by the Government of Canada. We show our sources, so you know exactly where it comes from."
 msgstr "Toutes les informations proviennent des bases de données publiques et des rapports du gouvernement du Canada. Nous indiquons nos sources pour que vous sachiez exactement d'où elles proviennent."
 
@@ -402,13 +402,14 @@ msgstr "Articles | Canada Spends"
 msgid "As of fiscal year end {0}"
 msgstr "À la fin de l'exercice financier {0}"
 
-#: src/components/first-nations/FinancialPositionStats.tsx:170
-#: src/components/first-nations/FinancialPositionStats.tsx:193
-#: src/components/first-nations/FinancialPositionStats.tsx:243
+#: src/components/first-nations/FinancialPositionStats.tsx:182
+#: src/components/first-nations/FinancialPositionStats.tsx:205
+#: src/components/first-nations/FinancialPositionStats.tsx:255
+#: src/components/first-nations/FinancialPositionStats.tsx:301
 msgid "As of fiscal year end {fiscalYear}"
 msgstr "À la fin de l'exercice financier {fiscalYear}"
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:342
+#: src/components/first-nations/FirstNationsPageContent.tsx:373
 msgid "Assets, liabilities, and net financial position as of the end of fiscal year {fiscalYear}."
 msgstr "Actifs, passifs et situation financière nette à la fin de l'exercice financier {fiscalYear}."
 
@@ -430,7 +431,7 @@ msgstr "Retour à tous les articles"
 msgid "Balance for {0}"
 msgstr "Solde pour {0}"
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:216
+#: src/components/first-nations/FirstNationsPageContent.tsx:235
 msgid "Balance for FY {fiscalYear}"
 msgstr "Solde pour l'exercice {fiscalYear}"
 
@@ -438,7 +439,7 @@ msgstr "Solde pour l'exercice {fiscalYear}"
 msgid "Banking + Finance"
 msgstr "Banques + Finances"
 
-#: src/app/[lang]/(main)/page.tsx:151
+#: src/app/[lang]/(main)/page.tsx:143
 msgid "Based on Data"
 msgstr "Basé sur les données"
 
@@ -526,7 +527,7 @@ msgid "Canada social transfer"
 msgstr "Transfert canadien en matière de programmes sociaux"
 
 #. js-lingui-explicit-id
-#: src/app/[lang]/(main)/page.tsx:118
+#: src/app/[lang]/(main)/page.tsx:110
 msgid "facts-2"
 msgstr "Canada Spends change cela. Nous prenons les données brutes des dépenses fédérales et les transformons en faits précis et directs pour que vous puissiez comprendre comment votre argent est utilisé."
 
@@ -583,7 +584,7 @@ msgstr "Remboursement de la taxe sur le carbone"
 msgid "Carbon Taxes"
 msgstr "Taxes sur le carbone"
 
-#: src/components/first-nations/FinancialPositionStats.tsx:159
+#: src/components/first-nations/FinancialPositionStats.tsx:171
 msgid "Cash, investments, accounts receivable, and other assets that can be converted to cash."
 msgstr "Encaisse, placements, comptes débiteurs et autres actifs pouvant être convertis en espèces."
 
@@ -665,10 +666,6 @@ msgstr "Connectez-vous avec nous"
 #: src/components/MainLayout/Footer.tsx:54
 msgid "Contact"
 msgstr "Contact"
-
-#: src/components/first-nations/RemunerationTable.tsx:77
-msgid "Contract"
-msgstr "Contrat"
 
 #: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:253
 msgid "Contributing Organization"
@@ -1034,26 +1031,30 @@ msgstr "Agence/Partenaire d'exécution"
 msgid "Expected Results"
 msgstr "Résultats attendus"
 
-#: src/app/[lang]/(main)/page.tsx:70
-msgid "Explore Budget 2025"
-msgstr "Explorer le budget 2025"
+#: src/components/first-nations/RemunerationTable.tsx:259
+msgid "Expenses"
+msgstr ""
 
 #: src/app/[lang]/(main)/federal/budget/layout.tsx:17
 msgid "Explore Canada's federal budget with interactive visualizations and detailed analysis of government revenue and expenditures."
 msgstr "Explorez le budget fédéral du Canada avec des visualisations interactives et une analyse détaillée des revenus et dépenses gouvernementales."
-
-#: src/app/[lang]/(main)/page.tsx:72
-msgid "Explore federal data"
-msgstr "Explorer les données fédérales"
 
 #: src/app/[lang]/(main)/federal/spending/page.tsx:250
 #: src/app/[lang]/(main)/spending/page.tsx:241
 msgid "Explore federal employee salary distribution by year and demographic group"
 msgstr "Explorez la répartition des salaires des employés fédéraux par année et groupe démographique"
 
-#: src/app/[lang]/(main)/first-nations/page.tsx:33
+#: src/app/[lang]/(main)/page.tsx:65
+msgid "Explore Federal Spending"
+msgstr ""
+
+#: src/app/[lang]/(main)/first-nations/page.tsx:36
 msgid "Explore financial data from First Nations across Canada. Data is extracted from annual reports published under the First Nations Financial Transparency Act (FNFTA), including statements of operations, financial position, and remuneration."
 msgstr "Explorez les données financières des Premières Nations à travers le Canada. Les données sont extraites des rapports annuels publiés en vertu de la Loi sur la transparence financière des Premières Nations (LTFPN), y compris les états des résultats, la situation financière et la rémunération."
+
+#: src/app/[lang]/(main)/page.tsx:75
+msgid "Explore First Nations"
+msgstr ""
 
 #: src/app/[lang]/(main)/federal/spending/layout.tsx:17
 msgid "Explore how the Canadian federal government spends your tax dollars across departments and programs."
@@ -1062,10 +1063,6 @@ msgstr "Découvrez comment le gouvernement fédéral canadien dépense vos impô
 #: src/app/[lang]/(main)/articles/page.tsx:19
 msgid "Explore in-depth articles about Canadian government spending, budget analysis, and public finance. Stay informed about how your tax dollars are used through Canada Spends."
 msgstr "Explorez des articles approfondis sur les dépenses gouvernementales canadiennes, l'analyse budgétaire et les finances publiques. Restez informé de l'utilisation de vos dollars d'impôt grâce à Canada Spends."
-
-#: src/app/[lang]/(main)/page.tsx:83
-msgid "Explore Ontario data"
-msgstr "Explorer les données de l'Ontario"
 
 #: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:239
 #: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:230
@@ -1106,7 +1103,7 @@ msgstr "ID externe"
 msgid "External Revenues"
 msgstr "Revenus externes"
 
-#: src/app/[lang]/(main)/page.tsx:136
+#: src/app/[lang]/(main)/page.tsx:128
 msgid "Facts about Spending"
 msgstr "Faits sur les dépenses"
 
@@ -1271,23 +1268,26 @@ msgid "Finance Type"
 msgstr "Type de financement"
 
 #. placeholder {0}: firstNation.name
-#: src/components/first-nations/FirstNationsPageContent.tsx:267
-msgid "Financial data for {0} for fiscal year {fiscalYear}. Information is extracted from publicly available annual reports published under the First Nations Financial Transparency Act."
-msgstr "Données financières pour {0} pour l'exercice financier {fiscalYear}. Les informations sont extraites des rapports annuels publics publiés en vertu de la Loi sur la transparence financière des Premières Nations."
+#. placeholder {1}: firstNation.name
+#. placeholder {2}: getProvinceName(firstNation.province)
+#. placeholder {3}: firstNation.populationRegistered != null && firstNation.populationOnReserve != null && ( <> {" "} with a registered population of{" "} {firstNation.populationRegistered.toLocaleString()} and an on-reserve population of{" "} {firstNation.populationOnReserve.toLocaleString()} </> )
+#: src/components/first-nations/FirstNationsPageContent.tsx:286
+msgid "Financial data for {0} for fiscal year {fiscalYear}. {1} is a First Nation in {2}{3}. Information is extracted from publicly available annual reports published under the First Nations Financial Transparency Act."
+msgstr ""
 
 #: src/app/[lang]/(main)/first-nations/[bcid]/page.tsx:72
 msgid "Financial data from annual reports published under the First Nations Financial Transparency Act will appear here once available."
 msgstr "Les données financières des rapports annuels publiés en vertu de la Loi sur la transparence financière des Premières Nations apparaîtront ici une fois disponibles."
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:458
+#: src/components/first-nations/FirstNationsPageContent.tsx:476
 msgid "Financial data is sourced from annual reports published under the First Nations Financial Transparency Act (FNFTA). Data is extracted using automated processes and may contain errors. If you notice any issues, please contact us."
 msgstr "Les données financières proviennent des rapports annuels publiés en vertu de la Loi sur la transparence financière des Premières Nations (LTFPN). Les données sont extraites à l'aide de processus automatisés et peuvent contenir des erreurs. Si vous remarquez des problèmes, veuillez nous contacter."
 
-#: src/components/first-nations/FinancialPositionStats.tsx:220
+#: src/components/first-nations/FinancialPositionStats.tsx:232
 msgid "Financial liabilities less financial assets"
 msgstr "Passifs financiers moins actifs financiers"
 
-#: src/components/first-nations/FinancialPositionStats.tsx:206
+#: src/components/first-nations/FinancialPositionStats.tsx:218
 msgid "Financial liabilities minus financial assets. A negative value indicates net financial assets."
 msgstr "Passifs financiers moins actifs financiers. Une valeur négative indique des actifs financiers nets."
 
@@ -1296,7 +1296,7 @@ msgstr "Passifs financiers moins actifs financiers. Une valeur négative indique
 msgid "Financial Position {0}"
 msgstr "Situation financière {0}"
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:312
+#: src/components/first-nations/FirstNationsPageContent.tsx:343
 msgid "Financial Summary FY {fiscalYear}"
 msgstr "Résumé financier EF {fiscalYear}"
 
@@ -1325,7 +1325,7 @@ msgstr "Soins de santé primaires des Premières Nations et des Inuits"
 msgid "First Nations Elementary and Secondary Educational Advancement"
 msgstr "Avancement de l'éducation primaire et secondaire des Premières Nations"
 
-#: src/app/[lang]/(main)/first-nations/page.tsx:30
+#: src/app/[lang]/(main)/first-nations/page.tsx:33
 msgid "First Nations Financial Data"
 msgstr "Données financières des Premières Nations"
 
@@ -1416,7 +1416,7 @@ msgstr "Obtenez des analyses basées sur les données sur la façon dont les rev
 msgid "Get Involved"
 msgstr "Impliquez-vous"
 
-#: src/app/[lang]/(main)/page.tsx:42
+#: src/app/[lang]/(main)/page.tsx:41
 #: src/app/[lang]/layout.tsx:22
 msgid "Get The Facts About Government Spending"
 msgstr "Découvrez les faits sur les dépenses gouvernementales"
@@ -1493,7 +1493,7 @@ msgid "Government spending is based on 2023-2024 fiscal spending. Attempts have 
 msgstr "Les dépenses gouvernementales sont basées sur les dépenses fiscales de 2023-2024. Des tentatives ont été faites pour fusionner des catégories similaires entre les dépenses fédérales et provinciales."
 
 #. js-lingui-explicit-id
-#: src/app/[lang]/(main)/page.tsx:109
+#: src/app/[lang]/(main)/page.tsx:101
 msgid "facts-1"
 msgstr "Les dépenses gouvernementales ne devraient pas être une boîte noire. Chaque année, le gouvernement fédéral dépense des centaines de milliards de dollars, mais la plupart des Canadiens n'ont aucune idée où tout cet argent va. Les données sont disponibles, mais elles sont enfouies sur des sites Web obscurs et impossibles à naviguer."
 
@@ -1509,6 +1509,10 @@ msgstr "Effectif gouvernemental"
 #: src/app/[lang]/(main)/spending/layout.tsx:16
 msgid "Government Workforce & Spending Data | See the Breakdown"
 msgstr "Données sur l'effectif et les dépenses gouvernementales | Voir la répartition"
+
+#: src/components/first-nations/RemunerationTable.tsx:285
+msgid "Grand Total"
+msgstr ""
 
 #: src/components/Sankey/index.tsx:599
 msgid "Grants to Support the New Fiscal Relationship with First Nations"
@@ -1594,13 +1598,9 @@ msgid "HICC spent $14.5 billion in fiscal year (FY) 2024. This was 2.8% of the $
 msgstr "LICC a dépensé 14,5 milliards de dollars au cours de l'exercice 2024. Cela représentait 2,8 % des 513,9 milliards de dollars de dépenses fédérales totales. Le ministère s'est classé huitième parmi les ministères fédéraux en termes de dépenses totales."
 
 #. placeholder {0}: firstNation.name
-#: src/components/first-nations/FirstNationsPageContent.tsx:390
+#: src/components/first-nations/FirstNationsPageContent.tsx:408
 msgid "Historical and ongoing land claims involving {0}."
 msgstr "Revendications territoriales historiques et en cours impliquant {0}."
-
-#: src/components/first-nations/RemunerationTable.tsx:69
-msgid "Honorarium"
-msgstr "Honoraires"
 
 #: src/components/Sankey/index.tsx:59
 msgid "Housing Assistance"
@@ -1977,9 +1977,13 @@ msgstr "Mots-clés"
 msgid "Labour Market Development Agreements (LMDAs): federal funding to provinces for job training and employment support."
 msgstr "Ententes sur le développement du marché du travail (EDMT) : financement fédéral aux provinces pour la formation professionnelle et le soutien à l'emploi."
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:377
+#: src/components/first-nations/FirstNationsPageContent.tsx:395
 msgid "Land Claims"
 msgstr "Revendications territoriales"
+
+#: src/components/first-nations/FinancialPositionStats.tsx:290
+msgid "Land, buildings, equipment, vehicles, and infrastructure owned by the First Nation."
+msgstr ""
 
 #: src/components/first-nations/ClaimsTable.tsx:142
 msgid "Last Update"
@@ -2077,6 +2081,10 @@ msgstr "Ministère"
 msgid "Miscellaneous revenues"
 msgstr "Revenus divers"
 
+#: src/components/first-nations/RemunerationTable.tsx:122
+msgid "Months"
+msgstr ""
+
 #: src/components/DepartmentList.tsx:45
 msgid "More coming soon..."
 msgstr "Plus à venir..."
@@ -2101,7 +2109,7 @@ msgstr "La plupart des dépenses fédérales peuvent être classées comme direc
 msgid "Municipal"
 msgstr "Municipal"
 
-#: src/components/first-nations/RemunerationTable.tsx:54
+#: src/components/first-nations/RemunerationTable.tsx:114
 msgid "Name"
 msgstr "Nom"
 
@@ -2149,11 +2157,11 @@ msgstr "Pertes actuarielles nettes"
 msgid "Net actuarial losses (gains)"
 msgstr "Pertes actuarielles nettes (gains)"
 
-#: src/components/first-nations/FinancialPositionStats.tsx:252
+#: src/components/first-nations/FinancialPositionStats.tsx:264
 msgid "Net Assets"
 msgstr "Actifs nets"
 
-#: src/components/first-nations/FinancialPositionStats.tsx:203
+#: src/components/first-nations/FinancialPositionStats.tsx:215
 #: src/components/JurisdictionPageContent.tsx:210
 msgid "Net Debt"
 msgstr "Dette nette"
@@ -2216,7 +2224,7 @@ msgstr "Aucun contenu disponible."
 msgid "No financial data is currently available for {0}."
 msgstr "Aucune donnée financière n'est actuellement disponible pour {0}."
 
-#: src/components/first-nations/FinancialPositionStats.tsx:295
+#: src/components/first-nations/FinancialPositionStats.tsx:330
 msgid "No financial position data available."
 msgstr "Aucune donnée de situation financière disponible."
 
@@ -2232,7 +2240,7 @@ msgstr "Aucune forme de communication électronique ne peut être rendue 100% s�
 msgid "No notes available."
 msgstr "Aucune note disponible."
 
-#: src/components/first-nations/RemunerationTable.tsx:26
+#: src/components/first-nations/RemunerationTable.tsx:60
 msgid "No remuneration data available."
 msgstr "Aucune donnée de rémunération disponible."
 
@@ -2244,11 +2252,11 @@ msgstr "Non, nous ne sommes pas un groupe de pression. Nous ne sommes pas payés
 msgid "No, we're not copying the DOGE playbook from the US."
 msgstr "Non, nous ne copions pas le modèle DOGE des États-Unis."
 
-#: src/components/first-nations/FinancialPositionStats.tsx:229
+#: src/components/first-nations/FinancialPositionStats.tsx:241
 msgid "Non-Financial Assets"
 msgstr "Actifs non financiers"
 
-#: src/app/[lang]/(main)/page.tsx:166
+#: src/app/[lang]/(main)/page.tsx:158
 msgid "Non-Partisan"
 msgstr "Non partisan"
 
@@ -2276,7 +2284,7 @@ msgstr "TPS Territoires du Nord-Ouest"
 msgid "Note the different salary ranges prior to 2023. Information for small numbers has been suppressed (values of 0 are actually counts of 1 to 5)."
 msgstr "Notez les différentes fourchettes salariales avant 2023. Les informations pour les petits nombres ont été supprimées (les valeurs de 0 représentent en fait des comptes de 1 à 5)."
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:436
+#: src/components/first-nations/FirstNationsPageContent.tsx:454
 msgid "Notes to Financial Statements"
 msgstr "Notes aux états financiers"
 
@@ -2647,22 +2655,18 @@ msgstr "Tarification de la pollution"
 msgid "Pollution pricing proceeds"
 msgstr "Produits de la tarification de la pollution"
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:363
-msgid "Population Trends"
-msgstr ""
-
 #. placeholder {0}: populationData[0]?.year
 #. placeholder {1}: populationData[populationData.length - 1]?.year
-#: src/components/first-nations/PopulationCharts.tsx:124
+#: src/components/first-nations/PopulationCharts.tsx:125
 msgid "Population trends for {bandName} from {0} to {1}."
 msgstr ""
 
-#: src/components/first-nations/RemunerationTable.tsx:48
+#: src/components/first-nations/RemunerationTable.tsx:107
 msgid "Position"
 msgstr "Poste"
 
 #. placeholder {0}: data.auditor_name
-#: src/components/first-nations/RemunerationTable.tsx:142
+#: src/components/first-nations/RemunerationTable.tsx:305
 msgid "Prepared by: {0}"
 msgstr "Préparé par : {0}"
 
@@ -2901,7 +2905,11 @@ msgstr "Classe de bénéficiaire"
 msgid "Regions"
 msgstr "Régions"
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:405
+#: src/components/first-nations/RemunerationTable.tsx:233
+msgid "Remuneration"
+msgstr ""
+
+#: src/components/first-nations/FirstNationsPageContent.tsx:423
 msgid "Remuneration and Expenses"
 msgstr "Rémunération et dépenses"
 
@@ -2973,7 +2981,7 @@ msgstr "Rendement des investissements"
 msgid "Revenue"
 msgstr "Revenus"
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:281
+#: src/components/first-nations/FirstNationsPageContent.tsx:312
 msgid "Revenue and Expenses FY {fiscalYear}"
 msgstr "Revenus et dépenses EF {fiscalYear}"
 
@@ -2985,13 +2993,9 @@ msgstr "Revenu Canada"
 msgid "Safety"
 msgstr "Sécurité"
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:417
+#: src/components/first-nations/FirstNationsPageContent.tsx:435
 msgid "Salaries, honoraria, travel, and other expenses paid to elected officials and senior employees during fiscal year {fiscalYear}."
 msgstr "Salaires, honoraires, déplacements et autres dépenses versés aux élus et aux cadres supérieurs au cours de l'exercice financier {fiscalYear}."
-
-#: src/components/first-nations/RemunerationTable.tsx:61
-msgid "Salary"
-msgstr "Salaire"
 
 #: src/app/[lang]/(main)/federal/spending/page.tsx:247
 #: src/app/[lang]/(main)/spending/page.tsx:238
@@ -3107,7 +3111,7 @@ msgstr "Source :"
 #: src/app/[lang]/(main)/federal/budget/page.tsx:304
 #: src/app/[lang]/(main)/federal/spending/page.tsx:275
 #: src/app/[lang]/(main)/spending/page.tsx:266
-#: src/components/first-nations/FirstNationsPageContent.tsx:455
+#: src/components/first-nations/FirstNationsPageContent.tsx:473
 #: src/components/JurisdictionPageContent.tsx:504
 msgid "Sources"
 msgstr "Sources"
@@ -3157,11 +3161,11 @@ msgstr "Niveau de vie et aide pour réduire les inégalités"
 msgid "Start Date"
 msgstr "Date de début"
 
-#: src/app/[lang]/(main)/page.tsx:94
+#: src/app/[lang]/(main)/page.tsx:86
 msgid "Start reading"
 msgstr "Commencer la lecture"
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:332
+#: src/components/first-nations/FirstNationsPageContent.tsx:363
 msgid "Statement of Financial Position"
 msgstr "État de la situation financière"
 
@@ -3194,6 +3198,14 @@ msgstr "Soumettez des informations anonymes en toute sécurité grâce à notre 
 msgid "Subscribe to our newsletter"
 msgstr "Abonnez-vous à notre infolettre"
 
+#: src/components/first-nations/RemunerationTable.tsx:270
+msgid "Subtotal - Expenses"
+msgstr ""
+
+#: src/components/first-nations/RemunerationTable.tsx:244
+msgid "Subtotal - Remuneration"
+msgstr ""
+
 #: src/app/[lang]/(main)/search/[database]/[id]/DetailsPage.tsx:71
 msgid "Summary"
 msgstr "Résumé"
@@ -3214,7 +3226,7 @@ msgstr "Soutien à la compétition mondiale"
 msgid "Support for Veterans"
 msgstr "Soutien aux anciens combattants"
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:202
+#: src/components/first-nations/FirstNationsPageContent.tsx:221
 #: src/components/JurisdictionPageContent.tsx:140
 msgid "Surplus/Deficit"
 msgstr "Excédent/Déficit"
@@ -3223,7 +3235,11 @@ msgstr "Excédent/Déficit"
 msgid "Sustainable Bases, IT Systems, Infrastructure"
 msgstr "Bases durables, systèmes TI, infrastructure"
 
-#: src/components/first-nations/FinancialPositionStats.tsx:232
+#: src/components/first-nations/FinancialPositionStats.tsx:287
+msgid "Tangible Capital Assets"
+msgstr ""
+
+#: src/components/first-nations/FinancialPositionStats.tsx:244
 msgid "Tangible capital assets such as land, buildings, equipment, and infrastructure."
 msgstr "Immobilisations corporelles telles que terrains, bâtiments, équipements et infrastructures."
 
@@ -3298,7 +3314,7 @@ msgstr "L'Agence du revenu du Canada a dépensé 16,8 milliards de dollars au co
 msgid "The CRA accounted for 3.2% of all federal spending in FY 2024"
 msgstr "L'ARC représentait 3,2 % de toutes les dépenses fédérales pour l'exercice 2024"
 
-#: src/components/first-nations/FinancialPositionStats.tsx:278
+#: src/components/first-nations/FinancialPositionStats.tsx:313
 msgid "The cumulative surplus accumulated over time from operations."
 msgstr "L'excédent cumulé accumulé au fil du temps à partir des opérations."
 
@@ -3386,7 +3402,7 @@ msgstr "Les dépenses du ministère ont augmenté moins que les dépenses global
 msgid "The difference between revenue and spending. A surplus indicates revenue exceeded spending."
 msgstr "La différence entre les revenus et les dépenses. Un excédent indique que les revenus ont dépassé les dépenses."
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:205
+#: src/components/first-nations/FirstNationsPageContent.tsx:224
 msgid "The difference between total revenue and total expenses. A surplus indicates revenue exceeded expenses."
 msgstr "La différence entre les revenus totaux et les dépenses totales. Un excédent indique que les revenus ont dépassé les dépenses."
 
@@ -3458,11 +3474,11 @@ msgstr "Ces ministres sont parmi les <0>membres du cabinet</0> qui servent à la
 msgid "This page presents the official Fall 2025 Federal Budget as released by the Government of Canada on November 4th, 2025. All data is sourced directly from official government publications and public accounts from the Government of Canada."
 msgstr "Cette page présente le budget fédéral officiel de l'automne 2025 tel que publié par le gouvernement du Canada le 4 novembre 2025. Toutes les données proviennent directement des publications officielles du gouvernement et des comptes publics du gouvernement du Canada."
 
-#: src/components/first-nations/RemunerationTable.tsx:135
+#: src/components/first-nations/RemunerationTable.tsx:298
 msgid "This schedule has been audited."
 msgstr "Ce tableau a été vérifié."
 
-#: src/components/first-nations/RemunerationTable.tsx:137
+#: src/components/first-nations/RemunerationTable.tsx:300
 msgid "This schedule is unaudited."
 msgstr "Ce tableau n'a pas été vérifié."
 
@@ -3482,7 +3498,8 @@ msgstr "pour nous aider à soutenir notre mission."
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:398
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:509
 #: src/components/first-nations/ClaimsTable.tsx:300
-#: src/components/first-nations/RemunerationTable.tsx:92
+#: src/components/first-nations/RemunerationTable.tsx:139
+#: src/components/first-nations/RemunerationTable.tsx:208
 #: src/components/JurisdictionComparisonChart.tsx:282
 msgid "Total"
 msgstr "Total"
@@ -3491,11 +3508,11 @@ msgstr "Total"
 msgid "Total {provinceName} Tax"
 msgstr "Total impôt {provinceName}"
 
-#: src/components/first-nations/FinancialPositionStats.tsx:288
+#: src/components/first-nations/FinancialPositionStats.tsx:323
 msgid "Total accumulated surplus"
 msgstr "Surplus cumulé total"
 
-#: src/components/first-nations/FinancialPositionStats.tsx:255
+#: src/components/first-nations/FinancialPositionStats.tsx:267
 msgid "Total assets minus total liabilities. This represents the First Nation's overall financial position."
 msgstr "Total des actifs moins total des passifs. Ceci représente la situation financière globale de la Première Nation."
 
@@ -3512,11 +3529,11 @@ msgstr "Dette totale"
 msgid "Total Debt is the government's complete outstanding debt. This is the figure on which interest payments are calculated."
 msgstr "La dette totale est la dette complète en cours du gouvernement. C'est le chiffre sur lequel les paiements d'intérêts sont calculés."
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:242
+#: src/components/first-nations/FirstNationsPageContent.tsx:261
 msgid "Total Expenses"
 msgstr "Dépenses totales"
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:256
+#: src/components/first-nations/FirstNationsPageContent.tsx:275
 msgid "Total expenses in FY {fiscalYear}"
 msgstr "Dépenses totales pour l'exercice {fiscalYear}"
 
@@ -3524,7 +3541,7 @@ msgstr "Dépenses totales pour l'exercice {fiscalYear}"
 msgid "Total Federal Tax"
 msgstr "Total impôt fédéral"
 
-#: src/components/first-nations/FinancialPositionStats.tsx:156
+#: src/components/first-nations/FinancialPositionStats.tsx:168
 msgid "Total Financial Assets"
 msgstr "Total des actifs financiers"
 
@@ -3533,11 +3550,11 @@ msgstr "Total des actifs financiers"
 msgid "Total full-time equivalents"
 msgstr "Équivalents temps plein totaux"
 
-#: src/components/first-nations/FinancialPositionStats.tsx:179
+#: src/components/first-nations/FinancialPositionStats.tsx:191
 msgid "Total Liabilities"
 msgstr "Total des passifs"
 
-#: src/components/first-nations/FinancialPositionStats.tsx:266
+#: src/components/first-nations/FinancialPositionStats.tsx:278
 msgid "Total net assets"
 msgstr "Total des actifs nets"
 
@@ -3549,7 +3566,7 @@ msgstr "Total des paiements"
 msgid "Total property tax revenue divided by population. Primary revenue source for municipalities."
 msgstr "Revenus totaux de l'impôt foncier divisés par la population. Source de revenus principale pour les municipalités."
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:222
+#: src/components/first-nations/FirstNationsPageContent.tsx:241
 #: src/components/JurisdictionPageContent.tsx:160
 msgid "Total Revenue"
 msgstr "Revenus totaux"
@@ -3559,7 +3576,7 @@ msgstr "Revenus totaux"
 msgid "Total revenue in {0}"
 msgstr "Revenus totaux en {0}"
 
-#: src/components/first-nations/FirstNationsPageContent.tsx:236
+#: src/components/first-nations/FirstNationsPageContent.tsx:255
 msgid "Total revenue in FY {fiscalYear}"
 msgstr "Revenus totaux pour l'exercice {fiscalYear}"
 
@@ -3659,10 +3676,6 @@ msgstr "Transport + Communication"
 msgid "Transportation and Communication"
 msgstr "Transport et Communication"
 
-#: src/components/first-nations/RemunerationTable.tsx:85
-msgid "Travel"
-msgstr "Voyages"
-
 #: src/app/[lang]/(main)/federal/spending/page.tsx:241
 #: src/app/[lang]/(main)/federal/spending/page.tsx:262
 #: src/app/[lang]/(main)/spending/page.tsx:232
@@ -3759,7 +3772,7 @@ msgid "Visitors, International Students + Temporary Workers"
 msgstr "Visiteurs, étudiants internationaux + travailleurs temporaires"
 
 #. placeholder {0}: firstNation.name
-#: src/components/first-nations/FirstNationsPageContent.tsx:291
+#: src/components/first-nations/FirstNationsPageContent.tsx:322
 msgid "Visual breakdown of {0}'s revenue sources and how funds were spent during fiscal year {fiscalYear}."
 msgstr "Répartition visuelle des sources de revenus de {0} et de la façon dont les fonds ont été dépensés au cours de l'exercice {fiscalYear}."
 
@@ -3849,11 +3862,11 @@ msgstr "Nous ne vous disons pas quoi penser—nous vous donnons les faits. Renco
 msgid "We love to hear from the community."
 msgstr "Nous aimons avoir des nouvelles de la communauté."
 
-#: src/app/[lang]/(main)/page.tsx:53
+#: src/app/[lang]/(main)/page.tsx:52
 msgid "We share clear insights to level up transparency"
 msgstr "Nous partageons des informations claires pour améliorer la transparence"
 
-#: src/app/[lang]/(main)/page.tsx:139
+#: src/app/[lang]/(main)/page.tsx:131
 msgid "We turn complex government data into clear insights. We explain federal spending so every Canadian can understand where their money goes."
 msgstr "Nous transformons des données gouvernementales complexes en informations claires. Nous expliquons les dépenses fédérales pour que chaque Canadien comprenne où va son argent."
 
@@ -3865,7 +3878,7 @@ msgstr "Nous accueillons des personnes passionnées qui veulent faire une diffé
 msgid "We were frustrated by the lack of clear, accessible, unbiased data on government spending. We wanted to create a platform that focused on giving Canadians data-driven facts about how their money is being spent without spin."
 msgstr "Nous étions frustrés par le manque de données claires, accessibles et impartiales sur les dépenses gouvernementales. Nous voulions créer une plateforme qui se concentre sur la présentation aux Canadiens de faits basés sur des données concernant la façon dont leur argent est dépensé, sans parti pris."
 
-#: src/app/[lang]/(main)/page.tsx:169
+#: src/app/[lang]/(main)/page.tsx:161
 msgid "We're strictly non-partisan—we don't judge policies or debate spending decisions. Our only goal is to ensure that every Canadian understands how the federal government spends money."
 msgstr "Nous sommes strictement non partisans—nous ne jugeons pas les politiques ni ne débattons des décisions de dépenses. Notre seul objectif est de nous assurer que chaque Canadien comprenne comment le gouvernement fédéral dépense l'argent."
 
@@ -4001,7 +4014,7 @@ msgstr "Année"
 msgid "You can access our whistleblower platform directly through your web browser at:"
 msgstr "Vous pouvez accéder à notre plateforme de dénonciation directement via votre navigateur web à :"
 
-#: src/app/[lang]/(main)/page.tsx:106
+#: src/app/[lang]/(main)/page.tsx:98
 msgid "You deserve the facts"
 msgstr "Vous méritez les faits"
 

--- a/src/locales/fr.po
+++ b/src/locales/fr.po
@@ -276,7 +276,7 @@ msgstr "Âge"
 msgid "Agriculture"
 msgstr "Agriculture"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:266
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:270
 msgid "Aid Type"
 msgstr "Type d'aide"
 
@@ -371,7 +371,7 @@ msgstr "Dépenses municipales annuelles par résident de {0}"
 msgid "Annual payroll"
 msgstr "Masse salariale annuelle"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:90
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:94
 msgid "Application ID"
 msgstr "ID de la demande"
 
@@ -384,7 +384,7 @@ msgstr "Appliqué à l'impôt provincial de {0}"
 msgid "Are you DOGE?"
 msgstr "Êtes-vous DOGE?"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:176
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:180
 msgid "Area of Research"
 msgstr "Domaine de recherche"
 
@@ -418,7 +418,7 @@ msgstr "Actifs, passifs et situation financière nette à la fin de l'exercice f
 msgid "Average annual compensation"
 msgstr "Rémunération annuelle moyenne"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:67
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:71
 msgid "Awarded"
 msgstr "Attribué"
 
@@ -609,7 +609,7 @@ msgstr "Revendication"
 msgid "Claims Settlements"
 msgstr "Règlements des revendications"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:166
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:170
 msgid "Co-Applicant(s)"
 msgstr "Co-demandeur(s)"
 
@@ -617,7 +617,7 @@ msgstr "Co-demandeur(s)"
 msgid "Coastguard Operations"
 msgstr "Opérations de la Garde côtière"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:268
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:272
 msgid "Collaboration Type"
 msgstr "Type de collaboration"
 
@@ -646,9 +646,9 @@ msgstr "Comparez votre fardeau fiscal total dans toutes les provinces et territo
 msgid "Compensation per Employee"
 msgstr "Rémunération par employé"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:77
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:124
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:170
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:81
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:128
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:174
 msgid "Competition Year"
 msgstr "Année de concours"
 
@@ -667,7 +667,7 @@ msgstr "Connectez-vous avec nous"
 msgid "Contact"
 msgstr "Contact"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:253
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:257
 msgid "Contributing Organization"
 msgstr "Organisation contributrice"
 
@@ -691,7 +691,7 @@ msgstr "Impôts sur le revenu des sociétés"
 msgid "Corrections"
 msgstr "Services correctionnels"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:243
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:247
 msgid "Countries"
 msgstr "Pays"
 
@@ -778,8 +778,8 @@ msgstr "Équipe de la défense"
 msgid "Deficit"
 msgstr "Déficit"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:74
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:322
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:78
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:326
 msgid "Department"
 msgstr "Ministère"
 
@@ -837,7 +837,7 @@ msgstr "Les dépenses directes font référence à l'argent alloué aux programm
 msgid "Disaster Relief"
 msgstr "Secours aux sinistrés"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:174
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:178
 msgid "Discipline"
 msgstr "Discipline"
 
@@ -853,7 +853,7 @@ msgstr "Ne discutez pas de votre soumission avec quiconque et ne recherchez pas 
 msgid "Download and install the <0>Tor Browser</0> from the official Tor Project website."
 msgstr "Téléchargez et installez le <0>navigateur Tor</0> depuis le site officiel du projet Tor."
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:122
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:126
 msgid "Duration"
 msgstr "Durée"
 
@@ -923,7 +923,7 @@ msgstr "Assurance-emploi"
 msgid "Employment Insurance Premiums"
 msgstr "Cotisations d'assurance-emploi"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:240
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:244
 msgid "End Date"
 msgstr "Date de fin"
 
@@ -1023,17 +1023,17 @@ msgstr "Taxe d'accise — Essence d'aviation et carburéacteur"
 msgid "Excise Tax — Gasoline"
 msgstr "Taxe d'accise — Essence"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:245
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:249
 msgid "Executing Agency/Partner"
 msgstr "Agence/Partenaire d'exécution"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:258
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:262
 msgid "Expected Results"
 msgstr "Résultats attendus"
 
 #: src/components/first-nations/RemunerationTable.tsx:259
 msgid "Expenses"
-msgstr ""
+msgstr "Dépenses"
 
 #: src/app/[lang]/(main)/federal/budget/layout.tsx:17
 msgid "Explore Canada's federal budget with interactive visualizations and detailed analysis of government revenue and expenditures."
@@ -1046,7 +1046,7 @@ msgstr "Explorez la répartition des salaires des employés fédéraux par anné
 
 #: src/app/[lang]/(main)/page.tsx:65
 msgid "Explore Federal Spending"
-msgstr ""
+msgstr "Explorer les dépenses fédérales"
 
 #: src/app/[lang]/(main)/first-nations/page.tsx:36
 msgid "Explore financial data from First Nations across Canada. Data is extracted from annual reports published under the First Nations Financial Transparency Act (FNFTA), including statements of operations, financial position, and remuneration."
@@ -1054,7 +1054,7 @@ msgstr "Explorez les données financières des Premières Nations à travers le 
 
 #: src/app/[lang]/(main)/page.tsx:75
 msgid "Explore First Nations"
-msgstr ""
+msgstr "Explorer les Premières Nations"
 
 #: src/app/[lang]/(main)/federal/spending/layout.tsx:17
 msgid "Explore how the Canadian federal government spends your tax dollars across departments and programs."
@@ -1086,7 +1086,7 @@ msgstr "Explorer d'autres ministères fédéraux"
 msgid "Explore revenue and spending categories or filter by agency for deeper insights."
 msgstr "Explorez les catégories de revenus et de dépenses ou filtrez par organisme pour des analyses plus approfondies."
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:133
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:137
 msgid "External ID"
 msgstr "ID externe"
 
@@ -1263,7 +1263,7 @@ msgstr "Total fédéral"
 msgid "Finance Canada"
 msgstr "Finance Canada"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:271
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:275
 msgid "Finance Type"
 msgstr "Type de financement"
 
@@ -1273,7 +1273,7 @@ msgstr "Type de financement"
 #. placeholder {3}: firstNation.populationRegistered != null && firstNation.populationOnReserve != null && ( <> {" "} with a registered population of{" "} {firstNation.populationRegistered.toLocaleString()} and an on-reserve population of{" "} {firstNation.populationOnReserve.toLocaleString()} </> )
 #: src/components/first-nations/FirstNationsPageContent.tsx:286
 msgid "Financial data for {0} for fiscal year {fiscalYear}. {1} is a First Nation in {2}{3}. Information is extracted from publicly available annual reports published under the First Nations Financial Transparency Act."
-msgstr ""
+msgstr "Données financières pour {0} pour l'exercice {fiscalYear}. {1} est une Première Nation en {2}{3}. Les informations sont extraites des rapports annuels publiés en vertu de la Loi sur la transparence financière des Premières Nations."
 
 #: src/app/[lang]/(main)/first-nations/[bcid]/page.tsx:72
 msgid "Financial data from annual reports published under the First Nations Financial Transparency Act will appear here once available."
@@ -1333,9 +1333,9 @@ msgstr "Données financières des Premières Nations"
 msgid "Fiscal arrangements"
 msgstr "Arrangements fiscaux"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:80
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:173
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:326
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:84
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:177
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:330
 msgid "Fiscal Year"
 msgstr "Exercice financier"
 
@@ -1512,7 +1512,7 @@ msgstr "Données sur l'effectif et les dépenses gouvernementales | Voir la rép
 
 #: src/components/first-nations/RemunerationTable.tsx:285
 msgid "Grand Total"
-msgstr ""
+msgstr "Total général"
 
 #: src/components/Sankey/index.tsx:599
 msgid "Grants to Support the New Fiscal Relationship with First Nations"
@@ -1870,12 +1870,12 @@ msgstr "Innovation, Sciences et Industrie Canada | Canada Spends"
 msgid "Innovative and Sustainable Natural Resources Development"
 msgstr "Développement innovant et durable des ressources naturelles"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:68
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:72
 msgid "Installment"
 msgstr "Versement"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:73
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:120
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:77
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:124
 msgid "Institution"
 msgstr "Institution"
 
@@ -1983,7 +1983,7 @@ msgstr "Revendications territoriales"
 
 #: src/components/first-nations/FinancialPositionStats.tsx:290
 msgid "Land, buildings, equipment, vehicles, and infrastructure owned by the First Nation."
-msgstr ""
+msgstr "Terrains, bâtiments, équipements, véhicules et infrastructures appartenant à la Première Nation."
 
 #: src/components/first-nations/ClaimsTable.tsx:142
 msgid "Last Update"
@@ -1998,7 +1998,7 @@ msgstr "Dernières nouvelles budgétaires et impact"
 msgid "Learn more about the technology at <0>globaleaks.org</0>."
 msgstr "En savoir plus sur la technologie sur <0>globaleaks.org</0>."
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:332
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:336
 msgid "Location"
 msgstr "Emplacement"
 
@@ -2061,7 +2061,7 @@ msgstr "TCS Manitoba"
 msgid "Manitoba STP"
 msgstr "TPS Manitoba"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:249
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:253
 msgid "Maximum Contribution"
 msgstr "Contribution maximale"
 
@@ -2073,7 +2073,7 @@ msgstr "Méthodologie"
 msgid "Ministries + Agencies"
 msgstr "Ministères + Organismes"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:325
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:329
 msgid "Ministry"
 msgstr "Ministère"
 
@@ -2083,7 +2083,7 @@ msgstr "Revenus divers"
 
 #: src/components/first-nations/RemunerationTable.tsx:122
 msgid "Months"
-msgstr ""
+msgstr "Mois"
 
 #: src/components/DepartmentList.tsx:45
 msgid "More coming soon..."
@@ -2441,7 +2441,7 @@ msgstr "Dépenses opérationnelles"
 msgid "or subscribe to"
 msgstr "ou abonnez-vous à"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:164
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:168
 msgid "Organization"
 msgstr "Organisation"
 
@@ -2577,7 +2577,7 @@ msgstr "Règlement hors cour"
 msgid "Parliament"
 msgstr "Parlement"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:334
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:338
 msgid "Payment Amount"
 msgstr "Montant du paiement"
 
@@ -2655,11 +2655,9 @@ msgstr "Tarification de la pollution"
 msgid "Pollution pricing proceeds"
 msgstr "Produits de la tarification de la pollution"
 
-#. placeholder {0}: populationData[0]?.year
-#. placeholder {1}: populationData[populationData.length - 1]?.year
 #: src/components/first-nations/PopulationCharts.tsx:125
-msgid "Population trends for {bandName} from {0} to {1}."
-msgstr ""
+#~ msgid "Population trends for {bandName} from {0} to {1}."
+#~ msgstr ""
 
 #: src/components/first-nations/RemunerationTable.tsx:107
 msgid "Position"
@@ -2686,12 +2684,12 @@ msgstr "TCS Île-du-Prince-Édouard"
 msgid "Prince Edward Island STP"
 msgstr "TPS Île-du-Prince-Édouard"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:161
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:165
 msgid "Principal Applicant"
 msgstr "Demandeur principal"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:70
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:117
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:74
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:121
 msgid "Principal Investigator"
 msgstr "Chercheur principal"
 
@@ -2718,15 +2716,15 @@ msgstr "Services professionnels + spéciaux"
 msgid "Professional and Special Services"
 msgstr "Services professionnels et spéciaux"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:276
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:280
 msgid "Program Name"
 msgstr "Nom du programme"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:127
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:131
 msgid "Program Type"
 msgstr "Type de programme"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:231
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:235
 msgid "Project Number"
 msgstr "Numéro de projet"
 
@@ -2753,8 +2751,8 @@ msgstr "Revenus de l'impôt foncier par résident de {0}"
 msgid "Prov."
 msgstr "Prov."
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:75
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:121
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:79
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:125
 msgid "Province"
 msgstr "Province"
 
@@ -2893,21 +2891,21 @@ msgstr "Forces prêtes"
 msgid "Recent developments and their projected impact on the Fall 2025 Budget"
 msgstr "Développements récents et leur impact projeté sur le budget de l'automne 2025"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:331
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:335
 msgid "Recipient"
 msgstr "Bénéficiaire"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:328
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:332
 msgid "Recipient Class"
 msgstr "Classe de bénéficiaire"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:282
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:286
 msgid "Regions"
 msgstr "Régions"
 
 #: src/components/first-nations/RemunerationTable.tsx:233
 msgid "Remuneration"
-msgstr ""
+msgstr "Rémunération"
 
 #: src/components/first-nations/FirstNationsPageContent.tsx:423
 msgid "Remuneration and Expenses"
@@ -2948,7 +2946,7 @@ msgstr "Réparation + Entretien"
 msgid "Repair and Maintenance"
 msgstr "Réparation et entretien"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:273
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:277
 msgid "Reporting Organization"
 msgstr "Organisation déclarante"
 
@@ -2956,12 +2954,12 @@ msgstr "Organisation déclarante"
 msgid "Research"
 msgstr "Recherche"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:86
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:130
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:90
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:134
 msgid "Research Subject"
 msgstr "Sujet de recherche"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:263
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:267
 msgid "Results Achieved"
 msgstr "Résultats obtenus"
 
@@ -3042,11 +3040,11 @@ msgstr "Voyez comment le gouvernement du Canada dépense les dollars des contrib
 msgid "See how your taxes are spent across federal and provincial programs. Interactive calculator for Canadian taxpayers."
 msgstr "Voyez comment vos impôts sont dépensés dans les programmes fédéraux et provinciaux. Calculateur interactif pour les contribuables canadiens."
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:82
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:86
 msgid "Selection Committee"
 msgstr "Comité de sélection"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:278
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:282
 msgid "Selection Mechanism"
 msgstr "Mécanisme de sélection"
 
@@ -3157,7 +3155,7 @@ msgstr "Niveau de vie"
 msgid "Standard of Living and Assistance to Address Inequalities"
 msgstr "Niveau de vie et aide pour réduire les inégalités"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:236
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:240
 msgid "Start Date"
 msgstr "Date de début"
 
@@ -3173,7 +3171,7 @@ msgstr "État de la situation financière"
 msgid "Statistics Canada"
 msgstr "Statistique Canada"
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:234
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:238
 #: src/components/first-nations/ClaimsTable.tsx:136
 msgid "Status"
 msgstr "Statut"
@@ -3200,11 +3198,11 @@ msgstr "Abonnez-vous à notre infolettre"
 
 #: src/components/first-nations/RemunerationTable.tsx:270
 msgid "Subtotal - Expenses"
-msgstr ""
+msgstr "Sous-total - Dépenses"
 
 #: src/components/first-nations/RemunerationTable.tsx:244
 msgid "Subtotal - Remuneration"
-msgstr ""
+msgstr "Sous-total - Rémunération"
 
 #: src/app/[lang]/(main)/search/[database]/[id]/DetailsPage.tsx:71
 msgid "Summary"
@@ -3237,7 +3235,7 @@ msgstr "Bases durables, systèmes TI, infrastructure"
 
 #: src/components/first-nations/FinancialPositionStats.tsx:287
 msgid "Tangible Capital Assets"
-msgstr ""
+msgstr "Immobilisations corporelles"
 
 #: src/components/first-nations/FinancialPositionStats.tsx:244
 msgid "Tangible capital assets such as land, buildings, equipment, and infrastructure."
@@ -3454,7 +3452,7 @@ msgstr "Services publics et Approvisionnement Canada (SPAC) est le ministère f�
 msgid "The values you see here are based on the FY 2024 Budget with preliminary updates based on government announcements, memos, and leaks, and are meant to provide a rough idea of the budget. Once the official Fall 2025 Budget is released on November 4th, we will update this page to reflect the official budget."
 msgstr "Les valeurs que vous voyez ici sont basées sur le budget de l'exercice 2024 avec des mises à jour préliminaires basées sur les annonces gouvernementales, les notes de service et les fuites, et sont destinées à donner une idée générale du budget. Une fois le budget officiel de l'automne 2025 publié le 4 novembre, nous mettrons à jour cette page pour refléter le budget officiel."
 
-#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:128
+#: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:132
 msgid "Theme"
 msgstr "Thème"
 


### PR DESCRIPTION
## Summary

- Display merged cells in the First Nations index table for sub-bands and self-governed nations
- Sub-bands show a message with a link to their parent band's profile page
- Self-governed nations show their membership authority and FNFTA exemption status
- Years with actual data still display normally; merged cell only spans years without data

## Changes

- **types.ts**: Added new fields to `ExtractionAvailabilityResponse` and `FirstNationInfo`:
  - `membershipAuthority` / `membership_authority`
  - `isSubBand` / `is_sub_band`
  - `isSelfGoverned` / `is_self_governed`
  - `parentBandBcid` / `parent_band_bcid`
  - `parentBandName` / `parent_band_name`

- **first-nations.ts**: Updated `toFirstNationInfo()` to map the new fields

- **FirstNationsSearch.tsx**: Modified `FirstNationRow` component to:
  - Calculate last year with data
  - Render merged cell spanning remaining years for sub-bands/self-governed nations
  - Show appropriate message with link for sub-bands

## Test plan

- [x] Verify self-governed nations with data (e.g., Whitecap Dakota Nation) show data cells then merged message
- [x] Verify self-governed nations with no data (e.g., Naskapi Nation) show merged cell spanning all years
- [x] Verify sub-bands (e.g., Aishihik, Bay of Quinte Mohawk) show sub-band message with parent band link
- [x] Verify regular First Nations still show normal gray FS/R boxes for years without data

🤖 Generated with [Claude Code](https://claude.com/claude-code)