### PR TITLE
Remove Vercel Analytics dependency and usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@radix-ui/react-slot": "^1.2.3",
     "@tailwindcss/forms": "^0.5.10",
     "@types/mdx": "^2.0.13",
-    "@vercel/analytics": "^1.5.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,9 +71,6 @@ importers:
       '@types/mdx':
         specifier: ^2.0.13
         version: 2.0.13
-      '@vercel/analytics':
-        specifier: ^1.5.0
-        version: 1.5.0(next@15.4.8(@babel/core@7.28.3)(babel-plugin-macros@3.1.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1988,32 +1985,6 @@ packages:
     resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
     cpu: [x64]
     os: [win32]
-
-  '@vercel/analytics@1.5.0':
-    resolution: {integrity: sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==}
-    peerDependencies:
-      '@remix-run/react': ^2
-      '@sveltejs/kit': ^1 || ^2
-      next: '>= 13'
-      react: ^18 || ^19 || ^19.0.0-rc
-      svelte: '>= 4'
-      vue: ^3
-      vue-router: ^4
-    peerDependenciesMeta:
-      '@remix-run/react':
-        optional: true
-      '@sveltejs/kit':
-        optional: true
-      next:
-        optional: true
-      react:
-        optional: true
-      svelte:
-        optional: true
-      vue:
-        optional: true
-      vue-router:
-        optional: true
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -6674,11 +6645,6 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
-
-  '@vercel/analytics@1.5.0(next@15.4.8(@babel/core@7.28.3)(babel-plugin-macros@3.1.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)':
-    optionalDependencies:
-      next: 15.4.8(@babel/core@7.28.3)(babel-plugin-macros@3.1.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      react: 19.1.1
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:

--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -3,7 +3,6 @@ import { LinguiClientProvider } from "@/components/LinguiClientProvider";
 import { initLingui, PageLangParam } from "@/initLingui";
 import { generateHreflangAlternates } from "@/lib/utils";
 import { useLingui } from "@lingui/react/macro";
-import { Analytics } from "@vercel/analytics/next";
 import { PropsWithChildren } from "react";
 import { Toaster } from "sonner";
 import "./globals.css";
@@ -78,7 +77,6 @@ export default async function RootLayout({
             <Toaster position="top-right" richColors />
           </LinguiClientProvider>
         </PostHogProvider>
-        <Analytics />
         {/* Simple Analytics Script */}
         <script
           async

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import { allMessages } from "@/appRouterI18n";
 import { LinguiClientProvider } from "@/components/LinguiClientProvider";
 import { initLingui } from "@/initLingui";
-import { Analytics } from "@vercel/analytics/next";
 import { ReactNode } from "react";
 import { Toaster } from "sonner";
 import "./[lang]/globals.css";
@@ -24,7 +23,6 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             <Toaster position="top-right" richColors />
           </LinguiClientProvider>
         </PostHogProvider>
-        <Analytics />
         {/* Simple Analytics Script */}
         <script
           async


### PR DESCRIPTION
Vercel Analytics is no longer needed since the project uses Simple Analytics
and PostHog for tracking.

https://claude.ai/code/session_01TYCqP3HSzFi9pTFkMs75rR