### PR TITLE
Add Supabase Auth with OAuth and PostHog identification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# PostHog (optional — analytics disabled if not set)
+# NEXT_PUBLIC_POSTHOG_KEY=
+
+# Supabase (required at build time — prerendering will fail without these)
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,10 @@ yarn-error.log*
 # vercel
 .vercel
 
+# cloudflare
+.open-next
+.dev.vars
+
 # typescript
 *.tsbuildinfo
 next-env.d.ts

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,9 @@ import {
   getProvincialSlugs,
   getMunicipalitiesByProvince,
 } from "./src/lib/jurisdictions";
+import { initOpenNextCloudflareForDev } from "@opennextjs/cloudflare";
+
+initOpenNextCloudflareForDev();
 
 const nextConfig: NextConfig = {
   /* config options here */

--- a/open-next.config.ts
+++ b/open-next.config.ts
@@ -1,0 +1,3 @@
+import { defineCloudflareConfig } from "@opennextjs/cloudflare";
+
+export default defineCloudflareConfig({});

--- a/open-next.config.ts
+++ b/open-next.config.ts
@@ -1,3 +1,9 @@
 import { defineCloudflareConfig } from "@opennextjs/cloudflare";
+import r2IncrementalCache from "@opennextjs/cloudflare/overrides/incremental-cache/r2-incremental-cache";
+import d1NextTagCache from "@opennextjs/cloudflare/overrides/tag-cache/d1-next-tag-cache";
 
-export default defineCloudflareConfig({});
+export default defineCloudflareConfig({
+  incrementalCache: r2IncrementalCache,
+  tagCache: d1NextTagCache,
+  queue: "direct",
+});

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "dev:ntp": "next dev",
-    "build": "pnpm extract && pnpm generate-statics && next build",
+    "build": "pnpm extract && pnpm generate-statics && opennextjs-cloudflare build",
     "generate-statics": "tsx scripts/generate-statics.ts",
     "start": "next start",
     "lint": "next lint",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "dev:ntp": "next dev",
-    "build": "pnpm extract && pnpm generate-statics && opennextjs-cloudflare build",
+    "build": "pnpm extract && pnpm generate-statics && next build",
+    "build:cloudflare": "opennextjs-cloudflare build",
     "generate-statics": "tsx scripts/generate-statics.ts",
     "start": "next start",
     "lint": "next lint",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.3",
+    "@supabase/ssr": "^0.8.0",
+    "@supabase/supabase-js": "^2.95.3",
     "@tailwindcss/forms": "^0.5.10",
     "@types/mdx": "^2.0.13",
     "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,11 @@
     "lint:fix": "next lint --fix",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "prepare": "node -e \"if (!process.env.CI) { require('child_process').execSync('npx simple-git-hooks', {stdio: 'inherit'}) }\"",
-    "extract": "lingui extract --clean"
+    "extract": "lingui extract --clean",
+    "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
+    "deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
+    "upload": "opennextjs-cloudflare build && opennextjs-cloudflare upload",
+    "cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts"
   },
   "dependencies": {
     "@beehiiv/sdk": "^0.1.6",
@@ -27,6 +31,7 @@
     "@mui/icons-material": "^7.3.1",
     "@mui/material": "^7.3.1",
     "@next/mdx": "^15.5.6",
+    "@opennextjs/cloudflare": "^1.16.4",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -93,7 +98,8 @@
     "simple-git-hooks": "^2.13.1",
     "tailwindcss": "^4.1.12",
     "tsx": "^4.20.4",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "wrangler": "^4.65.0"
   },
   "packageManager": "pnpm@9.5.0+sha512.140036830124618d624a2187b50d04289d5a087f326c9edfc0ccd733d76c4f52c3a313d4fc148794a2a9d81553016004e6742e8cf850670268a7387fc220c903",
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,12 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.3(@types/react@19.1.10)(react@19.1.1)
+      '@supabase/ssr':
+        specifier: ^0.8.0
+        version: 0.8.0(@supabase/supabase-js@2.95.3)
+      '@supabase/supabase-js':
+        specifier: ^2.95.3
+        version: 2.95.3
       '@tailwindcss/forms':
         specifier: ^0.5.10
         version: 0.5.10(tailwindcss@4.1.12)
@@ -1540,6 +1546,35 @@ packages:
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
+  '@supabase/auth-js@2.95.3':
+    resolution: {integrity: sha512-vD2YoS8E2iKIX0F7EwXTmqhUpaNsmbU6X2R0/NdFcs02oEfnHyNP/3M716f3wVJ2E5XHGiTFXki6lRckhJ0Thg==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/functions-js@2.95.3':
+    resolution: {integrity: sha512-uTuOAKzs9R/IovW1krO0ZbUHSJnsnyJElTXIRhjJTqymIVGcHzkAYnBCJqd7468Fs/Foz1BQ7Dv6DCl05lr7ig==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/postgrest-js@2.95.3':
+    resolution: {integrity: sha512-LTrRBqU1gOovxRm1vRXPItSMPBmEFqrfTqdPTRtzOILV4jPSueFz6pES5hpb4LRlkFwCPRmv3nQJ5N625V2Xrg==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/realtime-js@2.95.3':
+    resolution: {integrity: sha512-D7EAtfU3w6BEUxDACjowWNJo/ZRo7sDIuhuOGKHIm9FHieGeoJV5R6GKTLtga/5l/6fDr2u+WcW/m8I9SYmaIw==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/ssr@0.8.0':
+    resolution: {integrity: sha512-/PKk8kNFSs8QvvJ2vOww1mF5/c5W8y42duYtXvkOSe+yZKRgTTZywYG2l41pjhNomqESZCpZtXuWmYjFRMV+dw==}
+    peerDependencies:
+      '@supabase/supabase-js': ^2.76.1
+
+  '@supabase/storage-js@2.95.3':
+    resolution: {integrity: sha512-4GxkJiXI3HHWjxpC3sDx1BVrV87O0hfX+wvJdqGv67KeCu+g44SPnII8y0LL/Wr677jB7tpjAxKdtVWf+xhc9A==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/supabase-js@2.95.3':
+    resolution: {integrity: sha512-Fukw1cUTQ6xdLiHDJhKKPu6svEPaCEDvThqCne3OaQyZvuq2qjhJAd91kJu3PXLG18aooCgYBaB6qQz35hhABg==}
+    engines: {node: '>=20.0.0'}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -1798,6 +1833,9 @@ packages:
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
 
+  '@types/phoenix@1.6.7':
+    resolution: {integrity: sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==}
+
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
@@ -1822,6 +1860,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -2388,6 +2429,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   core-js@3.45.0:
     resolution: {integrity: sha512-c2KZL9lP4DjkN3hk/an4pWn5b5ZefhRJnAc42n6LJ19kSnbeRbdQZE5dSeE2LBol1OwJD3X1BQvFTAsa8ReeDA==}
@@ -3134,6 +3179,10 @@ packages:
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -4820,6 +4869,18 @@ packages:
     resolution: {integrity: sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==}
     engines: {node: '>=18'}
 
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -6197,6 +6258,49 @@ snapshots:
 
   '@sinclair/typebox@0.27.8': {}
 
+  '@supabase/auth-js@2.95.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.95.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/postgrest-js@2.95.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.95.3':
+    dependencies:
+      '@types/phoenix': 1.6.7
+      '@types/ws': 8.18.1
+      tslib: 2.8.1
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@supabase/ssr@0.8.0(@supabase/supabase-js@2.95.3)':
+    dependencies:
+      '@supabase/supabase-js': 2.95.3
+      cookie: 1.1.1
+
+  '@supabase/storage-js@2.95.3':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.95.3':
+    dependencies:
+      '@supabase/auth-js': 2.95.3
+      '@supabase/functions-js': 2.95.3
+      '@supabase/postgrest-js': 2.95.3
+      '@supabase/realtime-js': 2.95.3
+      '@supabase/storage-js': 2.95.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -6466,6 +6570,8 @@ snapshots:
 
   '@types/parse-json@4.0.2': {}
 
+  '@types/phoenix@1.6.7': {}
+
   '@types/prop-types@15.7.15': {}
 
   '@types/qs@6.14.0': {}
@@ -6485,6 +6591,10 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 20.19.25
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -7101,6 +7211,8 @@ snapshots:
   convert-source-map@1.9.0: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie@1.1.1: {}
 
   core-js@3.45.0: {}
 
@@ -8107,6 +8219,8 @@ snapshots:
   htm@3.1.1: {}
 
   html-void-elements@3.0.0: {}
+
+  iceberg-js@0.8.1: {}
 
   iconv-lite@0.6.3:
     dependencies:
@@ -10217,6 +10331,8 @@ snapshots:
       ansi-styles: 6.2.1
       string-width: 7.2.0
       strip-ansi: 7.1.0
+
+  ws@8.19.0: {}
 
   yallist@3.1.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@next/mdx':
         specifier: ^15.5.6
         version: 15.5.6(@mdx-js/loader@3.1.1(webpack@5.98.0))(@mdx-js/react@3.1.1(@types/react@19.1.10)(react@19.1.1))
+      '@opennextjs/cloudflare':
+        specifier: ^1.16.4
+        version: 1.16.4(next@15.4.8(@babel/core@7.28.3)(babel-plugin-macros@3.1.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(wrangler@4.65.0)
       '@radix-ui/react-accordion':
         specifier: ^1.2.12
         version: 1.2.12(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -240,6 +243,9 @@ importers:
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
+      wrangler:
+        specifier: ^4.65.0
+        version: 4.65.0
 
 packages:
 
@@ -311,6 +317,263 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@ast-grep/napi-darwin-arm64@0.40.5':
+    resolution: {integrity: sha512-2F072fGN0WTq7KI3okuEnkGJVEHLbi56Bw1H6NAMf7j2mJJeQWsRyGOMcyNnUXZDeNdvoMH0OB2a5wwUegY/nQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@ast-grep/napi-darwin-x64@0.40.5':
+    resolution: {integrity: sha512-dJMidHZhhxuLBYNi6/FKI812jQ7wcFPSKkVPwviez2D+KvYagapUMAV/4dJ7FCORfguVk8Y0jpPAlYmWRT5nvA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@ast-grep/napi-linux-arm64-gnu@0.40.5':
+    resolution: {integrity: sha512-nBRCbyoS87uqkaw4Oyfe5VO+SRm2B+0g0T8ME69Qry9ShMf41a2bTdpcQx9e8scZPogq+CTwDHo3THyBV71l9w==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@ast-grep/napi-linux-arm64-musl@0.40.5':
+    resolution: {integrity: sha512-/qKsmds5FMoaEj6FdNzepbmLMtlFuBLdrAn9GIWCqOIcVcYvM1Nka8+mncfeXB/MFZKOrzQsQdPTWqrrQzXLrA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@ast-grep/napi-linux-x64-gnu@0.40.5':
+    resolution: {integrity: sha512-DP4oDbq7f/1A2hRTFLhJfDFR6aI5mRWdEfKfHzRItmlKsR9WlcEl1qDJs/zX9R2EEtIDsSKRzuJNfJllY3/W8Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@ast-grep/napi-linux-x64-musl@0.40.5':
+    resolution: {integrity: sha512-BRZUvVBPUNpWPo6Ns8chXVzxHPY+k9gpsubGTHy92Q26ecZULd/dTkWWdnvfhRqttsSQ9Pe/XQdi5+hDQ6RYcg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@ast-grep/napi-win32-arm64-msvc@0.40.5':
+    resolution: {integrity: sha512-y95zSEwc7vhxmcrcH0GnK4ZHEBQrmrszRBNQovzaciF9GUqEcCACNLoBesn4V47IaOp4fYgD2/EhGRTIBFb2Ug==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@ast-grep/napi-win32-ia32-msvc@0.40.5':
+    resolution: {integrity: sha512-K/u8De62iUnFCzVUs7FBdTZ2Jrgc5/DLHqjpup66KxZ7GIM9/HGME/O8aSoPkpcAeCD4TiTZ11C1i5p5H98hTg==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@ast-grep/napi-win32-x64-msvc@0.40.5':
+    resolution: {integrity: sha512-dqm5zg/o4Nh4VOQPEpMS23ot8HVd22gG0eg01t4CFcZeuzyuSgBlOL3N7xLbz3iH2sVkk7keuBwAzOIpTqziNQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@ast-grep/napi@0.40.5':
+    resolution: {integrity: sha512-hJA62OeBKUQT68DD2gDyhOqJxZxycqg8wLxbqjgqSzYttCMSDL9tiAQ9abgekBYNHudbJosm9sWOEbmCDfpX2A==}
+    engines: {node: '>= 10'}
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/crc32c@5.2.0':
+    resolution: {integrity: sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==}
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    resolution: {integrity: sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-cloudfront@3.984.0':
+    resolution: {integrity: sha512-couDuDLpJtoeWne/nYyJ+I+5ntBVdNgBVRTCoDaXuVV7OC3u/wz5Ps0+GogspEwMLEFoOJ8t691h3YXQtnpQTw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-dynamodb@3.984.0':
+    resolution: {integrity: sha512-8/Oft9MWQtbG6p9f8eY5fsKC2CcO5YVDlwive8eUYS9mEbgnyQxm68OyH26WvsSTykQ9QkIbR+fOG56RsIBODw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-lambda@3.984.0':
+    resolution: {integrity: sha512-kqwNBIGNxGVhINwgN/UQfdsQkaMjbu9PFV2EhATWouV+RT60uMjK9JENgLDwbgJmEVbbnPsh9HaZ5KKwPSdiDg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-s3@3.984.0':
+    resolution: {integrity: sha512-7ny2Slr93Y+QniuluvcfWwyDi32zWQfznynL56Tk0vVh7bWrvS/odm8WP2nInKicRVNipcJHY2YInur6Q/9V0A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-sqs@3.984.0':
+    resolution: {integrity: sha512-TDvHpOUWlpanc3xQ5Xw0y8L2hoojBFCCSmXQ/6rKqGOf1ScX3dMA+K9aF0Zp0iwjhSh4VvsHD42esl8XwQZDjA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-sso@3.989.0':
+    resolution: {integrity: sha512-3sC+J1ru5VFXLgt9KZmXto0M7mnV5RkS6FNGwRMK3XrojSjHso9DLOWjbnXhbNv4motH8vu53L1HK2VC1+Nj5w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.973.9':
+    resolution: {integrity: sha512-cyUOfJSizn8da7XrBEFBf4UMI4A6JQNX6ZFcKtYmh/CrwfzsDcabv3k/z0bNwQ3pX5aeq5sg/8Bs/ASiL0bJaA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/crc64-nvme@3.972.0':
+    resolution: {integrity: sha512-ThlLhTqX68jvoIVv+pryOdb5coP1cX1/MaTbB9xkGDCbWbsqQcLqzPxuSoW1DCnAAIacmXCWpzUNOB9pv+xXQw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.7':
+    resolution: {integrity: sha512-r8kBtglvLjGxBT87l6Lqkh9fL8yJJ6O4CYQPjKlj3AkCuL4/4784x3rxxXWw9LTKXOo114VB6mjxAuy5pI7XIg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.9':
+    resolution: {integrity: sha512-40caFblEg/TPrp9EpvyMxp4xlJ5TuTI+A8H6g8FhHn2hfH2PObFAPLF9d5AljK/G69E1YtTklkuQeAwPlV3w8Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.7':
+    resolution: {integrity: sha512-zeYKrMwM5bCkHFho/x3+1OL0vcZQ0OhTR7k35tLq74+GP5ieV3juHXTZfa2LVE0Bg75cHIIerpX0gomVOhzo/w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.7':
+    resolution: {integrity: sha512-Q103cLU6OjAllYjX7+V+PKQw654jjvZUkD+lbUUiFbqut6gR5zwl1DrelvJPM5hnzIty7BCaxaRB3KMuz3M/ug==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.8':
+    resolution: {integrity: sha512-AaDVOT7iNJyLjc3j91VlucPZ4J8Bw+eu9sllRDugJqhHWYyR3Iyp2huBUW8A3+DfHoh70sxGkY92cThAicSzlQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.7':
+    resolution: {integrity: sha512-hxMo1V3ujWWrQSONxQJAElnjredkRpB6p8SDjnvRq70IwYY38R/CZSys0IbhRPxdgWZ5j12yDRk2OXhxw4Gj3g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.7':
+    resolution: {integrity: sha512-ZGKBOHEj8Ap15jhG2XMncQmKLTqA++2DVU2eZfLu3T/pkwDyhCp5eZv5c/acFxbZcA/6mtxke+vzO/n+aeHs4A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.7':
+    resolution: {integrity: sha512-AbYupBIoSJoVMlbMqBhNvPhqj+CdGtzW7Uk4ZIMBm2br18pc3rkG1VaKVFV85H87QCvLHEnni1idJjaX1wOmIw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/dynamodb-codec@3.972.10':
+    resolution: {integrity: sha512-Q41dpb2kqx5FEq/qtTHXB5ocHVLaFzdKTogKHEZyylV0Wt+uJwhAPMzJ46+dL/4K20ZPGvkNRK3cOqp8Su/CIw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/endpoint-cache@3.972.2':
+    resolution: {integrity: sha512-3L7mwqSLJ6ouZZKtCntoNF0HTYDNs1FDQqkGjoPWXcv1p0gnLotaDmLq1rIDqfu4ucOit0Re3ioLyYDUTpSroA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-bucket-endpoint@3.972.3':
+    resolution: {integrity: sha512-fmbgWYirF67YF1GfD7cg5N6HHQ96EyRNx/rDIrTF277/zTWVuPI2qS/ZHgofwR1NZPe/NWvoppflQY01LrbVLg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-endpoint-discovery@3.972.3':
+    resolution: {integrity: sha512-xAxA8/TOygQmMrzcw9CrlpTHCGWSG/lvzrHCySfSZpDN4/yVSfXO+gUwW9WxeskBmuv9IIFATOVpzc9EzfTZ0Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-expect-continue@3.972.3':
+    resolution: {integrity: sha512-4msC33RZsXQpUKR5QR4HnvBSNCPLGHmB55oDiROqqgyOc+TOfVu2xgi5goA7ms6MdZLeEh2905UfWMnMMF4mRg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-flexible-checksums@3.972.7':
+    resolution: {integrity: sha512-YU/5rpz8k2mwFGi2M0px9ChOQZY7Bbow5knB2WLRVPqDM/cG8T5zj55UaWS1qcaFpE7vCX9a9/kvYBlKGcD+KA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-host-header@3.972.3':
+    resolution: {integrity: sha512-aknPTb2M+G3s+0qLCx4Li/qGZH8IIYjugHMv15JTYMe6mgZO8VBpYgeGYsNMGCqCZOcWzuf900jFBG5bopfzmA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-location-constraint@3.972.3':
+    resolution: {integrity: sha512-nIg64CVrsXp67vbK0U1/Is8rik3huS3QkRHn2DRDx4NldrEFMgdkZGI/+cZMKD9k4YOS110Dfu21KZLHrFA/1g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-logger@3.972.3':
+    resolution: {integrity: sha512-Ftg09xNNRqaz9QNzlfdQWfpqMCJbsQdnZVJP55jfhbKi1+FTWxGuvfPoBhDHIovqWKjqbuiew3HuhxbJ0+OjgA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-recursion-detection@3.972.3':
+    resolution: {integrity: sha512-PY57QhzNuXHnwbJgbWYTrqIDHYSeOlhfYERTAuc16LKZpTZRJUjzBFokp9hF7u1fuGeE3D70ERXzdbMBOqQz7Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.9':
+    resolution: {integrity: sha512-F4Ak2HM7te/o3izFTqg/jUTBLjavpaJ5iynKM6aLMwNddXbwAZQ1VbIG8RFUHBo7fBHj2eeN2FNLtIFT4ejWYQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-sqs@3.972.7':
+    resolution: {integrity: sha512-DcJLYE4sRjgUyb2SupQGaRgBYc+j89N9nXeMT0PwwVvaBGmKqcxa7PFvz0kBnQrBckPWlfrPyyyMwOeT5BEp6Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-ssec@3.972.3':
+    resolution: {integrity: sha512-dU6kDuULN3o3jEHcjm0c4zWJlY1zWVkjG9NPe9qxYLLpcbdj5kRYBS2DdWYD+1B9f910DezRuws7xDEqKkHQIg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-user-agent@3.972.9':
+    resolution: {integrity: sha512-1g1B7yf7KzessB0mKNiV9gAHEwbM662xgU+VE4LxyGe6kVGZ8LqYsngjhE+Stna09CJ7Pxkjr6Uq1OtbGwJJJg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.989.0':
+    resolution: {integrity: sha512-Dbk2HMPU3mb6RrSRzgf0WCaWSbgtZG258maCpuN2/ONcAQNpOTw99V5fU5CA1qVK6Vkm4Fwj2cnOnw7wbGVlOw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/region-config-resolver@3.972.3':
+    resolution: {integrity: sha512-v4J8qYAWfOMcZ4MJUyatntOicTzEMaU7j3OpkRCGGFSL2NgXQ5VbxauIyORA+pxdKZ0qQG2tCQjQjZDlXEC3Ow==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.984.0':
+    resolution: {integrity: sha512-TaWbfYCwnuOSvDSrgs7QgoaoXse49E7LzUkVOUhoezwB7bkmhp+iojADm7UepCEu4021SquD7NG1xA+WCvmldA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.989.0':
+    resolution: {integrity: sha512-OdBByMv+OjOZoekrk4THPFpLuND5aIQbDHCGh3n2rvifAbm31+6e0OLhxSeCF1UMPm+nKq12bXYYEoCIx5SQBg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.1':
+    resolution: {integrity: sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-arn-parser@3.972.2':
+    resolution: {integrity: sha512-VkykWbqMjlSgBFDyrY3nOSqupMc6ivXuGmvci6Q3NnLq5kC+mKQe2QBZ4nrWRE/jqOxeFP2uYzLtwncYYcvQDg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-endpoints@3.984.0':
+    resolution: {integrity: sha512-9ebjLA0hMKHeVvXEtTDCCOBtwjb0bOXiuUV06HNeVdgAjH6gj4x4Zwt4IBti83TiyTGOCl5YfZqGx4ehVsasbQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-endpoints@3.989.0':
+    resolution: {integrity: sha512-eKmAOeQM4Qusq0jtcbZPiNWky8XaojByKC/n+THbJ8vJf7t4ys8LlcZ4PrBSHZISe9cC484mQsPVOQh6iySjqw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.4':
+    resolution: {integrity: sha512-H1onv5SkgPBK2P6JR2MjGgbOnttoNzSPIRoeZTNPZYyaplwGg50zS3amXvXqF0/qfXpWEC9rLWU564QTB9bSog==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-user-agent-browser@3.972.3':
+    resolution: {integrity: sha512-JurOwkRUcXD/5MTDBcqdyQ9eVedtAsZgw5rBwktsPTN7QtPiS2Ld1jkJepNgYoCufz1Wcut9iup7GJDoIHp8Fw==}
+
+  '@aws-sdk/util-user-agent-node@3.972.7':
+    resolution: {integrity: sha512-oyhv+FjrgHjP+F16cmsrJzNP4qaRJzkV1n9Lvv4uyh3kLqo3rIe9NSBSBa35f2TedczfG2dD+kaQhHBB47D6Og==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+
+  '@aws-sdk/xml-builder@3.972.4':
+    resolution: {integrity: sha512-0zJ05ANfYqI6+rGqj8samZBFod0dPPousBjLEqg8WdxSgbMAkRgLyn81lP215Do0rFJ/17LIXwr7q0yK24mP6Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.3':
+    resolution: {integrity: sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -386,6 +649,63 @@ packages:
   '@beehiiv/sdk@0.1.6':
     resolution: {integrity: sha512-My+QGKXfe5qplmyHaJn7mBp0jice/Lc87B2ZHa8q6NsmTD/E3gYX+zFrkZ7y0QyQqvr5ZLQipW+WXDLy1WUrXA==}
 
+  '@cloudflare/kv-asset-handler@0.4.2':
+    resolution: {integrity: sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@cloudflare/unenv-preset@2.12.1':
+    resolution: {integrity: sha512-tP/Wi+40aBJovonSNJSsS7aFJY0xjuckKplmzDs2Xat06BJ68B6iG7YDUWXJL8gNn0gqW7YC5WhlYhO3QbugQA==}
+    peerDependencies:
+      unenv: 2.0.0-rc.24
+      workerd: ^1.20260115.0
+    peerDependenciesMeta:
+      workerd:
+        optional: true
+
+  '@cloudflare/workerd-darwin-64@1.20260212.0':
+    resolution: {integrity: sha512-kLxuYutk88Wlo7edp8mlkN68TgZZ9237SUnuX9kNaD5jcOdblUqiBctMRZeRcPsuoX/3g2t0vS4ga02NBEVRNg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260212.0':
+    resolution: {integrity: sha512-fqoqQWMA1D0ZzDOD8sp0allREM2M8GHdpxMXQ8EdZpZ70z5bJbJ9Vr4qe35++FNIZJspsDHfTw3Xm/M4ELm/dQ==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-linux-64@1.20260212.0':
+    resolution: {integrity: sha512-bCSQoZzDzV5MSh4ueWo1DgmOn4Hf3QBu4Yo3eQFXA2llYFIu/sZgRtkEehw1X2/SY5Sn6O0EMCqxJYRf82Wdeg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20260212.0':
+    resolution: {integrity: sha512-GPvp1iiKQodtbUDi6OmR5I0vD75lawB54tdYGtmypuHC7ZOI2WhBmhb3wCxgnQNOG1z7mhCQrzRCoqrKwYbVWQ==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cloudflare/workerd-windows-64@1.20260212.0':
+    resolution: {integrity: sha512-wHRI218Xn4ndgWJCUHH4Zx0YlU5q/o6OmcxXkcw95tJOsQn4lDrhppioPh4eScxJZALf2X+ODeZcyQTCq5exGw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
+  '@dotenvx/dotenvx@1.31.0':
+    resolution: {integrity: sha512-GeDxvtjiRuoyWVU9nQneId879zIyNdL05bS7RKiqMkfBSKpHMWHLoRyRqjYWLaXmX/llKO1hTlqHDmatkQAjPA==}
+    hasBin: true
+
+  '@ecies/ciphers@0.2.5':
+    resolution: {integrity: sha512-GalEZH4JgOMHYYcYmVqnFirFsjZHeoGMDt9IxEnM9F7GRUUyUksJ7Ou53L83WHJq3RWKD3AcBpo0iQh0oMpf8A==}
+    engines: {bun: '>=1', deno: '>=2', node: '>=16'}
+    peerDependencies:
+      '@noble/ciphers': ^1.0.0
+
   '@emnapi/core@1.4.5':
     resolution: {integrity: sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==}
 
@@ -449,16 +769,46 @@ packages:
   '@emotion/weak-memoize@0.4.0':
     resolution: {integrity: sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==}
 
+  '@esbuild/aix-ppc64@0.25.4':
+    resolution: {integrity: sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.25.9':
     resolution: {integrity: sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.4':
+    resolution: {integrity: sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.25.9':
     resolution: {integrity: sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.4':
+    resolution: {integrity: sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.9':
@@ -467,16 +817,52 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.4':
+    resolution: {integrity: sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.25.9':
     resolution: {integrity: sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.4':
+    resolution: {integrity: sha512-Y1giCfM4nlHDWEfSckMzeWNdQS31BQGs9/rouw6Ub91tkK79aIMTH3q9xHvzH8d0wDru5Ci0kWB8b3up/nl16g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.25.9':
     resolution: {integrity: sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.4':
+    resolution: {integrity: sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.9':
@@ -485,10 +871,34 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.4':
+    resolution: {integrity: sha512-yYq+39NlTRzU2XmoPW4l5Ifpl9fqSk0nAJYM/V/WUGPEFfek1epLHJIkTQM6bBs1swApjO5nWgvr843g6TjxuQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.25.9':
     resolution: {integrity: sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.4':
+    resolution: {integrity: sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.9':
@@ -497,10 +907,34 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.4':
+    resolution: {integrity: sha512-+89UsQTfXdmjIvZS6nUnOOLoXnkUTB9hR5QAeLrQdzOSWZvNSAXAtcRDHWtqAUtAmv7ZM1WPOOeSxDzzzMogiQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.25.9':
     resolution: {integrity: sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.4':
+    resolution: {integrity: sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.9':
@@ -509,10 +943,34 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.4':
+    resolution: {integrity: sha512-yTEjoapy8UP3rv8dB0ip3AfMpRbyhSN3+hY8mo/i4QXFeDxmiYbEKp3ZRjBKcOP862Ua4b1PDfwlvbuwY7hIGQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.25.9':
     resolution: {integrity: sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.4':
+    resolution: {integrity: sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.9':
@@ -521,10 +979,34 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.4':
+    resolution: {integrity: sha512-IcvTlF9dtLrfL/M8WgNI/qJYBENP3ekgsHbYUIzEzq5XJzzVEV/fXY9WFPfEEXmu3ck2qJP8LG/p3Q8f7Zc2Xg==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.25.9':
     resolution: {integrity: sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.4':
+    resolution: {integrity: sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.9':
@@ -533,10 +1015,34 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.4':
+    resolution: {integrity: sha512-i8JUDAufpz9jOzo4yIShCTcXzS07vEgWzyX3NH2G7LEFVgrLEhjwL3ajFE4fZI3I4ZgiM7JH3GQ7ReObROvSUA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.25.9':
     resolution: {integrity: sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.4':
+    resolution: {integrity: sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.25.9':
@@ -545,16 +1051,52 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.4':
+    resolution: {integrity: sha512-6e0cvXwzOnVWJHq+mskP8DNSrKBr1bULBvnFLpc1KY+d+irZSgZ02TGse5FsafKS5jg2e4pbvK6TPXaF/A6+CA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.25.9':
     resolution: {integrity: sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.4':
+    resolution: {integrity: sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.25.9':
     resolution: {integrity: sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.4':
+    resolution: {integrity: sha512-XAg8pIQn5CzhOB8odIcAm42QsOfa98SBeKUdo4xa8OvX8LbMZqEtgeWE9P/Wxt7MlG2QqvjGths+nq48TrUiKw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.25.9':
@@ -563,14 +1105,44 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.4':
+    resolution: {integrity: sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.25.9':
     resolution: {integrity: sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.4':
+    resolution: {integrity: sha512-xAGGhyOQ9Otm1Xu8NT1ifGLnA6M3sJxZ6ixylb+vIUVzvvd6GOALpwQrYrtlPouMqd/vSbgehz6HaVk4+7Afhw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openbsd-x64@0.25.9':
     resolution: {integrity: sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
@@ -581,16 +1153,52 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.4':
+    resolution: {integrity: sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.25.9':
     resolution: {integrity: sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.4':
+    resolution: {integrity: sha512-AVUP428VQTSddguz9dO9ngb+E5aScyg7nOeJDrF1HPYu555gmza3bDGMPhmVXL8svDSoqPCsCPjb265yG/kLKQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.25.9':
     resolution: {integrity: sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.4':
+    resolution: {integrity: sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
     os: [win32]
 
   '@esbuild/win32-ia32@0.25.9':
@@ -599,8 +1207,26 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.4':
+    resolution: {integrity: sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
   '@esbuild/win32-x64@0.25.9':
     resolution: {integrity: sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -830,6 +1456,10 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
+  '@isaacs/cliui@9.0.0':
+    resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
+    engines: {node: '>=18'}
+
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
@@ -863,6 +1493,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
   '@lingui/babel-plugin-extract-messages@5.4.1':
     resolution: {integrity: sha512-sjkVaLyuK3ZW62mv5gU6pOdl3ZpwDReeSaNodJuf9LssbMIQPa5WOirTnMeBaalrQ8BA2srrRzQAWgsXPQVdXA==}
@@ -1128,6 +1761,30 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@noble/ciphers@1.3.0':
+    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/curves@1.9.7':
+    resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@node-minify/core@8.0.6':
+    resolution: {integrity: sha512-/vxN46ieWDLU67CmgbArEvOb41zlYFOkOtr9QW9CnTrBLuTyGgkyNWC2y5+khvRw3Br58p2B5ZVSx/PxCTru6g==}
+    engines: {node: '>=16.0.0'}
+
+  '@node-minify/terser@8.0.6':
+    resolution: {integrity: sha512-grQ1ipham743ch2c3++C8Isk6toJnxJSyDiwUI/IWUCh4CZFD6aYVw6UAY40IpCnjrq5aXGwiv5OZJn6Pr0hvg==}
+    engines: {node: '>=16.0.0'}
+
+  '@node-minify/utils@8.0.6':
+    resolution: {integrity: sha512-csY4qcR7jUwiZmkreNTJhcypQfts2aY2CK+a+rXgXUImZiZiySh0FvwHjRnlqWKvg+y6ae9lHFzDRjBTmqlTIQ==}
+    engines: {node: '>=16.0.0'}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -1144,8 +1801,30 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
+  '@opennextjs/aws@3.9.16':
+    resolution: {integrity: sha512-jQQStCysIllNCPqz5W2KSguXpr+ETlOcD8SyNu+h9zwpRVYk4uEPQge+ErG3avI5xsT8vKA7EGLYG59dhj/B6Q==}
+    hasBin: true
+    peerDependencies:
+      next: ~15.0.8 || ~15.1.12 || ~15.2.9 || ~15.3.9 || ~15.4.11 || ~15.5.10 || ~16.0.11 || ^16.1.5
+
+  '@opennextjs/cloudflare@1.16.4':
+    resolution: {integrity: sha512-FILV7qQ20GcJOhjsnwVTw3knH/gHjLz09Udid6iws98DQH3vla61rm0lKam3VhMN4X9mum6kqPeP5+Q6Yit2ZQ==}
+    hasBin: true
+    peerDependencies:
+      next: ~15.0.8 || ~15.1.12 || ~15.2.9 || ~15.3.9 || ~15.4.11 || ~15.5.10 || ~16.0.11 || ^16.1.5
+      wrangler: ^4.59.2
+
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
+
+  '@poppinss/colors@4.1.6':
+    resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
+
+  '@poppinss/dumper@0.6.5':
+    resolution: {integrity: sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==}
+
+  '@poppinss/exception@1.2.3':
+    resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -1546,6 +2225,229 @@ packages:
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
+  '@sindresorhus/is@7.2.0':
+    resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
+    engines: {node: '>=18'}
+
+  '@smithy/abort-controller@4.2.8':
+    resolution: {integrity: sha512-peuVfkYHAmS5ybKxWcfraK7WBBP0J+rkfUcbHJJKQ4ir3UAUNQI+Y4Vt/PqSzGqgloJ5O1dk7+WzNL8wcCSXbw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/chunked-blob-reader-native@4.2.1':
+    resolution: {integrity: sha512-lX9Ay+6LisTfpLid2zZtIhSEjHMZoAR5hHCR4H7tBz/Zkfr5ea8RcQ7Tk4mi0P76p4cN+Btz16Ffno7YHpKXnQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/chunked-blob-reader@5.2.0':
+    resolution: {integrity: sha512-WmU0TnhEAJLWvfSeMxBNe5xtbselEO8+4wG0NtZeL8oR21WgH1xiO37El+/Y+H/Ie4SCwBy3MxYWmOYaGgZueA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/config-resolver@4.4.6':
+    resolution: {integrity: sha512-qJpzYC64kaj3S0fueiu3kXm8xPrR3PcXDPEgnaNMRn0EjNSZFoFjvbUp0YUDsRhN1CB90EnHJtbxWKevnH99UQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/core@3.23.0':
+    resolution: {integrity: sha512-Yq4UPVoQICM9zHnByLmG8632t2M0+yap4T7ANVw482J0W7HW0pOuxwVmeOwzJqX2Q89fkXz0Vybz55Wj2Xzrsg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.2.8':
+    resolution: {integrity: sha512-FNT0xHS1c/CPN8upqbMFP83+ul5YgdisfCfkZ86Jh2NSmnqw/AJ6x5pEogVCTVvSm7j9MopRU89bmDelxuDMYw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-codec@4.2.8':
+    resolution: {integrity: sha512-jS/O5Q14UsufqoGhov7dHLOPCzkYJl9QDzusI2Psh4wyYx/izhzvX9P4D69aTxcdfVhEPhjK+wYyn/PzLjKbbw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-browser@4.2.8':
+    resolution: {integrity: sha512-MTfQT/CRQz5g24ayXdjg53V0mhucZth4PESoA5IhvaWVDTOQLfo8qI9vzqHcPsdd2v6sqfTYqF5L/l+pea5Uyw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-config-resolver@4.3.8':
+    resolution: {integrity: sha512-ah12+luBiDGzBruhu3efNy1IlbwSEdNiw8fOZksoKoWW1ZHvO/04MQsdnws/9Aj+5b0YXSSN2JXKy/ClIsW8MQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-node@4.2.8':
+    resolution: {integrity: sha512-cYpCpp29z6EJHa5T9WL0KAlq3SOKUQkcgSoeRfRVwjGgSFl7Uh32eYGt7IDYCX20skiEdRffyDpvF2efEZPC0A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-universal@4.2.8':
+    resolution: {integrity: sha512-iJ6YNJd0bntJYnX6s52NC4WFYcZeKrPUr1Kmmr5AwZcwCSzVpS7oavAmxMR7pMq7V+D1G4s9F5NJK0xwOsKAlQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.3.9':
+    resolution: {integrity: sha512-I4UhmcTYXBrct03rwzQX1Y/iqQlzVQaPxWjCjula++5EmWq9YGBrx6bbGqluGc1f0XEfhSkiY4jhLgbsJUMKRA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-blob-browser@4.2.9':
+    resolution: {integrity: sha512-m80d/iicI7DlBDxyQP6Th7BW/ejDGiF0bgI754+tiwK0lgMkcaIBgvwwVc7OFbY4eUzpGtnig52MhPAEJ7iNYg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-node@4.2.8':
+    resolution: {integrity: sha512-7ZIlPbmaDGxVoxErDZnuFG18WekhbA/g2/i97wGj+wUBeS6pcUeAym8u4BXh/75RXWhgIJhyC11hBzig6MljwA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-stream-node@4.2.8':
+    resolution: {integrity: sha512-v0FLTXgHrTeheYZFGhR+ehX5qUm4IQsjAiL9qehad2cyjMWcN2QG6/4mSwbSgEQzI7jwfoXj7z4fxZUx/Mhj2w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/invalid-dependency@4.2.8':
+    resolution: {integrity: sha512-N9iozRybwAQ2dn9Fot9kI6/w9vos2oTXLhtK7ovGqwZjlOcxu6XhPlpLpC+INsxktqHinn5gS2DXDjDF2kG5sQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/is-array-buffer@4.2.0':
+    resolution: {integrity: sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/md5-js@4.2.8':
+    resolution: {integrity: sha512-oGMaLj4tVZzLi3itBa9TCswgMBr7k9b+qKYowQ6x1rTyTuO1IU2YHdHUa+891OsOH+wCsH7aTPRsTJO3RMQmjQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-content-length@4.2.8':
+    resolution: {integrity: sha512-RO0jeoaYAB1qBRhfVyq0pMgBoUK34YEJxVxyjOWYZiOKOq2yMZ4MnVXMZCUDenpozHue207+9P5ilTV1zeda0A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-endpoint@4.4.14':
+    resolution: {integrity: sha512-FUFNE5KVeaY6U/GL0nzAAHkaCHzXLZcY1EhtQnsAqhD8Du13oPKtMB9/0WK4/LK6a/T5OZ24wPoSShff5iI6Ag==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-retry@4.4.31':
+    resolution: {integrity: sha512-RXBzLpMkIrxBPe4C8OmEOHvS8aH9RUuCOH++Acb5jZDEblxDjyg6un72X9IcbrGTJoiUwmI7hLypNfuDACypbg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-serde@4.2.9':
+    resolution: {integrity: sha512-eMNiej0u/snzDvlqRGSN3Vl0ESn3838+nKyVfF2FKNXFbi4SERYT6PR392D39iczngbqqGG0Jl1DlCnp7tBbXQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-stack@4.2.8':
+    resolution: {integrity: sha512-w6LCfOviTYQjBctOKSwy6A8FIkQy7ICvglrZFl6Bw4FmcQ1Z420fUtIhxaUZZshRe0VCq4kvDiPiXrPZAe8oRA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-config-provider@4.3.8':
+    resolution: {integrity: sha512-aFP1ai4lrbVlWjfpAfRSL8KFcnJQYfTl5QxLJXY32vghJrDuFyPZ6LtUL+JEGYiFRG1PfPLHLoxj107ulncLIg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.4.10':
+    resolution: {integrity: sha512-u4YeUwOWRZaHbWaebvrs3UhwQwj+2VNmcVCwXcYTvPIuVyM7Ex1ftAj+fdbG/P4AkBwLq/+SKn+ydOI4ZJE9PA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/property-provider@4.2.8':
+    resolution: {integrity: sha512-EtCTbyIveCKeOXDSWSdze3k612yCPq1YbXsbqX3UHhkOSW8zKsM9NOJG5gTIya0vbY2DIaieG8pKo1rITHYL0w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/protocol-http@5.3.8':
+    resolution: {integrity: sha512-QNINVDhxpZ5QnP3aviNHQFlRogQZDfYlCkQT+7tJnErPQbDhysondEjhikuANxgMsZrkGeiAxXy4jguEGsDrWQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-builder@4.2.8':
+    resolution: {integrity: sha512-Xr83r31+DrE8CP3MqPgMJl+pQlLLmOfiEUnoyAlGzzJIrEsbKsPy1hqH0qySaQm4oWrCBlUqRt+idEgunKB+iw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-parser@4.2.8':
+    resolution: {integrity: sha512-vUurovluVy50CUlazOiXkPq40KGvGWSdmusa3130MwrR1UNnNgKAlj58wlOe61XSHRpUfIIh6cE0zZ8mzKaDPA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/service-error-classification@4.2.8':
+    resolution: {integrity: sha512-mZ5xddodpJhEt3RkCjbmUQuXUOaPNTkbMGR0bcS8FE0bJDLMZlhmpgrvPNCYglVw5rsYTpSnv19womw9WWXKQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/shared-ini-file-loader@4.4.3':
+    resolution: {integrity: sha512-DfQjxXQnzC5UbCUPeC3Ie8u+rIWZTvuDPAGU/BxzrOGhRvgUanaP68kDZA+jaT3ZI+djOf+4dERGlm9mWfFDrg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.3.8':
+    resolution: {integrity: sha512-6A4vdGj7qKNRF16UIcO8HhHjKW27thsxYci+5r/uVRkdcBEkOEiY8OMPuydLX4QHSrJqGHPJzPRwwVTqbLZJhg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/smithy-client@4.11.3':
+    resolution: {integrity: sha512-Q7kY5sDau8OoE6Y9zJoRGgje8P4/UY0WzH8R2ok0PDh+iJ+ZnEKowhjEqYafVcubkbYxQVaqwm3iufktzhprGg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.12.0':
+    resolution: {integrity: sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/url-parser@4.2.8':
+    resolution: {integrity: sha512-NQho9U68TGMEU639YkXnVMV3GEFFULmmaWdlu1E9qzyIePOHsoSnagTGSDv1Zi8DCNN6btxOSdgmy5E/hsZwhA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-base64@4.3.0':
+    resolution: {integrity: sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-browser@4.2.0':
+    resolution: {integrity: sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-node@4.2.1':
+    resolution: {integrity: sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-buffer-from@4.2.0':
+    resolution: {integrity: sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-config-provider@4.2.0':
+    resolution: {integrity: sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-browser@4.3.30':
+    resolution: {integrity: sha512-cMni0uVU27zxOiU8TuC8pQLC1pYeZ/xEMxvchSK/ILwleRd1ugobOcIRr5vXtcRqKd4aBLWlpeBoDPJJ91LQng==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-node@4.2.33':
+    resolution: {integrity: sha512-LEb2aq5F4oZUSzWBG7S53d4UytZSkOEJPXcBq/xbG2/TmK9EW5naUZ8lKu1BEyWMzdHIzEVN16M3k8oxDq+DJA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-endpoints@3.2.8':
+    resolution: {integrity: sha512-8JaVTn3pBDkhZgHQ8R0epwWt+BqPSLCjdjXXusK1onwJlRuN69fbvSK66aIKKO7SwVFM6x2J2ox5X8pOaWcUEw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-hex-encoding@4.2.0':
+    resolution: {integrity: sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-middleware@4.2.8':
+    resolution: {integrity: sha512-PMqfeJxLcNPMDgvPbbLl/2Vpin+luxqTGPpW3NAQVLbRrFRzTa4rNAASYeIGjRV9Ytuhzny39SpyU04EQreF+A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-retry@4.2.8':
+    resolution: {integrity: sha512-CfJqwvoRY0kTGe5AkQokpURNCT1u/MkRzMTASWMPPo2hNSnKtF1D45dQl3DE2LKLr4m+PW9mCeBMJr5mCAVThg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-stream@4.5.12':
+    resolution: {integrity: sha512-D8tgkrmhAX/UNeCZbqbEO3uqyghUnEmmoO9YEvRuwxjlkKKUE7FOgCJnqpTlQPe9MApdWPky58mNQQHbnCzoNg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-uri-escape@4.2.0':
+    resolution: {integrity: sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@4.2.0':
+    resolution: {integrity: sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-waiter@4.2.8':
+    resolution: {integrity: sha512-n+lahlMWk+aejGuax7DPWtqav8HYnWxQwR+LCG2BgCUmaGcTe9qZCFsmw8TMg9iG75HOwhrJCX9TCJRLH+Yzqg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/uuid@1.1.0':
+    resolution: {integrity: sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==}
+    engines: {node: '>=18.0.0'}
+
+  '@speed-highlight/core@1.2.14':
+    resolution: {integrity: sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA==}
+
   '@supabase/auth-js@2.95.3':
     resolution: {integrity: sha512-vD2YoS8E2iKIX0F7EwXTmqhUpaNsmbU6X2R0/NdFcs02oEfnHyNP/3M716f3wVJ2E5XHGiTFXki6lRckhJ0Thg==}
     engines: {node: '>=20.0.0'}
@@ -1670,6 +2572,9 @@ packages:
 
   '@tailwindcss/postcss@4.1.12':
     resolution: {integrity: sha512-5PpLYhCAwf9SJEeIsSmCDLgyVfdBhdBpzX1OJ87anT9IVR0Z9pjM0FNixCAUAHGnMBGB8K99SwAheXrT0Kh6QQ==}
+
+  '@tsconfig/node18@1.0.3':
+    resolution: {integrity: sha512-RbwvSJQsuN9TB04AQbGULYfOGE/RnSFk/FLQ5b0NmDf5Kx2q/lABZbHQPKCO1vZ6Fiwkplu+yb9pGdLy1iGseQ==}
 
   '@tybys/wasm-util@0.10.0':
     resolution: {integrity: sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==}
@@ -1823,6 +2728,12 @@ packages:
 
   '@types/negotiator@0.6.4':
     resolution: {integrity: sha512-elf6BsTq+AkyNsb2h5cGNst2Mc7dPliVoAPm1fXglC/BM3f2pFA40BaSSv3E5lyHteEawVKLP+8TwiY1DMNb3A==}
+
+  '@types/node-fetch@2.6.13':
+    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
+
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
   '@types/node@20.19.10':
     resolution: {integrity: sha512-iAFpG6DokED3roLSP0K+ybeDdIX6Bc0Vd3mLW5uDqThPWtNos3E+EqOM11mPQHKzfWHqEBuLjIlsBQQ8CsISmQ==}
@@ -2085,6 +2996,10 @@ packages:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -2094,6 +3009,10 @@ packages:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  agentkeepalive@4.6.0:
+    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
+    engines: {node: '>= 8.0.0'}
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
@@ -2127,6 +3046,10 @@ packages:
   algoliasearch@5.21.0:
     resolution: {integrity: sha512-hexLq2lSO1K5SW9j21Ubc+q9Ptx7dyRTY7se19U8lhIlVMLCNXWCyQ6C22p9ez8ccX0v7QVmwkl2l1CnuGoO2Q==}
     engines: {node: '>= 14.0.0'}
+
+  ansi-colors@4.1.3:
+    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
+    engines: {node: '>=6'}
 
   ansi-escapes@7.0.0:
     resolution: {integrity: sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==}
@@ -2220,6 +3143,9 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
+  aws4fetch@1.0.20:
+    resolution: {integrity: sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==}
+
   axe-core@4.10.3:
     resolution: {integrity: sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==}
     engines: {node: '>=4'}
@@ -2241,6 +3167,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.2:
+    resolution: {integrity: sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg==}
+    engines: {node: 20 || >=22}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -2255,11 +3185,25 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  blake3-wasm@2.1.5:
+    resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
+
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  brace-expansion@5.0.2:
+    resolution: {integrity: sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2283,6 +3227,10 @@ packages:
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -2316,6 +3264,10 @@ packages:
 
   chalk@5.5.0:
     resolution: {integrity: sha512-1tm8DTaJhPBG3bIkVeZt1iZM9GfSX2lzOeDVZH9R9ffRHpmHvxZ/QhgQH/aDTkswQVt+YHdXAdS/In/30OjCbg==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   character-entities-html4@2.1.0:
@@ -2368,9 +3320,16 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
+  cliui@9.0.1:
+    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
+    engines: {node: '>=20'}
+
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
+
+  cloudflare@4.5.0:
+    resolution: {integrity: sha512-fPcbPKx4zF45jBvQ0z7PCdgejVAPBBCZxwqk1k7krQNfpM07Cfj97/Q6wBzvYqlWXx/zt1S9+m8vnfCe06umbQ==}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -2410,6 +3369,10 @@ packages:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
     engines: {node: '>=14'}
 
+  commander@11.1.0:
+    resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
+    engines: {node: '>=16'}
+
   commander@14.0.0:
     resolution: {integrity: sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==}
     engines: {node: '>=20'}
@@ -2424,11 +3387,27 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  content-disposition@1.0.1:
+    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
   convert-source-map@1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
@@ -2619,6 +3598,15 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   decimal.js-light@2.5.1:
     resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
@@ -2646,6 +3634,10 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -2671,12 +3663,26 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  duplexer@0.1.2:
+    resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  eciesjs@0.4.17:
+    resolution: {integrity: sha512-TOOURki4G7sD1wDCjj7NfLaXZZ49dFOeEb5y39IXpb8p0hRzVvfvzZHOi5JcT+PpyAbi/Y+lxPb8eTag2WYH8w==}
+    engines: {bun: '>=1', deno: '>=2', node: '>=16'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
   electron-to-chromium@1.5.200:
     resolution: {integrity: sha512-rFCxROw7aOe4uPTfIAx+rXv9cEcGx+buAF4npnhtTqCJk5KDFRnh3+KYj7rdVh6lsFt5/aPs+Irj9rZ33WMA7w==}
@@ -2693,9 +3699,17 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
   enhanced-resolve@5.18.3:
     resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
     engines: {node: '>=10.13.0'}
+
+  enquirer@2.4.1:
+    resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
+    engines: {node: '>=8.6'}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -2707,6 +3721,9 @@ packages:
 
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
+
+  error-stack-parser-es@1.0.5:
+    resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
 
   es-abstract@1.24.0:
     resolution: {integrity: sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==}
@@ -2749,14 +3766,27 @@ packages:
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
 
+  esbuild@0.25.4:
+    resolution: {integrity: sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   esbuild@0.25.9:
     resolution: {integrity: sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
     engines: {node: '>=18'}
     hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -2918,6 +3948,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
@@ -2931,6 +3965,14 @@ packages:
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
+
+  execa@5.1.1:
+    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
+    engines: {node: '>=10'}
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
@@ -2963,6 +4005,10 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
+  fast-xml-parser@5.3.4:
+    resolution: {integrity: sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA==}
+    hasBin: true
+
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
@@ -2984,6 +4030,10 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
 
   find-root@1.1.0:
     resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
@@ -3016,13 +4066,31 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  form-data-encoder@1.7.2:
+    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
+
   form-data@4.0.4:
     resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
 
+  formdata-node@4.4.1:
+    resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
+    engines: {node: '>= 12.20'}
+
   formdata-node@6.0.3:
     resolution: {integrity: sha512-8e1++BCiTzUno9v5IZ2J6bv4RU+3UKDmqWUQD0MIMVCd9AdhWkO1gw57oo1mNEX1dMq2EGI+FbWz4B92pscSQg==}
     engines: {node: '>= 18'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -3043,6 +4111,10 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
   get-east-asian-width@1.3.0:
     resolution: {integrity: sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==}
     engines: {node: '>=18'}
@@ -3058,6 +4130,10 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
+
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
 
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
@@ -3085,6 +4161,16 @@ packages:
     engines: {node: 20 || >=22}
     hasBin: true
 
+  glob@12.0.0:
+    resolution: {integrity: sha512-5Qcll1z7IKgHr5g485ePDdHcNQY0k2dtv/bjYy0iuyGxQw2qSOiiXUXJ+AYQpg3HNoUMHqAruX478Jeev7UULw==}
+    engines: {node: 20 || >=22}
+    hasBin: true
+
+  glob@9.3.5:
+    resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
@@ -3106,6 +4192,10 @@ packages:
   gray-matter@4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
+
+  gzip-size@6.0.0:
+    resolution: {integrity: sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==}
+    engines: {node: '>=10'}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -3180,12 +4270,27 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
+
+  humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+
   iceberg-js@0.8.1:
     resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
     engines: {node: '>=20.0.0'}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
@@ -3233,6 +4338,10 @@ packages:
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -3344,6 +4453,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -3355,6 +4467,10 @@ packages:
   is-shared-array-buffer@1.0.4:
     resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
     engines: {node: '>= 0.4'}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
 
   is-string@1.1.1:
     resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
@@ -3390,12 +4506,20 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  isexe@3.1.5:
+    resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
+    engines: {node: '>=18'}
+
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
 
   jackspeak@4.1.1:
     resolution: {integrity: sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==}
+    engines: {node: 20 || >=22}
+
+  jackspeak@4.2.3:
+    resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
     engines: {node: 20 || >=22}
 
   jest-get-type@29.6.3:
@@ -3474,6 +4598,10 @@ packages:
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
+
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
 
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
@@ -3609,6 +4737,9 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lru-cache@11.1.0:
     resolution: {integrity: sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==}
     engines: {node: 20 || >=22}
@@ -3662,8 +4793,16 @@ packages:
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   memoize-one@6.0.0:
     resolution: {integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -3764,9 +4903,17 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
@@ -3780,12 +4927,25 @@ packages:
     resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
     hasBin: true
 
+  miniflare@4.20260212.0:
+    resolution: {integrity: sha512-Lgxq83EuR2q/0/DAVOSGXhXS1V7GDB04HVggoPsenQng8sqEDR3hO4FigIw5ZI2Sv2X7kIc30NCzGHJlCFIYWg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   minimatch@10.0.3:
     resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
     engines: {node: 20 || >=22}
 
+  minimatch@10.2.0:
+    resolution: {integrity: sha512-ugkC31VaVg9cF0DFVoADH12k6061zNZkZON+aX8AWsR9GhPcErkcMBceb6znR8wLERM2AkkOxy2nWRLpT9Jq5w==}
+    engines: {node: 20 || >=22}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+
+  minimatch@8.0.4:
+    resolution: {integrity: sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
@@ -3793,6 +4953,10 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@4.2.8:
+    resolution: {integrity: sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==}
+    engines: {node: '>=8'}
 
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
@@ -3806,10 +4970,18 @@ packages:
     resolution: {integrity: sha512-OHsdUcVAQ6pOtg5JYWpCBo9W/GySVuwvP9hueRMW7UqshC0tbfzLv8wjySTPm3tfUZ/21CE9E1pJagOA91Pxew==}
     deprecated: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
 
+  mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   mkdirp@3.0.1:
     resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
     engines: {node: '>=10'}
     hasBin: true
+
+  mnemonist@0.38.3:
+    resolution: {integrity: sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==}
 
   moo@0.5.2:
     resolution: {integrity: sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==}
@@ -3838,6 +5010,10 @@ packages:
     resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
     engines: {node: '>= 0.6'}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
@@ -3862,6 +5038,11 @@ packages:
       sass:
         optional: true
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
@@ -3885,6 +5066,10 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  npm-run-path@4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -3896,6 +5081,10 @@ packages:
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
+
+  object-treeify@1.1.33:
+    resolution: {integrity: sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A==}
+    engines: {node: '>= 10'}
 
   object.assign@4.1.7:
     resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
@@ -3916,6 +5105,16 @@ packages:
   object.values@1.2.1:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
+
+  obliterator@1.6.1:
+    resolution: {integrity: sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
@@ -3974,6 +5173,10 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -3985,13 +5188,26 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
+
   path-scurry@2.0.0:
     resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
     engines: {node: 20 || >=22}
 
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
+  path-to-regexp@8.3.0:
+    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -4065,6 +5281,10 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
@@ -4081,6 +5301,10 @@ packages:
     resolution: {integrity: sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==}
     engines: {node: '>=0.6'}
 
+  qs@6.14.2:
+    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
+    engines: {node: '>=0.6'}
+
   qs@6.9.7:
     resolution: {integrity: sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==}
     engines: {node: '>=0.6'}
@@ -4090,6 +5314,14 @@ packages:
 
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-dom@19.1.1:
     resolution: {integrity: sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==}
@@ -4311,6 +5543,10 @@ packages:
   robust-predicates@3.0.2:
     resolution: {integrity: sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==}
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -4358,8 +5594,16 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -4372,6 +5616,9 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -4462,6 +5709,10 @@ packages:
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
@@ -4527,9 +5778,16 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strnum@2.1.2:
+    resolution: {integrity: sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==}
 
   style-to-js@1.1.18:
     resolution: {integrity: sha512-JFPn62D4kJaPTnhFUI244MThx+FEGbi+9dw1b9yBBQ+1CZpV7QAT8kUtJ7b7EUNdHajjF/0x8fT+16oLJoojLg==}
@@ -4552,6 +5810,10 @@ packages:
 
   stylis@4.2.0:
     resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}
+
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -4604,6 +5866,11 @@ packages:
       uglify-js:
         optional: true
 
+  terser@5.16.9:
+    resolution: {integrity: sha512-HPa/FdTB9XGI2H1/keLFZHxl6WNvAI4YalHGtDQTlMnJcoqSab1UwL4l1hGEhs6/GmLHBZIg/YgB++jcbzoOEg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   terser@5.44.1:
     resolution: {integrity: sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==}
     engines: {node: '>=10'}
@@ -4619,6 +5886,10 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
@@ -4638,6 +5909,9 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  ts-tqdm@0.8.6:
+    resolution: {integrity: sha512-3X3M1PZcHtgQbnwizL+xU8CAgbYbeLHrrDwL9xxcZZrV5J+e7loJm1XrXozHjSkl44J0Zg0SgA8rXbh83kCkcQ==}
+
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
@@ -4655,6 +5929,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -4693,8 +5971,18 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@7.18.2:
+    resolution: {integrity: sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==}
+    engines: {node: '>=20.18.1'}
+
+  unenv@2.0.0-rc.24:
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -4717,6 +6005,10 @@ packages:
   unist-util-visit@5.0.0:
     resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
 
@@ -4737,6 +6029,9 @@ packages:
 
   url-join@4.0.1:
     resolution: {integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==}
+
+  urlpattern-polyfill@10.1.0:
+    resolution: {integrity: sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==}
 
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
@@ -4781,6 +6076,10 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
 
@@ -4802,6 +6101,10 @@ packages:
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  web-streams-polyfill@4.0.0-beta.3:
+    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
+    engines: {node: '>= 14'}
 
   web-vitals@4.2.4:
     resolution: {integrity: sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==}
@@ -4853,9 +6156,29 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  which@4.0.0:
+    resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
+    engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  workerd@1.20260212.0:
+    resolution: {integrity: sha512-4B9BoZUzKSRv3pVZGEPh7OX+Q817hpUqAUtz5O0TxJVqo4OsYJAUA/sY177Q5ha/twjT9KaJt2DtQzE+oyCOzw==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  wrangler@4.65.0:
+    resolution: {integrity: sha512-R+n3o3tlGzLK9I4fGocPReOuvcnjhtOL2aCVKkHMeuEwt9pPbOO4FxJtx/ec5cIUG/otRyJnfQGCAr9DplBVng==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20260212.0
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -4869,6 +6192,21 @@ packages:
     resolution: {integrity: sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==}
     engines: {node: '>=18'}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.18.0:
+    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   ws@8.19.0:
     resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
     engines: {node: '>=10.0.0'}
@@ -4880,6 +6218,10 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -4897,9 +6239,23 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yargs-parser@22.0.0:
+    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yargs@18.0.0:
+    resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  youch-core@0.3.3:
+    resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
+
+  youch@4.1.0-beta.10:
+    resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -4998,6 +6354,758 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.30
+
+  '@ast-grep/napi-darwin-arm64@0.40.5':
+    optional: true
+
+  '@ast-grep/napi-darwin-x64@0.40.5':
+    optional: true
+
+  '@ast-grep/napi-linux-arm64-gnu@0.40.5':
+    optional: true
+
+  '@ast-grep/napi-linux-arm64-musl@0.40.5':
+    optional: true
+
+  '@ast-grep/napi-linux-x64-gnu@0.40.5':
+    optional: true
+
+  '@ast-grep/napi-linux-x64-musl@0.40.5':
+    optional: true
+
+  '@ast-grep/napi-win32-arm64-msvc@0.40.5':
+    optional: true
+
+  '@ast-grep/napi-win32-ia32-msvc@0.40.5':
+    optional: true
+
+  '@ast-grep/napi-win32-x64-msvc@0.40.5':
+    optional: true
+
+  '@ast-grep/napi@0.40.5':
+    optionalDependencies:
+      '@ast-grep/napi-darwin-arm64': 0.40.5
+      '@ast-grep/napi-darwin-x64': 0.40.5
+      '@ast-grep/napi-linux-arm64-gnu': 0.40.5
+      '@ast-grep/napi-linux-arm64-musl': 0.40.5
+      '@ast-grep/napi-linux-x64-gnu': 0.40.5
+      '@ast-grep/napi-linux-x64-musl': 0.40.5
+      '@ast-grep/napi-win32-arm64-msvc': 0.40.5
+      '@ast-grep/napi-win32-ia32-msvc': 0.40.5
+      '@ast-grep/napi-win32-x64-msvc': 0.40.5
+
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.1
+      tslib: 2.8.1
+
+  '@aws-crypto/crc32c@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.1
+      tslib: 2.8.1
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-locate-window': 3.965.4
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-locate-window': 3.965.4
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.1
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-cloudfront@3.984.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.9
+      '@aws-sdk/credential-provider-node': 3.972.8
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.9
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.984.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.7
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.23.0
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.14
+      '@smithy/middleware-retry': 4.4.31
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.3
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.30
+      '@smithy/util-defaults-mode-node': 4.2.33
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-stream': 4.5.12
+      '@smithy/util-utf8': 4.2.0
+      '@smithy/util-waiter': 4.2.8
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/client-dynamodb@3.984.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.9
+      '@aws-sdk/credential-provider-node': 3.972.8
+      '@aws-sdk/dynamodb-codec': 3.972.10
+      '@aws-sdk/middleware-endpoint-discovery': 3.972.3
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.9
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.984.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.7
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.23.0
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.14
+      '@smithy/middleware-retry': 4.4.31
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.3
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.30
+      '@smithy/util-defaults-mode-node': 4.2.33
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      '@smithy/util-waiter': 4.2.8
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/client-lambda@3.984.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.9
+      '@aws-sdk/credential-provider-node': 3.972.8
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.9
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.984.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.7
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.23.0
+      '@smithy/eventstream-serde-browser': 4.2.8
+      '@smithy/eventstream-serde-config-resolver': 4.3.8
+      '@smithy/eventstream-serde-node': 4.2.8
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.14
+      '@smithy/middleware-retry': 4.4.31
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.3
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.30
+      '@smithy/util-defaults-mode-node': 4.2.33
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-stream': 4.5.12
+      '@smithy/util-utf8': 4.2.0
+      '@smithy/util-waiter': 4.2.8
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/client-s3@3.984.0':
+    dependencies:
+      '@aws-crypto/sha1-browser': 5.2.0
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.9
+      '@aws-sdk/credential-provider-node': 3.972.8
+      '@aws-sdk/middleware-bucket-endpoint': 3.972.3
+      '@aws-sdk/middleware-expect-continue': 3.972.3
+      '@aws-sdk/middleware-flexible-checksums': 3.972.7
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-location-constraint': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-sdk-s3': 3.972.9
+      '@aws-sdk/middleware-ssec': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.9
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/signature-v4-multi-region': 3.984.0
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.984.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.7
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.23.0
+      '@smithy/eventstream-serde-browser': 4.2.8
+      '@smithy/eventstream-serde-config-resolver': 4.3.8
+      '@smithy/eventstream-serde-node': 4.2.8
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-blob-browser': 4.2.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/hash-stream-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/md5-js': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.14
+      '@smithy/middleware-retry': 4.4.31
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.3
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.30
+      '@smithy/util-defaults-mode-node': 4.2.33
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-stream': 4.5.12
+      '@smithy/util-utf8': 4.2.0
+      '@smithy/util-waiter': 4.2.8
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/client-sqs@3.984.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.9
+      '@aws-sdk/credential-provider-node': 3.972.8
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-sdk-sqs': 3.972.7
+      '@aws-sdk/middleware-user-agent': 3.972.9
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.984.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.7
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.23.0
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/md5-js': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.14
+      '@smithy/middleware-retry': 4.4.31
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.3
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.30
+      '@smithy/util-defaults-mode-node': 4.2.33
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/client-sso@3.989.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.9
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.9
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.989.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.7
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.23.0
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.14
+      '@smithy/middleware-retry': 4.4.31
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.3
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.30
+      '@smithy/util-defaults-mode-node': 4.2.33
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/core@3.973.9':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/xml-builder': 3.972.4
+      '@smithy/core': 3.23.0
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/signature-v4': 5.3.8
+      '@smithy/smithy-client': 4.11.3
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@aws-sdk/crc64-nvme@3.972.0':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.7':
+    dependencies:
+      '@aws-sdk/core': 3.973.9
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.9':
+    dependencies:
+      '@aws-sdk/core': 3.973.9
+      '@aws-sdk/types': 3.973.1
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/property-provider': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.3
+      '@smithy/types': 4.12.0
+      '@smithy/util-stream': 4.5.12
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.7':
+    dependencies:
+      '@aws-sdk/core': 3.973.9
+      '@aws-sdk/credential-provider-env': 3.972.7
+      '@aws-sdk/credential-provider-http': 3.972.9
+      '@aws-sdk/credential-provider-login': 3.972.7
+      '@aws-sdk/credential-provider-process': 3.972.7
+      '@aws-sdk/credential-provider-sso': 3.972.7
+      '@aws-sdk/credential-provider-web-identity': 3.972.7
+      '@aws-sdk/nested-clients': 3.989.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/credential-provider-imds': 4.2.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.7':
+    dependencies:
+      '@aws-sdk/core': 3.973.9
+      '@aws-sdk/nested-clients': 3.989.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-node@3.972.8':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.7
+      '@aws-sdk/credential-provider-http': 3.972.9
+      '@aws-sdk/credential-provider-ini': 3.972.7
+      '@aws-sdk/credential-provider-process': 3.972.7
+      '@aws-sdk/credential-provider-sso': 3.972.7
+      '@aws-sdk/credential-provider-web-identity': 3.972.7
+      '@aws-sdk/types': 3.973.1
+      '@smithy/credential-provider-imds': 4.2.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-process@3.972.7':
+    dependencies:
+      '@aws-sdk/core': 3.973.9
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.7':
+    dependencies:
+      '@aws-sdk/client-sso': 3.989.0
+      '@aws-sdk/core': 3.973.9
+      '@aws-sdk/token-providers': 3.989.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.7':
+    dependencies:
+      '@aws-sdk/core': 3.973.9
+      '@aws-sdk/nested-clients': 3.989.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/dynamodb-codec@3.972.10':
+    dependencies:
+      '@aws-sdk/core': 3.973.9
+      '@smithy/core': 3.23.0
+      '@smithy/smithy-client': 4.11.3
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/endpoint-cache@3.972.2':
+    dependencies:
+      mnemonist: 0.38.3
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-bucket-endpoint@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-arn-parser': 3.972.2
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-config-provider': 4.2.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-endpoint-discovery@3.972.3':
+    dependencies:
+      '@aws-sdk/endpoint-cache': 3.972.2
+      '@aws-sdk/types': 3.973.1
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-expect-continue@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-flexible-checksums@3.972.7':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@aws-crypto/crc32c': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/core': 3.973.9
+      '@aws-sdk/crc64-nvme': 3.972.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/is-array-buffer': 4.2.0
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-stream': 4.5.12
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-host-header@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-location-constraint@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-logger@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-recursion-detection@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@aws/lambda-invoke-store': 0.2.3
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.9':
+    dependencies:
+      '@aws-sdk/core': 3.973.9
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-arn-parser': 3.972.2
+      '@smithy/core': 3.23.0
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/signature-v4': 5.3.8
+      '@smithy/smithy-client': 4.11.3
+      '@smithy/types': 4.12.0
+      '@smithy/util-config-provider': 4.2.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-stream': 4.5.12
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-sqs@3.972.7':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/smithy-client': 4.11.3
+      '@smithy/types': 4.12.0
+      '@smithy/util-hex-encoding': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-ssec@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-user-agent@3.972.9':
+    dependencies:
+      '@aws-sdk/core': 3.973.9
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.989.0
+      '@smithy/core': 3.23.0
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.989.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.9
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.9
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.989.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.7
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.23.0
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.14
+      '@smithy/middleware-retry': 4.4.31
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.3
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.30
+      '@smithy/util-defaults-mode-node': 4.2.33
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/region-config-resolver@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.984.0':
+    dependencies:
+      '@aws-sdk/middleware-sdk-s3': 3.972.9
+      '@aws-sdk/types': 3.973.1
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/signature-v4': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.989.0':
+    dependencies:
+      '@aws-sdk/core': 3.973.9
+      '@aws-sdk/nested-clients': 3.989.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/types@3.973.1':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/util-arn-parser@3.972.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-endpoints@3.984.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-endpoints': 3.2.8
+      tslib: 2.8.1
+
+  '@aws-sdk/util-endpoints@3.989.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-endpoints': 3.2.8
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.4':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-browser@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-node@3.972.7':
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.972.9
+      '@aws-sdk/types': 3.973.1
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.4':
+    dependencies:
+      '@smithy/types': 4.12.0
+      fast-xml-parser: 5.3.4
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.3': {}
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -5113,6 +7221,49 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  '@cloudflare/kv-asset-handler@0.4.2': {}
+
+  '@cloudflare/unenv-preset@2.12.1(unenv@2.0.0-rc.24)(workerd@1.20260212.0)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260212.0
+
+  '@cloudflare/workerd-darwin-64@1.20260212.0':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260212.0':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20260212.0':
+    optional: true
+
+  '@cloudflare/workerd-linux-arm64@1.20260212.0':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260212.0':
+    optional: true
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
+  '@dotenvx/dotenvx@1.31.0':
+    dependencies:
+      commander: 11.1.0
+      dotenv: 16.6.1
+      eciesjs: 0.4.17
+      execa: 5.1.1
+      fdir: 6.4.6(picomatch@4.0.3)
+      ignore: 5.3.2
+      object-treeify: 1.1.33
+      picomatch: 4.0.3
+      which: 4.0.0
+
+  '@ecies/ciphers@0.2.5(@noble/ciphers@1.3.0)':
+    dependencies:
+      '@noble/ciphers': 1.3.0
+
   '@emnapi/core@1.4.5':
     dependencies:
       '@emnapi/wasi-threads': 1.0.4
@@ -5212,82 +7363,235 @@ snapshots:
 
   '@emotion/weak-memoize@0.4.0': {}
 
+  '@esbuild/aix-ppc64@0.25.4':
+    optional: true
+
   '@esbuild/aix-ppc64@0.25.9':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.4':
     optional: true
 
   '@esbuild/android-arm64@0.25.9':
     optional: true
 
+  '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm@0.25.4':
+    optional: true
+
   '@esbuild/android-arm@0.25.9':
+    optional: true
+
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.25.4':
     optional: true
 
   '@esbuild/android-x64@0.25.9':
     optional: true
 
+  '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.4':
+    optional: true
+
   '@esbuild/darwin-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.4':
     optional: true
 
   '@esbuild/darwin-x64@0.25.9':
     optional: true
 
+  '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.4':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.4':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.9':
     optional: true
 
+  '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.4':
+    optional: true
+
   '@esbuild/linux-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.4':
     optional: true
 
   '@esbuild/linux-arm@0.25.9':
     optional: true
 
+  '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.4':
+    optional: true
+
   '@esbuild/linux-ia32@0.25.9':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.4':
     optional: true
 
   '@esbuild/linux-loong64@0.25.9':
     optional: true
 
+  '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.4':
+    optional: true
+
   '@esbuild/linux-mips64el@0.25.9':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.4':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.9':
     optional: true
 
+  '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.4':
+    optional: true
+
   '@esbuild/linux-riscv64@0.25.9':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.4':
     optional: true
 
   '@esbuild/linux-s390x@0.25.9':
     optional: true
 
+  '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.4':
+    optional: true
+
   '@esbuild/linux-x64@0.25.9':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.4':
     optional: true
 
   '@esbuild/netbsd-arm64@0.25.9':
     optional: true
 
+  '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.4':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.9':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.4':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.9':
     optional: true
 
+  '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.4':
+    optional: true
+
   '@esbuild/openbsd-x64@0.25.9':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.3':
     optional: true
 
   '@esbuild/openharmony-arm64@0.25.9':
     optional: true
 
+  '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.4':
+    optional: true
+
   '@esbuild/sunos-x64@0.25.9':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.4':
     optional: true
 
   '@esbuild/win32-arm64@0.25.9':
     optional: true
 
+  '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.4':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.9':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.4':
+    optional: true
+
   '@esbuild/win32-x64@0.25.9':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
     optional: true
 
   '@eslint-community/eslint-utils@4.7.0(eslint@9.33.0(jiti@2.5.1))':
@@ -5368,8 +7672,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@img/colour@1.0.0':
-    optional: true
+  '@img/colour@1.0.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
@@ -5480,6 +7783,8 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
+  '@isaacs/cliui@9.0.0': {}
+
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.2
@@ -5522,6 +7827,11 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -5822,6 +8132,29 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.4.8':
     optional: true
 
+  '@noble/ciphers@1.3.0': {}
+
+  '@noble/curves@1.9.7':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
+  '@noble/hashes@1.8.0': {}
+
+  '@node-minify/core@8.0.6':
+    dependencies:
+      '@node-minify/utils': 8.0.6
+      glob: 9.3.5
+      mkdirp: 1.0.4
+
+  '@node-minify/terser@8.0.6':
+    dependencies:
+      '@node-minify/utils': 8.0.6
+      terser: 5.16.9
+
+  '@node-minify/utils@8.0.6':
+    dependencies:
+      gzip-size: 6.0.0
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -5836,7 +8169,60 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@opennextjs/aws@3.9.16(next@15.4.8(@babel/core@7.28.3)(babel-plugin-macros@3.1.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))':
+    dependencies:
+      '@ast-grep/napi': 0.40.5
+      '@aws-sdk/client-cloudfront': 3.984.0
+      '@aws-sdk/client-dynamodb': 3.984.0
+      '@aws-sdk/client-lambda': 3.984.0
+      '@aws-sdk/client-s3': 3.984.0
+      '@aws-sdk/client-sqs': 3.984.0
+      '@node-minify/core': 8.0.6
+      '@node-minify/terser': 8.0.6
+      '@tsconfig/node18': 1.0.3
+      aws4fetch: 1.0.20
+      chalk: 5.6.2
+      cookie: 1.1.1
+      esbuild: 0.25.4
+      express: 5.2.1
+      next: 15.4.8(@babel/core@7.28.3)(babel-plugin-macros@3.1.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      path-to-regexp: 6.3.0
+      urlpattern-polyfill: 10.1.0
+      yaml: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+      - supports-color
+
+  '@opennextjs/cloudflare@1.16.4(next@15.4.8(@babel/core@7.28.3)(babel-plugin-macros@3.1.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(wrangler@4.65.0)':
+    dependencies:
+      '@ast-grep/napi': 0.40.5
+      '@dotenvx/dotenvx': 1.31.0
+      '@opennextjs/aws': 3.9.16(next@15.4.8(@babel/core@7.28.3)(babel-plugin-macros@3.1.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
+      cloudflare: 4.5.0
+      enquirer: 2.4.1
+      glob: 12.0.0
+      next: 15.4.8(@babel/core@7.28.3)(babel-plugin-macros@3.1.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      ts-tqdm: 0.8.6
+      wrangler: 4.65.0
+      yargs: 18.0.0
+    transitivePeerDependencies:
+      - aws-crt
+      - encoding
+      - supports-color
+
   '@popperjs/core@2.11.8': {}
+
+  '@poppinss/colors@4.1.6':
+    dependencies:
+      kleur: 4.1.5
+
+  '@poppinss/dumper@0.6.5':
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@sindresorhus/is': 7.2.0
+      supports-color: 10.2.2
+
+  '@poppinss/exception@1.2.3': {}
 
   '@radix-ui/number@1.1.1': {}
 
@@ -6258,6 +8644,348 @@ snapshots:
 
   '@sinclair/typebox@0.27.8': {}
 
+  '@sindresorhus/is@7.2.0': {}
+
+  '@smithy/abort-controller@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/chunked-blob-reader-native@4.2.1':
+    dependencies:
+      '@smithy/util-base64': 4.3.0
+      tslib: 2.8.1
+
+  '@smithy/chunked-blob-reader@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/config-resolver@4.4.6':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-config-provider': 4.2.0
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      tslib: 2.8.1
+
+  '@smithy/core@3.23.0':
+    dependencies:
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-stream': 4.5.12
+      '@smithy/util-utf8': 4.2.0
+      '@smithy/uuid': 1.1.0
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.2.8':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      tslib: 2.8.1
+
+  '@smithy/eventstream-codec@4.2.8':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.12.0
+      '@smithy/util-hex-encoding': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-browser@4.2.8':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-config-resolver@4.3.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-node@4.2.8':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-universal@4.2.8':
+    dependencies:
+      '@smithy/eventstream-codec': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.3.9':
+    dependencies:
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/querystring-builder': 4.2.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      tslib: 2.8.1
+
+  '@smithy/hash-blob-browser@4.2.9':
+    dependencies:
+      '@smithy/chunked-blob-reader': 5.2.0
+      '@smithy/chunked-blob-reader-native': 4.2.1
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/hash-node@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      '@smithy/util-buffer-from': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/hash-stream-node@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/invalid-dependency@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/md5-js@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-content-length@4.2.8':
+    dependencies:
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-endpoint@4.4.14':
+    dependencies:
+      '@smithy/core': 3.23.0
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-middleware': 4.2.8
+      tslib: 2.8.1
+
+  '@smithy/middleware-retry@4.4.31':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/service-error-classification': 4.2.8
+      '@smithy/smithy-client': 4.11.3
+      '@smithy/types': 4.12.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/uuid': 1.1.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-serde@4.2.9':
+    dependencies:
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-stack@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/node-config-provider@4.3.8':
+    dependencies:
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.4.10':
+    dependencies:
+      '@smithy/abort-controller': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/querystring-builder': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/property-provider@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/protocol-http@5.3.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/querystring-builder@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      '@smithy/util-uri-escape': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/querystring-parser@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/service-error-classification@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+
+  '@smithy/shared-ini-file-loader@4.4.3':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.3.8':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.0
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-hex-encoding': 4.2.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-uri-escape': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/smithy-client@4.11.3':
+    dependencies:
+      '@smithy/core': 3.23.0
+      '@smithy/middleware-endpoint': 4.4.14
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-stream': 4.5.12
+      tslib: 2.8.1
+
+  '@smithy/types@4.12.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/url-parser@4.2.8':
+    dependencies:
+      '@smithy/querystring-parser': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/util-base64@4.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-browser@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-node@4.2.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@4.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-config-provider@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-browser@4.3.30':
+    dependencies:
+      '@smithy/property-provider': 4.2.8
+      '@smithy/smithy-client': 4.11.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-node@4.2.33':
+    dependencies:
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/credential-provider-imds': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/smithy-client': 4.11.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/util-endpoints@3.2.8':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/util-hex-encoding@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-middleware@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/util-retry@4.2.8':
+    dependencies:
+      '@smithy/service-error-classification': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/util-stream@4.5.12':
+    dependencies:
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-buffer-from': 4.2.0
+      '@smithy/util-hex-encoding': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-uri-escape@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@4.2.0':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-waiter@4.2.8':
+    dependencies:
+      '@smithy/abort-controller': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/uuid@1.1.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@speed-highlight/core@1.2.14': {}
+
   '@supabase/auth-js@2.95.3':
     dependencies:
       tslib: 2.8.1
@@ -6381,6 +9109,8 @@ snapshots:
       '@tailwindcss/oxide': 4.1.12
       postcss: 8.5.6
       tailwindcss: 4.1.12
+
+  '@tsconfig/node18@1.0.3': {}
 
   '@tybys/wasm-util@0.10.0':
     dependencies:
@@ -6559,6 +9289,15 @@ snapshots:
   '@types/ms@2.1.0': {}
 
   '@types/negotiator@0.6.4': {}
+
+  '@types/node-fetch@2.6.13':
+    dependencies:
+      '@types/node': 20.19.25
+      form-data: 4.0.4
+
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
 
   '@types/node@20.19.10':
     dependencies:
@@ -6842,11 +9581,20 @@ snapshots:
     dependencies:
       event-target-shim: 5.0.1
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
 
   acorn@8.15.0: {}
+
+  agentkeepalive@4.6.0:
+    dependencies:
+      humanize-ms: 1.2.1
 
   ajv-formats@2.1.1(ajv@8.17.1):
     optionalDependencies:
@@ -6896,6 +9644,8 @@ snapshots:
       '@algolia/requester-browser-xhr': 5.21.0
       '@algolia/requester-fetch': 5.21.0
       '@algolia/requester-node-http': 5.21.0
+
+  ansi-colors@4.1.3: {}
 
   ansi-escapes@7.0.0:
     dependencies:
@@ -7009,6 +9759,8 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
+  aws4fetch@1.0.20: {}
+
   axe-core@4.10.3: {}
 
   axios@1.11.0:
@@ -7031,6 +9783,10 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.2:
+    dependencies:
+      jackspeak: 4.2.3
+
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.9.5: {}
@@ -7043,6 +9799,24 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  blake3-wasm@2.1.5: {}
+
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.14.2
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  bowser@2.14.1: {}
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -7051,6 +9825,10 @@ snapshots:
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.2:
+    dependencies:
+      balanced-match: 4.0.2
 
   braces@3.0.3:
     dependencies:
@@ -7083,6 +9861,8 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  bytes@3.1.2: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -7114,6 +9894,8 @@ snapshots:
       supports-color: 7.2.0
 
   chalk@5.5.0: {}
+
+  chalk@5.6.2: {}
 
   character-entities-html4@2.1.0: {}
 
@@ -7164,7 +9946,25 @@ snapshots:
 
   client-only@0.0.1: {}
 
+  cliui@9.0.1:
+    dependencies:
+      string-width: 7.2.0
+      strip-ansi: 7.1.0
+      wrap-ansi: 9.0.0
+
   clone@1.0.4: {}
+
+  cloudflare@4.5.0:
+    dependencies:
+      '@types/node': 18.19.130
+      '@types/node-fetch': 2.6.13
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
 
   clsx@2.1.1: {}
 
@@ -7200,6 +10000,8 @@ snapshots:
 
   commander@10.0.1: {}
 
+  commander@11.1.0: {}
+
   commander@14.0.0: {}
 
   commander@2.20.3: {}
@@ -7208,9 +10010,17 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  content-disposition@1.0.1: {}
+
+  content-type@1.0.5: {}
+
   convert-source-map@1.9.0: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
 
   cookie@1.1.1: {}
 
@@ -7423,6 +10233,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   decimal.js-light@2.5.1: {}
 
   decode-named-character-reference@1.2.0:
@@ -7453,6 +10267,8 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  depd@2.0.0: {}
+
   dequal@2.0.3: {}
 
   detect-libc@2.0.4: {}
@@ -7474,13 +10290,26 @@ snapshots:
       '@babel/runtime': 7.28.3
       csstype: 3.1.3
 
+  dotenv@16.6.1: {}
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  duplexer@0.1.2: {}
+
   eastasianwidth@0.2.0: {}
+
+  eciesjs@0.4.17:
+    dependencies:
+      '@ecies/ciphers': 0.2.5(@noble/ciphers@1.3.0)
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+
+  ee-first@1.1.1: {}
 
   electron-to-chromium@1.5.200: {}
 
@@ -7492,10 +10321,17 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
+  encodeurl@2.0.0: {}
+
   enhanced-resolve@5.18.3:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.2
+
+  enquirer@2.4.1:
+    dependencies:
+      ansi-colors: 4.1.3
+      strip-ansi: 6.0.1
 
   entities@6.0.1: {}
 
@@ -7504,6 +10340,8 @@ snapshots:
   error-ex@1.3.2:
     dependencies:
       is-arrayish: 0.2.1
+
+  error-stack-parser-es@1.0.5: {}
 
   es-abstract@1.24.0:
     dependencies:
@@ -7622,6 +10460,34 @@ snapshots:
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
 
+  esbuild@0.25.4:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.4
+      '@esbuild/android-arm': 0.25.4
+      '@esbuild/android-arm64': 0.25.4
+      '@esbuild/android-x64': 0.25.4
+      '@esbuild/darwin-arm64': 0.25.4
+      '@esbuild/darwin-x64': 0.25.4
+      '@esbuild/freebsd-arm64': 0.25.4
+      '@esbuild/freebsd-x64': 0.25.4
+      '@esbuild/linux-arm': 0.25.4
+      '@esbuild/linux-arm64': 0.25.4
+      '@esbuild/linux-ia32': 0.25.4
+      '@esbuild/linux-loong64': 0.25.4
+      '@esbuild/linux-mips64el': 0.25.4
+      '@esbuild/linux-ppc64': 0.25.4
+      '@esbuild/linux-riscv64': 0.25.4
+      '@esbuild/linux-s390x': 0.25.4
+      '@esbuild/linux-x64': 0.25.4
+      '@esbuild/netbsd-arm64': 0.25.4
+      '@esbuild/netbsd-x64': 0.25.4
+      '@esbuild/openbsd-arm64': 0.25.4
+      '@esbuild/openbsd-x64': 0.25.4
+      '@esbuild/sunos-x64': 0.25.4
+      '@esbuild/win32-arm64': 0.25.4
+      '@esbuild/win32-ia32': 0.25.4
+      '@esbuild/win32-x64': 0.25.4
+
   esbuild@0.25.9:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.25.9
@@ -7651,7 +10517,38 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.9
       '@esbuild/win32-x64': 0.25.9
 
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
+
   escalade@3.2.0: {}
+
+  escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -7898,6 +10795,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
   event-target-shim@5.0.1: {}
 
   eventemitter3@4.0.7: {}
@@ -7905,6 +10804,51 @@ snapshots:
   eventemitter3@5.0.1: {}
 
   events@3.3.0: {}
+
+  execa@5.1.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.0.1
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.1
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.14.2
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   extend-shallow@2.0.1:
     dependencies:
@@ -7938,6 +10882,10 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
+  fast-xml-parser@5.3.4:
+    dependencies:
+      strnum: 2.1.2
+
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
@@ -7955,6 +10903,17 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.1
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   find-root@1.1.0: {}
 
@@ -7981,6 +10940,8 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  form-data-encoder@1.7.2: {}
+
   form-data@4.0.4:
     dependencies:
       asynckit: 0.4.0
@@ -7989,7 +10950,18 @@ snapshots:
       hasown: 2.0.2
       mime-types: 2.1.35
 
+  formdata-node@4.4.1:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 4.0.0-beta.3
+
   formdata-node@6.0.3: {}
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
+  fs.realpath@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
@@ -8008,6 +10980,8 @@ snapshots:
   functions-have-names@1.2.3: {}
 
   gensync@1.0.0-beta.2: {}
+
+  get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.3.0: {}
 
@@ -8030,6 +11004,8 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
+
+  get-stream@6.0.1: {}
 
   get-symbol-description@1.1.0:
     dependencies:
@@ -8062,6 +11038,22 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.0
 
+  glob@12.0.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 4.1.1
+      minimatch: 10.2.0
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.0
+
+  glob@9.3.5:
+    dependencies:
+      fs.realpath: 1.0.0
+      minimatch: 8.0.4
+      minipass: 4.2.8
+      path-scurry: 1.11.1
+
   globals@14.0.0: {}
 
   globalthis@1.0.4:
@@ -8081,6 +11073,10 @@ snapshots:
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
+
+  gzip-size@6.0.0:
+    dependencies:
+      duplexer: 0.1.2
 
   has-bigints@1.1.0: {}
 
@@ -8220,9 +11216,27 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  human-signals@2.1.0: {}
+
+  humanize-ms@1.2.1:
+    dependencies:
+      ms: 2.1.3
+
   iceberg-js@0.8.1: {}
 
   iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -8287,6 +11301,8 @@ snapshots:
       side-channel: 1.1.0
 
   internmap@2.0.3: {}
+
+  ipaddr.js@1.9.1: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -8391,6 +11407,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-promise@4.0.0: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -8403,6 +11421,8 @@ snapshots:
   is-shared-array-buffer@1.0.4:
     dependencies:
       call-bound: 1.0.4
+
+  is-stream@2.0.1: {}
 
   is-string@1.1.1:
     dependencies:
@@ -8436,6 +11456,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  isexe@3.1.5: {}
+
   iterator.prototype@1.1.5:
     dependencies:
       define-data-property: 1.1.4
@@ -8448,6 +11470,10 @@ snapshots:
   jackspeak@4.1.1:
     dependencies:
       '@isaacs/cliui': 8.0.2
+
+  jackspeak@4.2.3:
+    dependencies:
+      '@isaacs/cliui': 9.0.0
 
   jest-get-type@29.6.3: {}
 
@@ -8515,6 +11541,8 @@ snapshots:
       json-buffer: 3.0.1
 
   kind-of@6.0.3: {}
+
+  kleur@4.1.5: {}
 
   language-subtag-registry@0.3.23: {}
 
@@ -8636,6 +11664,8 @@ snapshots:
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  lru-cache@10.4.3: {}
 
   lru-cache@11.1.0: {}
 
@@ -8766,7 +11796,11 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
 
+  media-typer@1.1.0: {}
+
   memoize-one@6.0.0: {}
+
+  merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
 
@@ -8985,9 +12019,15 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mimic-fn@2.1.0: {}
 
@@ -8995,19 +12035,41 @@ snapshots:
 
   mini-svg-data-uri@1.4.4: {}
 
+  miniflare@4.20260212.0:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.34.5
+      undici: 7.18.2
+      workerd: 1.20260212.0
+      ws: 8.18.0
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   minimatch@10.0.3:
     dependencies:
       '@isaacs/brace-expansion': 5.0.0
 
+  minimatch@10.2.0:
+    dependencies:
+      brace-expansion: 5.0.2
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.12
+
+  minimatch@8.0.4:
+    dependencies:
+      brace-expansion: 2.0.2
 
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.2
 
   minimist@1.2.8: {}
+
+  minipass@4.2.8: {}
 
   minipass@7.1.2: {}
 
@@ -9017,7 +12079,13 @@ snapshots:
 
   mkdirp@0.3.0: {}
 
+  mkdirp@1.0.4: {}
+
   mkdirp@3.0.1: {}
+
+  mnemonist@0.38.3:
+    dependencies:
+      obliterator: 1.6.1
 
   moo@0.5.2: {}
 
@@ -9032,6 +12100,8 @@ snapshots:
   natural-compare@1.4.0: {}
 
   negotiator@0.6.4: {}
+
+  negotiator@1.0.0: {}
 
   neo-async@2.6.2: {}
 
@@ -9058,6 +12128,8 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  node-domexception@1.0.0: {}
+
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
@@ -9072,11 +12144,17 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
+  npm-run-path@4.0.1:
+    dependencies:
+      path-key: 3.1.1
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
 
   object-keys@1.1.1: {}
+
+  object-treeify@1.1.33: {}
 
   object.assign@4.1.7:
     dependencies:
@@ -9113,6 +12191,16 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  obliterator@1.6.1: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   onetime@5.1.2:
     dependencies:
@@ -9196,18 +12284,31 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  parseurl@1.3.3: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
 
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.2
+
   path-scurry@2.0.0:
     dependencies:
       lru-cache: 11.1.0
       minipass: 7.1.2
 
+  path-to-regexp@6.3.0: {}
+
+  path-to-regexp@8.3.0: {}
+
   path-type@4.0.0: {}
+
+  pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
@@ -9268,6 +12369,11 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   proxy-from-env@1.1.0: {}
 
   pseudolocale@2.1.0:
@@ -9280,6 +12386,10 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
+  qs@6.14.2:
+    dependencies:
+      side-channel: 1.1.0
+
   qs@6.9.7: {}
 
   queue-microtask@1.2.3: {}
@@ -9287,6 +12397,15 @@ snapshots:
   randombytes@2.1.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   react-dom@19.1.1(react@19.1.1):
     dependencies:
@@ -9598,6 +12717,16 @@ snapshots:
 
   robust-predicates@3.0.2: {}
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.1
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.3.0
+    transitivePeerDependencies:
+      - supports-color
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -9647,9 +12776,34 @@ snapshots:
 
   semver@7.7.3: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serialize-javascript@6.0.2:
     dependencies:
       randombytes: 2.1.0
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
 
   set-function-length@1.2.2:
     dependencies:
@@ -9672,6 +12826,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
+
+  setprototypeof@1.2.0: {}
 
   sharp@0.34.5:
     dependencies:
@@ -9703,7 +12859,6 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:
@@ -9793,6 +12948,8 @@ snapshots:
   sprintf-js@1.0.3: {}
 
   stable-hash@0.0.5: {}
+
+  statuses@2.0.2: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -9890,7 +13047,11 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-final-newline@2.0.0: {}
+
   strip-json-comments@3.1.1: {}
+
+  strnum@2.1.2: {}
 
   style-to-js@1.1.18:
     dependencies:
@@ -9909,6 +13070,8 @@ snapshots:
       babel-plugin-macros: 3.1.0
 
   stylis@4.2.0: {}
+
+  supports-color@10.2.2: {}
 
   supports-color@7.2.0:
     dependencies:
@@ -9950,6 +13113,13 @@ snapshots:
       terser: 5.44.1
       webpack: 5.98.0
 
+  terser@5.16.9:
+    dependencies:
+      '@jridgewell/source-map': 0.3.11
+      acorn: 8.15.0
+      commander: 2.20.3
+      source-map-support: 0.5.21
+
   terser@5.44.1:
     dependencies:
       '@jridgewell/source-map': 0.3.11
@@ -9968,6 +13138,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toidentifier@1.0.1: {}
+
   tr46@0.0.3: {}
 
   tr46@1.0.1:
@@ -9981,6 +13153,8 @@ snapshots:
   ts-api-utils@2.1.0(typescript@5.9.2):
     dependencies:
       typescript: 5.9.2
+
+  ts-tqdm@0.8.6: {}
 
   tsconfig-paths@3.15.0:
     dependencies:
@@ -10003,6 +13177,12 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -10062,7 +13242,15 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
+  undici-types@5.26.5: {}
+
   undici-types@6.21.0: {}
+
+  undici@7.18.2: {}
+
+  unenv@2.0.0-rc.24:
+    dependencies:
+      pathe: 2.0.3
 
   unified@11.0.5:
     dependencies:
@@ -10100,6 +13288,8 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
+
+  unpipe@1.0.0: {}
 
   unrs-resolver@1.11.1:
     dependencies:
@@ -10143,6 +13333,8 @@ snapshots:
 
   url-join@4.0.1: {}
 
+  urlpattern-polyfill@10.1.0: {}
+
   use-callback-ref@1.3.3(@types/react@19.1.10)(react@19.1.1):
     dependencies:
       react: 19.1.1
@@ -10174,6 +13366,8 @@ snapshots:
       react: 19.1.1
 
   util-deprecate@1.0.2: {}
+
+  vary@1.1.2: {}
 
   vfile-location@5.0.3:
     dependencies:
@@ -10217,6 +13411,8 @@ snapshots:
       defaults: 1.0.4
 
   web-namespaces@2.0.1: {}
+
+  web-streams-polyfill@4.0.0-beta.3: {}
 
   web-vitals@4.2.4: {}
 
@@ -10312,7 +13508,35 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  which@4.0.0:
+    dependencies:
+      isexe: 3.1.5
+
   word-wrap@1.2.5: {}
+
+  workerd@1.20260212.0:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260212.0
+      '@cloudflare/workerd-darwin-arm64': 1.20260212.0
+      '@cloudflare/workerd-linux-64': 1.20260212.0
+      '@cloudflare/workerd-linux-arm64': 1.20260212.0
+      '@cloudflare/workerd-windows-64': 1.20260212.0
+
+  wrangler@4.65.0:
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.4.2
+      '@cloudflare/unenv-preset': 2.12.1(unenv@2.0.0-rc.24)(workerd@1.20260212.0)
+      blake3-wasm: 2.1.5
+      esbuild: 0.27.3
+      miniflare: 4.20260212.0
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260212.0
+    optionalDependencies:
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   wrap-ansi@7.0.0:
     dependencies:
@@ -10332,7 +13556,13 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.1.0
 
+  wrappy@1.0.2: {}
+
+  ws@8.18.0: {}
+
   ws@8.19.0: {}
+
+  y18n@5.0.8: {}
 
   yallist@3.1.1: {}
 
@@ -10342,6 +13572,30 @@ snapshots:
 
   yaml@2.8.1: {}
 
+  yargs-parser@22.0.0: {}
+
+  yargs@18.0.0:
+    dependencies:
+      cliui: 9.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      string-width: 7.2.0
+      y18n: 5.0.8
+      yargs-parser: 22.0.0
+
   yocto-queue@0.1.0: {}
+
+  youch-core@0.3.3:
+    dependencies:
+      '@poppinss/exception': 1.2.3
+      error-stack-parser-es: 1.0.5
+
+  youch@4.1.0-beta.10:
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@poppinss/dumper': 0.6.5
+      '@speed-highlight/core': 1.2.14
+      cookie: 1.1.1
+      youch-core: 0.3.3
 
   zwitch@2.0.4: {}

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,2 @@
+/_next/static/*
+  Cache-Control: public,max-age=31536000,immutable

--- a/src/app/[lang]/(main)/login/login-form.tsx
+++ b/src/app/[lang]/(main)/login/login-form.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { createClient } from "@/lib/supabase/client";
+import { Trans } from "@lingui/react/macro";
+import { useLingui } from "@lingui/react/macro";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
+
+export function LoginForm() {
+  const { i18n } = useLingui();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const supabase = createClient();
+
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [isSignUp, setIsSignUp] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const error = searchParams.get("error");
+
+  const handleOAuthLogin = async (
+    provider: "google" | "x" | "discord" | "github",
+  ) => {
+    await supabase.auth.signInWithOAuth({
+      provider,
+      options: {
+        redirectTo: `${window.location.origin}/auth/callback?next=/${i18n.locale}`,
+      },
+    });
+  };
+
+  const handleEmailSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+
+    if (isSignUp) {
+      const { error } = await supabase.auth.signUp({
+        email,
+        password,
+        options: {
+          emailRedirectTo: `${window.location.origin}/auth/callback?next=/${i18n.locale}`,
+        },
+      });
+
+      if (error) {
+        toast.error(error.message);
+      } else {
+        toast.success("Check your email for a confirmation link.");
+      }
+    } else {
+      const { error } = await supabase.auth.signInWithPassword({
+        email,
+        password,
+      });
+
+      if (error) {
+        toast.error(error.message);
+      } else {
+        router.push(`/${i18n.locale}`);
+        router.refresh();
+      }
+    }
+
+    setLoading(false);
+  };
+
+  return (
+    <div className="mt-6 space-y-6">
+      {error && (
+        <div className="rounded-md bg-red-50 p-4 text-sm text-red-700">
+          <Trans>Authentication failed. Please try again.</Trans>
+        </div>
+      )}
+
+      <div className="space-y-3">
+        <button
+          onClick={() => handleOAuthLogin("google")}
+          className="flex w-full items-center justify-center gap-3 rounded-md border border-border bg-white px-4 py-2.5 text-sm font-medium text-foreground shadow-sm hover:bg-gray-50 transition-colors"
+        >
+          <svg className="h-5 w-5" viewBox="0 0 24 24">
+            <path
+              d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+              fill="#4285F4"
+            />
+            <path
+              d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+              fill="#34A853"
+            />
+            <path
+              d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+              fill="#FBBC05"
+            />
+            <path
+              d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+              fill="#EA4335"
+            />
+          </svg>
+          <Trans>Continue with Google</Trans>
+        </button>
+
+        <button
+          onClick={() => handleOAuthLogin("github")}
+          className="flex w-full items-center justify-center gap-3 rounded-md border border-border bg-white px-4 py-2.5 text-sm font-medium text-foreground shadow-sm hover:bg-gray-50 transition-colors"
+        >
+          <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
+          </svg>
+          <Trans>Continue with GitHub</Trans>
+        </button>
+
+        <button
+          onClick={() => handleOAuthLogin("x")}
+          className="flex w-full items-center justify-center gap-3 rounded-md border border-border bg-white px-4 py-2.5 text-sm font-medium text-foreground shadow-sm hover:bg-gray-50 transition-colors"
+        >
+          <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+          </svg>
+          <Trans>Continue with X</Trans>
+        </button>
+
+        <button
+          onClick={() => handleOAuthLogin("discord")}
+          className="flex w-full items-center justify-center gap-3 rounded-md border border-border bg-white px-4 py-2.5 text-sm font-medium text-foreground shadow-sm hover:bg-gray-50 transition-colors"
+        >
+          <svg className="h-5 w-5" viewBox="0 0 24 24" fill="#5865F2">
+            <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
+          </svg>
+          <Trans>Continue with Discord</Trans>
+        </button>
+      </div>
+
+      <div className="relative">
+        <div className="absolute inset-0 flex items-center">
+          <div className="w-full border-t border-border" />
+        </div>
+        <div className="relative flex justify-center text-sm">
+          <span className="bg-background px-2 text-muted-foreground">
+            <Trans>or</Trans>
+          </span>
+        </div>
+      </div>
+
+      <form onSubmit={handleEmailSubmit} className="space-y-4">
+        <div>
+          <label
+            htmlFor="email"
+            className="block text-sm font-medium text-foreground"
+          >
+            <Trans>Email</Trans>
+          </label>
+          <input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            className="mt-1 block w-full rounded-md border border-border bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="password"
+            className="block text-sm font-medium text-foreground"
+          >
+            <Trans>Password</Trans>
+          </label>
+          <input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            minLength={6}
+            className="mt-1 block w-full rounded-md border border-border bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+          />
+        </div>
+
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full rounded-md bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground shadow-sm hover:bg-primary/90 transition-colors disabled:opacity-50"
+        >
+          {isSignUp ? <Trans>Sign Up</Trans> : <Trans>Sign In</Trans>}
+        </button>
+      </form>
+
+      <p className="text-center text-sm text-muted-foreground">
+        {isSignUp ? (
+          <>
+            <Trans>Already have an account?</Trans>{" "}
+            <button
+              onClick={() => setIsSignUp(false)}
+              className="font-medium text-primary hover:underline"
+            >
+              <Trans>Sign In</Trans>
+            </button>
+          </>
+        ) : (
+          <>
+            <Trans>Don&apos;t have an account?</Trans>{" "}
+            <button
+              onClick={() => setIsSignUp(true)}
+              className="font-medium text-primary hover:underline"
+            >
+              <Trans>Sign Up</Trans>
+            </button>
+          </>
+        )}
+      </p>
+    </div>
+  );
+}

--- a/src/app/[lang]/(main)/login/page.tsx
+++ b/src/app/[lang]/(main)/login/page.tsx
@@ -1,0 +1,51 @@
+import { H1, Page, PageContent, Section } from "@/components/Layout";
+import { initLingui, PageLangParam } from "@/initLingui";
+import { createClient } from "@/lib/supabase/server";
+import { generateHreflangAlternates } from "@/lib/utils";
+import { useLingui } from "@lingui/react/macro";
+import { PropsWithChildren } from "react";
+import { redirect } from "next/navigation";
+import { Trans } from "@lingui/react/macro";
+import { LoginForm } from "./login-form";
+
+export async function generateMetadata(
+  props: PropsWithChildren<PageLangParam>,
+) {
+  const lang = (await props.params).lang;
+  initLingui(lang);
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const { t } = useLingui();
+  return {
+    title: t`Sign In`,
+    description: t`Sign in to your CanadaSpends account`,
+    alternates: generateHreflangAlternates(lang, "/login"),
+  };
+}
+
+export default async function Login(props: PropsWithChildren<PageLangParam>) {
+  const lang = (await props.params).lang;
+  initLingui(lang);
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (user) {
+    redirect(`/${lang}`);
+  }
+
+  return (
+    <Page>
+      <PageContent>
+        <Section className="max-w-md">
+          <H1>
+            <Trans>Sign In</Trans>
+          </H1>
+          <LoginForm />
+        </Section>
+      </PageContent>
+    </Page>
+  );
+}

--- a/src/app/[lang]/(main)/notifications/page.tsx
+++ b/src/app/[lang]/(main)/notifications/page.tsx
@@ -1,0 +1,56 @@
+import { H1, Intro, Page, PageContent, Section } from "@/components/Layout";
+import { initLingui, PageLangParam } from "@/initLingui";
+import { createClient } from "@/lib/supabase/server";
+import { generateHreflangAlternates } from "@/lib/utils";
+import { Trans, useLingui } from "@lingui/react/macro";
+import { redirect } from "next/navigation";
+import { PropsWithChildren } from "react";
+
+export async function generateMetadata(
+  props: PropsWithChildren<PageLangParam>,
+) {
+  const lang = (await props.params).lang;
+  initLingui(lang);
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const { t } = useLingui();
+  return {
+    title: t`Notifications`,
+    description: t`Your notifications`,
+    alternates: generateHreflangAlternates(lang, "/notifications"),
+  };
+}
+
+export default async function Notifications(
+  props: PropsWithChildren<PageLangParam>,
+) {
+  const lang = (await props.params).lang;
+  initLingui(lang);
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect(`/${lang}/login`);
+  }
+
+  return (
+    <Page>
+      <PageContent>
+        <Section>
+          <H1>
+            <Trans>Notifications</Trans>
+          </H1>
+          <Intro>
+            <Trans>Welcome, {user.email}!</Trans>
+          </Intro>
+          <p className="mt-4 text-muted-foreground">
+            <Trans>You have no new notifications.</Trans>
+          </p>
+        </Section>
+      </PageContent>
+    </Page>
+  );
+}

--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -1,4 +1,5 @@
 import { allMessages } from "@/appRouterI18n";
+import { AuthListener } from "@/components/AuthListener";
 import { LinguiClientProvider } from "@/components/LinguiClientProvider";
 import { initLingui, PageLangParam } from "@/initLingui";
 import { generateHreflangAlternates } from "@/lib/utils";
@@ -69,6 +70,7 @@ export default async function RootLayout({
     <html lang={lang}>
       <body className="antialiased">
         <PostHogProvider>
+          <AuthListener />
           <LinguiClientProvider
             initialLocale={lang}
             initialMessages={allMessages[lang]!}

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,0 +1,41 @@
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+export async function GET(request: Request) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get("code");
+  const next = searchParams.get("next") ?? "/en";
+
+  if (code) {
+    const cookieStore = await cookies();
+
+    const supabase = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        cookies: {
+          getAll() {
+            return cookieStore.getAll();
+          },
+          setAll(cookiesToSet) {
+            try {
+              cookiesToSet.forEach(({ name, value, options }) =>
+                cookieStore.set(name, value, options),
+              );
+            } catch {
+              // The `setAll` method was called from a Server Component.
+            }
+          },
+        },
+      },
+    );
+
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+    if (!error) {
+      return NextResponse.redirect(`${origin}${next}`);
+    }
+  }
+
+  return NextResponse.redirect(`${origin}/en/login?error=auth_callback_failed`);
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import { allMessages } from "@/appRouterI18n";
+import { AuthListener } from "@/components/AuthListener";
 import { LinguiClientProvider } from "@/components/LinguiClientProvider";
 import { initLingui } from "@/initLingui";
 import { ReactNode } from "react";
@@ -15,6 +16,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     <html lang="en">
       <body className="antialiased">
         <PostHogProvider>
+          <AuthListener />
           <LinguiClientProvider
             initialLocale="en"
             initialMessages={allMessages["en"]!}

--- a/src/components/AuthListener.tsx
+++ b/src/components/AuthListener.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { createClient } from "@/lib/supabase/client";
+import { usePostHog } from "posthog-js/react";
+import { useEffect } from "react";
+
+export function AuthListener() {
+  const posthog = usePostHog();
+  const supabase = createClient();
+
+  useEffect(() => {
+    // Check current session on mount (handles page refreshes)
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      if (user) {
+        posthog.identify(user.id, { email: user.email });
+      }
+    });
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((event, session) => {
+      if (event === "SIGNED_IN" && session?.user) {
+        posthog.identify(session.user.id, { email: session.user.email });
+      } else if (event === "SIGNED_OUT") {
+        posthog.reset();
+      }
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [posthog, supabase.auth]);
+
+  return null;
+}

--- a/src/components/MainLayout/_components/DesktopNav.tsx
+++ b/src/components/MainLayout/_components/DesktopNav.tsx
@@ -4,6 +4,7 @@ import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { provinceNames } from "@/lib/provinceNames";
+import { UserMenu } from "@/components/UserMenu";
 
 // Memoize NavLink
 const NavLink = memo(
@@ -321,6 +322,7 @@ export default function DesktopNav(props: DesktopNavProps) {
           </DropdownMenu.Content>
         </DropdownMenu.Portal>
       </DropdownMenu.Root>
+      <UserMenu />
       <a
         href="https://buildcanada.com/get-involved?utm_source=canadaspends&utm_medium=header"
         target="_blank"

--- a/src/components/MainLayout/_components/MobileMenu.tsx
+++ b/src/components/MainLayout/_components/MobileMenu.tsx
@@ -4,6 +4,7 @@ import { Trans, useLingui } from "@lingui/react/macro";
 import { memo } from "react";
 import Link from "next/link";
 import { provinceNames } from "@/lib/provinceNames";
+import { UserMenu } from "@/components/UserMenu";
 
 interface MobileMenuButtonProps {
   isMenuOpen: boolean;
@@ -201,6 +202,9 @@ export function MobileMenu(props: MobileMenuProps) {
         >
           <Trans>Whistleblowers</Trans>
         </MobileNavLink>
+        <div className="px-3 pt-3">
+          <UserMenu />
+        </div>
         <a
           href="https://buildcanada.com/get-involved?utm_source=canadaspends&utm_medium=header_mobile_menu&utm_campaign=transparency"
           target="_blank"

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { createClient } from "@/lib/supabase/client";
+import type { User } from "@supabase/supabase-js";
+import { Trans } from "@lingui/react/macro";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { useLingui } from "@lingui/react/macro";
+
+export function UserMenu() {
+  const { i18n } = useLingui();
+  const router = useRouter();
+  const supabase = createClient();
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      setUser(user);
+    });
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null);
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [supabase.auth]);
+
+  const handleSignOut = async () => {
+    await supabase.auth.signOut();
+    router.push(`/${i18n.locale}/login`);
+    router.refresh();
+  };
+
+  if (!user) {
+    return null;
+  }
+
+  return (
+    <button
+      onClick={handleSignOut}
+      className="text-sm font-medium text-muted-foreground/80 hover:text-foreground"
+    >
+      <Trans>Sign Out</Trans>
+    </button>
+  );
+}

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,0 +1,8 @@
+import { createBrowserClient } from "@supabase/ssr";
+
+export function createClient() {
+  return createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+  );
+}

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,0 +1,29 @@
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+
+export async function createClient() {
+  const cookieStore = await cookies();
+
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+        setAll(cookiesToSet) {
+          try {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              cookieStore.set(name, value, options),
+            );
+          } catch {
+            // The `setAll` method was called from a Server Component.
+            // This can be ignored if you have middleware refreshing
+            // user sessions.
+          }
+        },
+      },
+    },
+  );
+}

--- a/src/locales/en.po
+++ b/src/locales/en.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:149
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:149
 msgid " How did Health Canada spend its budget in FY24?"
 msgstr " How did Health Canada spend its budget in FY24?"
 
@@ -121,22 +121,22 @@ msgstr "{provinceName} Total"
 msgid "© 2025 Canada Spends. All rights reserved. A Project of <0>Build Canada</0>."
 msgstr "© 2025 Canada Spends. All rights reserved. A Project of <0>Build Canada</0>."
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:235
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:235
 msgid "<0>Minister of Foreign Affairs</0>: Responsible for diplomacy, international security, international development assistance, and global partnerships."
 msgstr "<0>Minister of Foreign Affairs</0>: Responsible for diplomacy, international security, international development assistance, and global partnerships."
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:244
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:244
 msgid "<0>Minister of International Trade</0>: Oversees Canada's trade negotiations, export promotion, and economic policy engagement."
 msgstr "<0>Minister of International Trade</0>: Oversees Canada's trade negotiations, export promotion, and economic policy engagement."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:103
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:103
 msgid "10 government departments accounted for 73.2% of federal spending in FY 2024"
 msgstr "10 government departments accounted for 73.2% of federal spending in FY 2024"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:103
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:109
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:115
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:97
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:103
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:109
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:115
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:97
 msgid "10 government departments accounted for 73.2% of federal spending in FY 2024."
 msgstr "10 government departments accounted for 73.2% of federal spending in FY 2024."
 
@@ -144,68 +144,68 @@ msgstr "10 government departments accounted for 73.2% of federal spending in FY 
 msgid "100,000"
 msgstr "100,000"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:194
+#: src/app/[lang]/(main)/federal/spending/page.tsx:195
 #: src/app/[lang]/(main)/spending/page.tsx:185
 msgid "80% of employees are in permanent roles"
 msgstr "80% of employees are in permanent roles"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:37
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:37
 msgid "A look at how Employment and Social Development Canada spends its budget"
 msgstr "A look at how Employment and Social Development Canada spends its budget"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:34
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:34
 msgid "A look at how Health Canada spends its budget"
 msgstr "A look at how Health Canada spends its budget"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:35
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:35
 msgid "A look at how Housing, Infrastructure and Communities Canada spends its budget"
 msgstr "A look at how Housing, Infrastructure and Communities Canada spends its budget"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:33
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:33
 msgid "A look at how Immigration, Refugees and Citizenship Canada spends its budget"
 msgstr "A look at how Immigration, Refugees and Citizenship Canada spends its budget"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:36
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:36
 msgid "A look at how Indigenous Services and Northern Affairs Canada spends its budget"
 msgstr "A look at how Indigenous Services and Northern Affairs Canada spends its budget"
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:33
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:33
 msgid "A look at how Innovation, Science and Industry Canada spends its budget"
 msgstr "A look at how Innovation, Science and Industry Canada spends its budget"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:36
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:36
 msgid "A look at how National Defence spends its budget"
 msgstr "A look at how National Defence spends its budget"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:35
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:35
 msgid "A look at how Public Safety Canada spends its budget"
 msgstr "A look at how Public Safety Canada spends its budget"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:33
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:33
 msgid "A look at how Public Services and Procurement Canada spends its budget"
 msgstr "A look at how Public Services and Procurement Canada spends its budget"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:35
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:35
 msgid "A look at how the Canada Revenue Agency spends its budget"
 msgstr "A look at how the Canada Revenue Agency spends its budget"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:36
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:36
 msgid "A look at how the Department of Finance spends its budget"
 msgstr "A look at how the Department of Finance spends its budget"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:37
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:37
 msgid "A look at how the Global Affairs Canada spends its budget"
 msgstr "A look at how the Global Affairs Canada spends its budget"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:34
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:34
 msgid "A look at how Transport Canada spends its budget"
 msgstr "A look at how Transport Canada spends its budget"
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:34
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:34
 msgid "A look at how Veterans Affairs Canada spends its budget"
 msgstr "A look at how Veterans Affairs Canada spends its budget"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:187
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:187
 msgid "A significant portion of GAC's budget supports Canada's international development assistance, with key programs focused on climate adaptation, gender equality, and health initiatives in developing nations. The department also facilitates economic diplomacy and trade agreements that benefit Canadian businesses and secure investment opportunities abroad."
 msgstr "A significant portion of GAC's budget supports Canada's international development assistance, with key programs focused on climate adaptation, gender equality, and health initiatives in developing nations. The department also facilitates economic diplomacy and trade agreements that benefit Canadian businesses and secure investment opportunities abroad."
 
@@ -236,36 +236,36 @@ msgstr "Accounts payable, long-term debt, and other obligations owed to external
 msgid "Accumulated Surplus"
 msgstr "Accumulated Surplus"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:47
 msgid "Acquisition of Land, Buildings and Works"
 msgstr "Acquisition of Land, Buildings and Works"
 
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:47
 msgid "Acquisition of Lands, Buildings and Works"
 msgstr "Acquisition of Lands, Buildings and Works"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:51
 msgid "Acquisition of Machinery and Equipment"
 msgstr "Acquisition of Machinery and Equipment"
 
@@ -277,7 +277,7 @@ msgstr "Adjust for inflation (2025 dollars)"
 msgid "Adjust sliders to see how department spending reductions affect the overall Fall 2025 Budget. The Minister of Finance has asked departments to reduce spending by 7.5% in 2026-27, 10% in 2027-28, and 15% in 2028-29."
 msgstr "Adjust sliders to see how department spending reductions affect the overall Fall 2025 Budget. The Minister of Finance has asked departments to reduce spending by 7.5% in 2026-27, 10% in 2027-28, and 15% in 2028-29."
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:205
+#: src/app/[lang]/(main)/federal/spending/page.tsx:206
 #: src/app/[lang]/(main)/spending/page.tsx:196
 msgid "Age"
 msgstr "Age"
@@ -319,11 +319,11 @@ msgid "All expenses incurred during the fiscal year including program delivery, 
 msgstr "All expenses incurred during the fiscal year including program delivery, administration, and capital costs."
 
 #: src/app/[lang]/(main)/budget/page.tsx:270
-#: src/app/[lang]/(main)/federal/budget/page.tsx:307
+#: src/app/[lang]/(main)/federal/budget/page.tsx:309
 msgid "All government budget data is sourced from official databases, but due to the complexity of these systems, occasional errors may occur despite our best efforts. This page is also based on government memos and leaks, so it is not an official release of the Fall 2025 Budget. We aim to make this information more accessible and accurate, and we welcome feedback. If you notice any issues, please let us know <0>here</0> — we appreciate it and will work to address them promptly."
 msgstr "All government budget data is sourced from official databases, but due to the complexity of these systems, occasional errors may occur despite our best efforts. This page is also based on government memos and leaks, so it is not an official release of the Fall 2025 Budget. We aim to make this information more accessible and accurate, and we welcome feedback. If you notice any issues, please let us know <0>here</0> — we appreciate it and will work to address them promptly."
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:278
+#: src/app/[lang]/(main)/federal/spending/page.tsx:279
 #: src/app/[lang]/(main)/spending/page.tsx:269
 #: src/components/JurisdictionPageContent.tsx:507
 msgid "All government spending data is sourced from official databases, but due to the complexity of these systems, occasional errors may occur despite our best efforts. We aim to make this information more accessible and accurate, and we welcome feedback. If you notice any issues, please let us know <0>here</0> — we appreciate it and will work to address them promptly."
@@ -353,8 +353,12 @@ msgstr "All the information comes from public databases and reports by the Gover
 msgid "All the taxes that apply to your income"
 msgstr "All the taxes that apply to your income"
 
+#: src/app/[lang]/(main)/login/login-form.tsx:193
+msgid "Already have an account?"
+msgstr "Already have an account?"
+
 #: src/app/[lang]/(main)/budget/page.tsx:62
-#: src/app/[lang]/(main)/federal/budget/page.tsx:62
+#: src/app/[lang]/(main)/federal/budget/page.tsx:63
 msgid "Amount/Change"
 msgstr "Amount/Change"
 
@@ -376,7 +380,7 @@ msgstr "Annual interest payments on outstanding debt. This represents the cost o
 msgid "Annual municipal spending per {0} resident"
 msgstr "Annual municipal spending per {0} resident"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:185
+#: src/app/[lang]/(main)/federal/spending/page.tsx:186
 #: src/app/[lang]/(main)/spending/page.tsx:176
 msgid "Annual payroll"
 msgstr "Annual payroll"
@@ -423,7 +427,11 @@ msgstr "As of fiscal year end {fiscalYear}"
 msgid "Assets, liabilities, and net financial position as of the end of fiscal year {fiscalYear}."
 msgstr "Assets, liabilities, and net financial position as of the end of fiscal year {fiscalYear}."
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:178
+#: src/app/[lang]/(main)/login/login-form.tsx:73
+msgid "Authentication failed. Please try again."
+msgstr "Authentication failed. Please try again."
+
+#: src/app/[lang]/(main)/federal/spending/page.tsx:179
 #: src/app/[lang]/(main)/spending/page.tsx:169
 msgid "Average annual compensation"
 msgstr "Average annual compensation"
@@ -490,12 +498,12 @@ msgid "Budget"
 msgstr "Budget"
 
 #: src/app/[lang]/(main)/budget/page.tsx:59
-#: src/app/[lang]/(main)/federal/budget/page.tsx:59
+#: src/app/[lang]/(main)/federal/budget/page.tsx:60
 msgid "Budget Impact"
 msgstr "Budget Impact"
 
 #: src/app/[lang]/(main)/budget/page.tsx:169
-#: src/app/[lang]/(main)/federal/budget/page.tsx:206
+#: src/app/[lang]/(main)/federal/budget/page.tsx:208
 msgid "Budget Statistics (Projected FY 2025)"
 msgstr "Budget Statistics (Projected FY 2025)"
 
@@ -519,20 +527,20 @@ msgstr "Canada Community-Building Fund"
 msgid "Canada Emergency Wage Subsidy"
 msgstr "Canada Emergency Wage Subsidy"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/MiniSankey.tsx:19
 msgid "Canada health transfer"
 msgstr "Canada health transfer"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:38
 msgid "Canada Revenue Agency"
 msgstr "Canada Revenue Agency"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:34
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:34
 msgid "Canada Revenue Agency | Canada Spends"
 msgstr "Canada Revenue Agency | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/MiniSankey.tsx:23
 msgid "Canada social transfer"
 msgstr "Canada social transfer"
 
@@ -569,7 +577,7 @@ msgstr "Canada Spends provides a secure way for sources to submit tips and docum
 msgid "Canada Spends, as a project of Build Canada, is funded through donations from our builder network. Donate"
 msgstr "Canada Spends, as a project of Build Canada, is funded through donations from our builder network. Donate"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:211
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:211
 msgid "Canada Student Loans Program: providing financial aid for post-secondary students."
 msgstr "Canada Student Loans Program: providing financial aid for post-secondary students."
 
@@ -582,7 +590,7 @@ msgid "Canada, you need the facts."
 msgstr "Canada, you need the facts."
 
 #: src/app/[lang]/(main)/budget/page.tsx:204
-#: src/app/[lang]/(main)/federal/budget/page.tsx:241
+#: src/app/[lang]/(main)/federal/budget/page.tsx:243
 msgid "Capital Investments"
 msgstr "Capital Investments"
 
@@ -674,7 +682,7 @@ msgstr "Compare your total tax burden across all Canadian provinces and territor
 msgid "Compensation"
 msgstr "Compensation"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:176
+#: src/app/[lang]/(main)/federal/spending/page.tsx:177
 #: src/app/[lang]/(main)/spending/page.tsx:167
 msgid "Compensation per Employee"
 msgstr "Compensation per Employee"
@@ -699,6 +707,22 @@ msgstr "Connect with us"
 #: src/components/MainLayout/Footer.tsx:54
 msgid "Contact"
 msgstr "Contact"
+
+#: src/app/[lang]/(main)/login/login-form.tsx:130
+msgid "Continue with Discord"
+msgstr "Continue with Discord"
+
+#: src/app/[lang]/(main)/login/login-form.tsx:110
+msgid "Continue with GitHub"
+msgstr "Continue with GitHub"
+
+#: src/app/[lang]/(main)/login/login-form.tsx:100
+msgid "Continue with Google"
+msgstr "Continue with Google"
+
+#: src/app/[lang]/(main)/login/login-form.tsx:120
+msgid "Continue with X"
+msgstr "Continue with X"
 
 #: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:257
 msgid "Contributing Organization"
@@ -733,19 +757,19 @@ msgstr "Countries"
 msgid "COVID-19 Income Support"
 msgstr "COVID-19 Income Support"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:187
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:187
 msgid "CRA spending is divided across tax administration, compliance enforcement, benefit program delivery, and intergovernmental agreements with provinces and territories. The largest expenditures in FY 2024 included personal income tax processing, corporate tax audits, and benefit administration."
 msgstr "CRA spending is divided across tax administration, compliance enforcement, benefit program delivery, and intergovernmental agreements with provinces and territories. The largest expenditures in FY 2024 included personal income tax processing, corporate tax audits, and benefit administration."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:197
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:197
 msgid "CRA spending isolated to FY 2024"
 msgstr "CRA spending isolated to FY 2024"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:141
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:141
 msgid "CRA's share of federal spending in FY 2024 was higher than in FY 1995"
 msgstr "CRA's share of federal spending in FY 2024 was higher than in FY 1995"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:121
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:121
 msgid "CRA's spending grew more than overall spending, meaning its share of the federal budget increased. In 2024, the agency accounted for 3.2% of all federal spending, 1.85 percentage points higher than in 1995."
 msgstr "CRA's spending grew more than overall spending, meaning its share of the federal budget increased. In 2024, the agency accounted for 3.2% of all federal spending, 1.85 percentage points higher than in 1995."
 
@@ -770,23 +794,23 @@ msgstr "Customs Duties"
 msgid "Customs Import Duties"
 msgstr "Customs Import Duties"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:68
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:68
 msgid "Data updated March 20, 2025"
 msgstr "Data updated March 20, 2025"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:69
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:70
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:76
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:74
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:76
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:63
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:81
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:64
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:71
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:68
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:66
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:64
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:66
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:69
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:70
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:76
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:74
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:76
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:63
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:81
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:64
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:71
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:68
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:66
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:64
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:66
 msgid "Data updated March 21, 2025"
 msgstr "Data updated March 21, 2025"
 
@@ -807,7 +831,7 @@ msgid "Defence Team"
 msgstr "Defence Team"
 
 #: src/app/[lang]/(main)/budget/page.tsx:215
-#: src/app/[lang]/(main)/federal/budget/page.tsx:252
+#: src/app/[lang]/(main)/federal/budget/page.tsx:254
 msgid "Deficit"
 msgstr "Deficit"
 
@@ -816,19 +840,19 @@ msgstr "Deficit"
 msgid "Department"
 msgstr "Department"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/MiniSankey.tsx:16
 msgid "Department of Finance"
 msgstr "Department of Finance"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:35
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:35
 msgid "Department of Finance | Canada Spends"
 msgstr "Department of Finance | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:188
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:188
 msgid "Department of Finance, Spending by Entity, FY 2024 (in millions)"
 msgstr "Department of Finance, Spending by Entity, FY 2024 (in millions)"
 
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:16
 msgid "Department of National Defence"
 msgstr "Department of National Defence"
 
@@ -841,12 +865,12 @@ msgstr "Department Spending"
 msgid "Department Spending Reductions"
 msgstr "Department Spending Reductions"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:230
+#: src/app/[lang]/(main)/federal/spending/page.tsx:231
 #: src/app/[lang]/(main)/spending/page.tsx:221
 msgid "Departments + Agencies"
 msgstr "Departments + Agencies"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:125
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:125
 msgid "Despite these increases, significant challenges remain in areas such as housing, healthcare access, and infrastructure in remote Indigenous communities."
 msgstr "Despite these increases, significant challenges remain in areas such as housing, healthcare access, and infrastructure in remote Indigenous communities."
 
@@ -854,7 +878,7 @@ msgstr "Despite these increases, significant challenges remain in areas such as 
 msgid "Development, Peace + Security Programming"
 msgstr "Development, Peace + Security Programming"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:177
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:177
 msgid "Development, Peace and Security Programming: $5.37B"
 msgstr "Development, Peace and Security Programming: $5.37B"
 
@@ -862,7 +886,7 @@ msgstr "Development, Peace and Security Programming: $5.37B"
 msgid "Direct program expenses"
 msgstr "Direct program expenses"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:160
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:160
 msgid "Direct spending refers to money allocated to government programs, employee salaries, and administrative expenses. Indirect spending includes federal transfers to individuals and provinces."
 msgstr "Direct spending refers to money allocated to government programs, employee salaries, and administrative expenses. Indirect spending includes federal transfers to individuals and provinces."
 
@@ -874,13 +898,17 @@ msgstr "Disaster Relief"
 msgid "Discipline"
 msgstr "Discipline"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:134
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:134
 msgid "DND's spending grew less than overall spending, meaning its share of the federal budget decreased. In 2024, the department accounted for 6.7% of all federal spending, 0.6 percentage points lower than in 1995."
 msgstr "DND's spending grew less than overall spending, meaning its share of the federal budget decreased. In 2024, the department accounted for 6.7% of all federal spending, 0.6 percentage points lower than in 1995."
 
 #: src/app/[lang]/(main)/whistleblowers/page.tsx:181
 msgid "Do not discuss your submission with anyone or search for related topics on work devices."
 msgstr "Do not discuss your submission with anyone or search for related topics on work devices."
+
+#: src/app/[lang]/(main)/login/login-form.tsx:203
+msgid "Don't have an account?"
+msgstr "Don't have an account?"
 
 #: src/app/[lang]/(main)/whistleblowers/page.tsx:104
 msgid "Download and install the <0>Tor Browser</0> from the official Tor Project website."
@@ -926,6 +954,10 @@ msgstr "Effective Rate"
 msgid "Effective tax rate"
 msgstr "Effective tax rate"
 
+#: src/app/[lang]/(main)/login/login-form.tsx:151
+msgid "Email"
+msgstr "Email"
+
 #: src/app/[lang]/(main)/contact/page.tsx:44
 msgid "Email us at <0>hi@buildcanada.com</0> or connect with us on X <1>@canada_spends</1> and we'll get back to you as soon as we can."
 msgstr "Email us at <0>hi@buildcanada.com</0> or connect with us on X <1>@canada_spends</1> and we'll get back to you as soon as we can."
@@ -942,7 +974,7 @@ msgstr "Employment + Training"
 msgid "Employment and Social Development Canada"
 msgstr "Employment and Social Development Canada"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:36
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:36
 msgid "Employment and Social Development Canada | Canada Spends"
 msgstr "Employment and Social Development Canada | Canada Spends"
 
@@ -977,46 +1009,46 @@ msgstr "Environment and Climate Change"
 msgid "Equalization Payments to Provinces"
 msgstr "Equalization Payments to Provinces"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:16
 msgid "ESDC"
 msgstr "ESDC"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:95
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:95
 msgid "ESDC accounted for 18.4% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024."
 msgstr "ESDC accounted for 18.4% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:88
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:88
 msgid "ESDC spent $94.48 billion in fiscal year (FY) 2024. This was 18.4% of the $513.9 billion in overall federal spending, making it one of the highest-spending federal departments."
 msgstr "ESDC spent $94.48 billion in fiscal year (FY) 2024. This was 18.4% of the $513.9 billion in overall federal spending, making it one of the highest-spending federal departments."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:197
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:197
 msgid "ESDC, Spending by Entity, FY 2024"
 msgstr "ESDC, Spending by Entity, FY 2024"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:179
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:179
 msgid "ESDC's share of federal spending in FY 2024"
 msgstr "ESDC's share of federal spending in FY 2024"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:141
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:141
 msgid "ESDC's share of federal spending in FY 2024 was lower than FY 1995"
 msgstr "ESDC's share of federal spending in FY 2024 was lower than FY 1995"
 
 #: src/app/[lang]/(main)/budget/page.tsx:217
-#: src/app/[lang]/(main)/federal/budget/page.tsx:254
+#: src/app/[lang]/(main)/federal/budget/page.tsx:256
 msgid "Est. projected budget deficit"
 msgstr "Est. projected budget deficit"
 
 #: src/app/[lang]/(main)/budget/page.tsx:177
-#: src/app/[lang]/(main)/federal/budget/page.tsx:214
+#: src/app/[lang]/(main)/federal/budget/page.tsx:216
 msgid "Est. projected government budget"
 msgstr "Est. projected government budget"
 
 #: src/app/[lang]/(main)/budget/page.tsx:186
-#: src/app/[lang]/(main)/federal/budget/page.tsx:223
+#: src/app/[lang]/(main)/federal/budget/page.tsx:225
 msgid "Est. projected government revenue"
 msgstr "Est. projected government revenue"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:57
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:57
 msgid "Established in 2005, ESDC is a federal department responsible for supporting Canadians through social programs and workforce development. It administers key programs such as Employment Insurance (EI), the Canada Pension Plan (CPP), Old Age Security (OAS), and skills training initiatives. ESDC also oversees Service Canada, which delivers government services directly to the public."
 msgstr "Established in 2005, ESDC is a federal department responsible for supporting Canadians through social programs and workforce development. It administers key programs such as Employment Insurance (EI), the Canada Pension Plan (CPP), Old Age Security (OAS), and skills training initiatives. ESDC also oversees Service Canada, which delivers government services directly to the public."
 
@@ -1076,12 +1108,12 @@ msgstr "Expenses"
 msgid "Explore Canada's federal budget with interactive visualizations and detailed analysis of government revenue and expenditures."
 msgstr "Explore Canada's federal budget with interactive visualizations and detailed analysis of government revenue and expenditures."
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:250
+#: src/app/[lang]/(main)/federal/spending/page.tsx:251
 #: src/app/[lang]/(main)/spending/page.tsx:241
 msgid "Explore federal employee salary distribution by year and demographic group"
 msgstr "Explore federal employee salary distribution by year and demographic group"
 
-#: src/components/HeroButtons.tsx:34
+#: src/components/HeroButtons.tsx:37
 msgid "Explore Federal Spending"
 msgstr "Explore Federal Spending"
 
@@ -1097,7 +1129,7 @@ msgstr "Explore financial data from First Nations across Canada. Data is extract
 msgid "Explore financial data from First Nations across Canada. View statements of operations, financial positions, and remuneration from annual reports published under the First Nations Financial Transparency Act (FNFTA)."
 msgstr "Explore financial data from First Nations across Canada. View statements of operations, financial positions, and remuneration from annual reports published under the First Nations Financial Transparency Act (FNFTA)."
 
-#: src/components/HeroButtons.tsx:107
+#: src/components/HeroButtons.tsx:110
 msgid "Explore First Nations Spending"
 msgstr "Explore First Nations Spending"
 
@@ -1109,32 +1141,32 @@ msgstr "Explore how the Canadian federal government spends your tax dollars acro
 msgid "Explore in-depth articles about Canadian government spending, budget analysis, and public finance. Stay informed about how your tax dollars are used through Canada Spends."
 msgstr "Explore in-depth articles about Canadian government spending, budget analysis, and public finance. Stay informed about how your tax dollars are used through Canada Spends."
 
-#: src/components/HeroButtons.tsx:70
+#: src/components/HeroButtons.tsx:73
 msgid "Explore Municipal Spending"
 msgstr "Explore Municipal Spending"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:239
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:230
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:258
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:277
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:199
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:210
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:194
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:227
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:194
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:241
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:191
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:201
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:199
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:199
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:239
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:230
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:258
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:277
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:199
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:210
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:194
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:227
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:194
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:241
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:191
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:201
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:199
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:199
 msgid "Explore other Federal Departments"
 msgstr "Explore other Federal Departments"
 
-#: src/components/HeroButtons.tsx:43
+#: src/components/HeroButtons.tsx:46
 msgid "Explore Provincial Spending"
 msgstr "Explore Provincial Spending"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:134
+#: src/app/[lang]/(main)/federal/spending/page.tsx:135
 #: src/app/[lang]/(main)/spending/page.tsx:125
 msgid "Explore revenue and spending categories or filter by agency for deeper insights."
 msgstr "Explore revenue and spending categories or filter by agency for deeper insights."
@@ -1143,16 +1175,16 @@ msgstr "Explore revenue and spending categories or filter by agency for deeper i
 msgid "External ID"
 msgstr "External ID"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:67
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:67
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:67
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:67
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:67
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:67
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:67
 msgid "External Revenues"
 msgstr "External Revenues"
 
@@ -1175,48 +1207,48 @@ msgstr "Federal"
 msgid "Federal Budget 2025 | Canada Spends"
 msgstr "Federal Budget 2025 | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:178
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:178
 msgid "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, Department of Finance entities with the highest expenditures were the Office of the Superintendent of Financial Institutions, Office of the Auditor General, and the Financial Transactions and Reports Analysis Centre of Canada."
 msgstr "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, Department of Finance entities with the highest expenditures were the Office of the Superintendent of Financial Institutions, Office of the Auditor General, and the Financial Transactions and Reports Analysis Centre of Canada."
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:158
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:158
 msgid "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, HICC entities with the highest expenditures were Office of Infrastructure Canada, the Canada Mortgage and Housing Corporation and the Windsor-Detroit Bridge Authority."
 msgstr "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, HICC entities with the highest expenditures were Office of Infrastructure Canada, the Canada Mortgage and Housing Corporation and the Windsor-Detroit Bridge Authority."
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:151
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:151
 msgid "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, IRCC reported total expenditures of $6.2 billion, broken out as follows:"
 msgstr "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, IRCC reported total expenditures of $6.2 billion, broken out as follows:"
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:153
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:153
 msgid "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, ISED's budget was split across the following entities:"
 msgstr "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, ISED's budget was split across the following entities:"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:159
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:159
 msgid "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, PSPC's budget was split across the following entities:"
 msgstr "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, PSPC's budget was split across the following entities:"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:152
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:152
 msgid "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, Transport Canada reported total expenditures of $5.1 billion across the following entities:"
 msgstr "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, Transport Canada reported total expenditures of $5.1 billion across the following entities:"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:152
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:152
 msgid "Federal departments often contain other entities including offices, crown corporations and agencies. The Health Canada entities with the biggest expenditures in FY 2024 were"
 msgstr "Federal departments often contain other entities including offices, crown corporations and agencies. The Health Canada entities with the biggest expenditures in FY 2024 were"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:208
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:208
 msgid "Federal departments often contain other entities. In FY 2024, Global Affairs Canada's entities with the highest expenditures were:"
 msgstr "Federal departments often contain other entities. In FY 2024, Global Affairs Canada's entities with the highest expenditures were:"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:194
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:194
 msgid "Federal departments often include additional agencies, commands, and operational divisions. In FY 2024, the largest spending entities within DND were the Canadian Army, the Royal Canadian Navy, and the Royal Canadian Air Force, accounting for the bulk of military expenditures."
 msgstr "Federal departments often include additional agencies, commands, and operational divisions. In FY 2024, the largest spending entities within DND were the Canadian Army, the Royal Canadian Navy, and the Royal Canadian Air Force, accounting for the bulk of military expenditures."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:190
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:190
 msgid "Federal departments often include multiple agencies and service delivery arms. In FY 2024, ESDC's highest-expenditure entities included:"
 msgstr "Federal departments often include multiple agencies and service delivery arms. In FY 2024, ESDC's highest-expenditure entities included:"
 
 #: src/app/[lang]/(main)/budget/page.tsx:156
-#: src/app/[lang]/(main)/federal/budget/page.tsx:183
+#: src/app/[lang]/(main)/federal/budget/page.tsx:185
 msgid "Federal Fall 2025 Government Budget"
 msgstr "Federal Fall 2025 Government Budget"
 
@@ -1224,78 +1256,78 @@ msgstr "Federal Fall 2025 Government Budget"
 msgid "Federal Government Spending | Canada Spends"
 msgstr "Federal Government Spending | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:170
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:197
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:173
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:170
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:197
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:173
 msgid "Federal government spending in FY 2024"
 msgstr "Federal government spending in FY 2024"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:140
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:142
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:148
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:141
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:144
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:140
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:142
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:148
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:141
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:144
 msgid "Federal government spending isolated to FY 2024"
 msgstr "Federal government spending isolated to FY 2024"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:232
+#: src/app/[lang]/(main)/federal/spending/page.tsx:233
 #: src/app/[lang]/(main)/spending/page.tsx:223
 msgid "Federal organizations"
 msgstr "Federal organizations"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:120
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:120
 msgid "Federal spending may shift over time due to changing global circumstances, diplomatic priorities, and Canada's economic relationships. Since 1995, overall federal spending has increased by 74.9%, while Global Affairs Canada's budget has grown by 166.5%, reflecting an expansion in international engagement."
 msgstr "Federal spending may shift over time due to changing global circumstances, diplomatic priorities, and Canada's economic relationships. Since 1995, overall federal spending has increased by 74.9%, while Global Affairs Canada's budget has grown by 166.5%, reflecting an expansion in international engagement."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:113
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:113
 msgid "Federal spending may shift over time due to economic fluctuations, changes in tax policy, and the expansion of benefit programs. Since 1995, overall federal spending has risen 74.9%, while Canada Revenue Agency spending has increased 302%"
 msgstr "Federal spending may shift over time due to economic fluctuations, changes in tax policy, and the expansion of benefit programs. Since 1995, overall federal spending has risen 74.9%, while Canada Revenue Agency spending has increased 302%"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:126
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:126
 msgid "Federal spending may shift over time due to geopolitical tensions, defence modernization needs, and emerging threats such as cyber warfare. Since 1995, overall federal spending has risen 74.9%, while Department of National Defence spending has increased 59.9%."
 msgstr "Federal spending may shift over time due to geopolitical tensions, defence modernization needs, and emerging threats such as cyber warfare. Since 1995, overall federal spending has risen 74.9%, while Department of National Defence spending has increased 59.9%."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:105
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:105
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging challenges. Since 2005, when ESDC was first established, overall federal spending has risen 62.9%, while ESDC spending has increased 1,485%."
 msgstr "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging challenges. Since 2005, when ESDC was first established, overall federal spending has risen 62.9%, while ESDC spending has increased 1,485%."
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:115
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:115
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging challenges. Since FY 1995, overall federal spending has risen 74.9%, while Health Canada spending has decreased 19.9% when adjusted for inflation."
 msgstr "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging challenges. Since FY 1995, overall federal spending has risen 74.9%, while Health Canada spending has decreased 19.9% when adjusted for inflation."
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:117
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:117
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address."
 msgstr "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:112
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:112
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 74.9%, while Department of Finance spending has increased 41.4%."
 msgstr "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 74.9%, while Department of Finance spending has increased 41.4%."
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:101
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:101
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 74.9%, while IRCC spending has increased 428% (adjusted for inflation)."
 msgstr "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 74.9%, while IRCC spending has increased 428% (adjusted for inflation)."
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:103
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:103
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 74.9%, while ISED spending has increased 90.3%."
 msgstr "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 74.9%, while ISED spending has increased 90.3%."
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:104
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:104
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 74.9%, while PSPC spending has increased by 7.1% when adjusted for inflation."
 msgstr "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 74.9%, while PSPC spending has increased by 7.1% when adjusted for inflation."
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:104
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:104
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 74.9%, while Transport spending has remained relatively flat."
 msgstr "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 74.9%, while Transport spending has remained relatively flat."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:105
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:105
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 77%, while VAC spending has increased 51%."
 msgstr "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 77%, while VAC spending has increased 51%."
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:114
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:114
 msgid "Federal spending on Indigenous priorities may fluctuate over time due to population growth, policy shifts, and emerging challenges such as climate change and infrastructure deficits. Since 1995, total federal spending has risen by 74.9%, while spending on Indigenous priorities has increased by 592%, reflecting expanded program commitments and new governance agreements and claim settlements."
 msgstr "Federal spending on Indigenous priorities may fluctuate over time due to population growth, policy shifts, and emerging challenges such as climate change and infrastructure deficits. Since 1995, total federal spending has risen by 74.9%, while spending on Indigenous priorities has increased by 592%, reflecting expanded program commitments and new governance agreements and claim settlements."
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:113
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:113
 msgid "Federal spending on public safety fluctuates based on evolving security threats, emergency events, and changes in government policy. Since 2005 shortly after it was established, Public Safety Canada's expenditures have increased by 69.6%, reflecting heightened investments in counterterrorism, cyber defence, and disaster response capabilities. The department's share of the federal budget has remained relatively flat from 2.6% in 2005 to 2.7% in 2024."
 msgstr "Federal spending on public safety fluctuates based on evolving security threats, emergency events, and changes in government policy. Since 2005 shortly after it was established, Public Safety Canada's expenditures have increased by 69.6%, reflecting heightened investments in counterterrorism, cyber defence, and disaster response capabilities. The department's share of the federal budget has remained relatively flat from 2.6% in 2005 to 2.7% in 2024."
 
@@ -1398,7 +1430,7 @@ msgstr "First Nations Remuneration Overview"
 msgid "First Nations Remuneration Overview | Canada Spends"
 msgstr "First Nations Remuneration Overview | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/MiniSankey.tsx:27
 msgid "Fiscal arrangements"
 msgstr "Fiscal arrangements"
 
@@ -1420,7 +1452,7 @@ msgstr "Fisheries + Aquatic Ecosystems"
 msgid "Food Safety"
 msgstr "Food Safety"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:130
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:130
 msgid "For example, during the COVID-19 pandemic, federal support programs led to a temporary surge in spending. ESDC expenditures increased from $63.3 billion in 2019 to $169.2 billion in 2021 before stabilizing in recent years."
 msgstr "For example, during the COVID-19 pandemic, federal support programs led to a temporary surge in spending. ESDC expenditures increased from $63.3 billion in 2019 to $169.2 billion in 2021 before stabilizing in recent years."
 
@@ -1452,16 +1484,16 @@ msgstr "Future Force Design"
 msgid "FY"
 msgstr "FY"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:131
+#: src/app/[lang]/(main)/federal/spending/page.tsx:132
 #: src/app/[lang]/(main)/spending/page.tsx:122
 msgid "FY 2024 Government Revenue and Spending"
 msgstr "FY 2024 Government Revenue and Spending"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:103
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:103
 msgid "GAC accounted for 3.7% of all federal spending in FY 2024."
 msgstr "GAC accounted for 3.7% of all federal spending in FY 2024."
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:165
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:165
 msgid "GAC's expenditures are divided across five primary categories:"
 msgstr "GAC's expenditures are divided across five primary categories:"
 
@@ -1469,7 +1501,7 @@ msgstr "GAC's expenditures are divided across five primary categories:"
 msgid "Gender Equality"
 msgstr "Gender Equality"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:123
+#: src/app/[lang]/(main)/federal/spending/page.tsx:124
 #: src/app/[lang]/(main)/spending/page.tsx:114
 msgid "Get data-driven insights into how governmental revenue and spending affect Canadian lives and programs."
 msgstr "Get data-driven insights into how governmental revenue and spending affect Canadian lives and programs."
@@ -1494,28 +1526,28 @@ msgstr "Get The Facts About Government Spending"
 msgid "Get weekly recaps of current events and updates from our team."
 msgstr "Get weekly recaps of current events and updates from our team."
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:32
 msgid "Global Affairs Canada"
 msgstr "Global Affairs Canada"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:55
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:55
 msgid "Global Affairs Canada (GAC) is the federal department responsible for managing Canada's diplomatic relations, international trade, and development assistance. Established in 1909 as the Department of External Affairs, GAC has evolved to oversee Canada's engagement in global affairs, promoting national interests abroad and ensuring the protection of Canadian citizens overseas. The department negotiates international agreements, administers trade policies, and provides humanitarian aid. Additionally, it supports Canadian businesses in expanding internationally and strengthens diplomatic ties through multilateral organizations like the United Nations, the World Trade Organization (WTO), and NATO. GAC also plays a critical role in crisis response, assisting Canadians abroad during emergencies, and fostering global security and stability."
 msgstr "Global Affairs Canada (GAC) is the federal department responsible for managing Canada's diplomatic relations, international trade, and development assistance. Established in 1909 as the Department of External Affairs, GAC has evolved to oversee Canada's engagement in global affairs, promoting national interests abroad and ensuring the protection of Canadian citizens overseas. The department negotiates international agreements, administers trade policies, and provides humanitarian aid. Additionally, it supports Canadian businesses in expanding internationally and strengthens diplomatic ties through multilateral organizations like the United Nations, the World Trade Organization (WTO), and NATO. GAC also plays a critical role in crisis response, assisting Canadians abroad during emergencies, and fostering global security and stability."
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:36
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:36
 msgid "Global Affairs Canada | Canada Spends"
 msgstr "Global Affairs Canada | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:227
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:227
 msgid "Global Affairs Canada is led by two ministers appointed by the Prime Minister and formally sworn into office at Rideau Hall. The department's leadership includes:"
 msgstr "Global Affairs Canada is led by two ministers appointed by the Prime Minister and formally sworn into office at Rideau Hall. The department's leadership includes:"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:94
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:94
 msgid "Global Affairs Canada spent $19.2 billion in fiscal year (FY) 2024, representing 3.7% of the $513.9 billion in overall federal spending. This placed GAC among the mid-sized federal departments in terms of total expenditures."
 msgstr "Global Affairs Canada spent $19.2 billion in fiscal year (FY) 2024, representing 3.7% of the $513.9 billion in overall federal spending. This placed GAC among the mid-sized federal departments in terms of total expenditures."
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:216
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:216
 msgid "Global Affairs Canada, Spending by Entity, FY 2024"
 msgstr "Global Affairs Canada, Spending by Entity, FY 2024"
 
@@ -1532,13 +1564,13 @@ msgstr "Goods and Services Tax"
 msgid "Gottfriedson Band Class Settlement"
 msgstr "Gottfriedson Band Class Settlement"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:269
+#: src/app/[lang]/(main)/federal/spending/page.tsx:270
 #: src/app/[lang]/(main)/spending/page.tsx:260
 msgid "Government Departments explained"
 msgstr "Government Departments explained"
 
 #: src/app/[lang]/(main)/budget/page.tsx:261
-#: src/app/[lang]/(main)/federal/budget/page.tsx:298
+#: src/app/[lang]/(main)/federal/budget/page.tsx:300
 msgid "Government Departments Explained"
 msgstr "Government Departments Explained"
 
@@ -1550,7 +1582,7 @@ msgstr "Government IT Operations"
 msgid "Government organizations"
 msgstr "Government organizations"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:120
+#: src/app/[lang]/(main)/federal/spending/page.tsx:121
 #: src/app/[lang]/(main)/spending/page.tsx:111
 msgid "Government Spending"
 msgstr "Government Spending"
@@ -1568,7 +1600,7 @@ msgstr "Government spending shouldn’t be a black box. Every year, the federal 
 msgid "Government spending shouldn't be a black box. We turn complex data into clear, non-partisan insights so every Canadian knows where their money goes."
 msgstr "Government spending shouldn't be a black box. We turn complex data into clear, non-partisan insights so every Canadian knows where their money goes."
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:165
+#: src/app/[lang]/(main)/federal/spending/page.tsx:166
 #: src/app/[lang]/(main)/spending/page.tsx:156
 msgid "Government Workforce"
 msgstr "Government Workforce"
@@ -1593,7 +1625,7 @@ msgstr "Group"
 msgid "Have questions or feedback? Email us at hi@canadaspends.com or connect with us on X @canada_spends - we'd love to hear from you!"
 msgstr "Have questions or feedback? Email us at hi@canadaspends.com or connect with us on X @canada_spends - we'd love to hear from you!"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:169
+#: src/app/[lang]/(main)/federal/spending/page.tsx:170
 #: src/app/[lang]/(main)/spending/page.tsx:160
 msgid "Headcount"
 msgstr "Headcount"
@@ -1606,28 +1638,28 @@ msgstr "Health"
 msgid "Health agreements with provinces and territories"
 msgstr "Health agreements with provinces and territories"
 
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:56
 msgid "Health Canada"
 msgstr "Health Canada"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:33
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:33
 msgid "Health Canada | Canada Spends"
 msgstr "Health Canada | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:101
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:101
 msgid "Health Canada accounted for 2.7% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 msgstr "Health Canada accounted for 2.7% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:170
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:170
 msgid "Health Canada is led by the <0>Minister of Health</0>, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 msgstr "Health Canada is led by the <0>Minister of Health</0>, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:51
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:51
 msgid "Health Canada is the federal department responsible for protecting and improving the health of Canadians. It develops health policies, regulates pharmaceuticals and medical devices, enforces food safety standards, and funds public health programs. The department works with provinces and territories to support the healthcare system while ensuring safety standards for drugs, consumer products, and nutrition guidelines."
 msgstr "Health Canada is the federal department responsible for protecting and improving the health of Canadians. It develops health policies, regulates pharmaceuticals and medical devices, enforces food safety standards, and funds public health programs. The department works with provinces and territories to support the healthcare system while ensuring safety standards for drugs, consumer products, and nutrition guidelines."
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:92
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:92
 msgid "Health Canada spent $13.7 billion in fiscal year (FY) 2024. This was 2.7% of the $513.9 billion in overall federal spending. The department ranked tenth among federal departments in total spending."
 msgstr "Health Canada spent $13.7 billion in fiscal year (FY) 2024. This was 2.7% of the $513.9 billion in overall federal spending. The department ranked tenth among federal departments in total spending."
 
@@ -1644,23 +1676,23 @@ msgstr "Health Research"
 msgid "Health Transfer to Provinces"
 msgstr "Health Transfer to Provinces"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:180
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:180
 msgid "Help for Canadians Abroad: $85.98M"
 msgstr "Help for Canadians Abroad: $85.98M"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:16
 msgid "HICC"
 msgstr "HICC"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:102
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:102
 msgid "HICC accounted for 2.8% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024."
 msgstr "HICC accounted for 2.8% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024."
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:62
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:62
 msgid "HICC administers the National Housing Strategy, which funds the construction, repair, and preservation of affordable housing. It also oversees the Canada Mortgage and Housing Corporation (CMHC), which provides mortgage insurance and financing programs. The department supports public transit, clean energy, and community infrastructure through programs like the Canada Infrastructure Bank (CIB)."
 msgstr "HICC administers the National Housing Strategy, which funds the construction, repair, and preservation of affordable housing. It also oversees the Canada Mortgage and Housing Corporation (CMHC), which provides mortgage insurance and financing programs. The department supports public transit, clean energy, and community infrastructure through programs like the Canada Infrastructure Bank (CIB)."
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:94
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:94
 msgid "HICC spent $14.5 billion in fiscal year (FY) 2024. This was 2.8% of the $513.9 billion in overall federal spending. The department ranked eighth among federal departments in total spending."
 msgstr "HICC spent $14.5 billion in fiscal year (FY) 2024. This was 2.8% of the $513.9 billion in overall federal spending. The department ranked eighth among federal departments in total spending."
 
@@ -1681,15 +1713,15 @@ msgstr "Housing Assistance"
 msgid "Housing, Infrastructure and Communities Canada"
 msgstr "Housing, Infrastructure and Communities Canada"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:180
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:180
 msgid "Housing, Infrastructure and Communities Canada (HICC) is led by the <0>Minister of Housing, Infrastructure and Communities</0>, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 msgstr "Housing, Infrastructure and Communities Canada (HICC) is led by the <0>Minister of Housing, Infrastructure and Communities</0>, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:52
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:52
 msgid "Housing, Infrastructure and Communities Canada (HICC) is responsible for federal policies and programs that support public infrastructure, affordable housing, and community development. It works with provinces, territories, and municipalities to fund major infrastructure projects and improve housing affordability across Canada."
 msgstr "Housing, Infrastructure and Communities Canada (HICC) is responsible for federal policies and programs that support public infrastructure, affordable housing, and community development. It works with provinces, territories, and municipalities to fund major infrastructure projects and improve housing affordability across Canada."
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:34
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:34
 msgid "Housing, Infrastructure and Communities Canada | Canada Spends"
 msgstr "Housing, Infrastructure and Communities Canada | Canada Spends"
 
@@ -1701,59 +1733,59 @@ msgstr "How can I show my support?"
 msgid "How can I stay up to date on your work?"
 msgstr "How can I stay up to date on your work?"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:170
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:170
 msgid "How did ESDC spend its budget in 2024?"
 msgstr "How did ESDC spend its budget in 2024?"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:160
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:160
 msgid "How did Global Affairs Canada spend its budget in 2024?"
 msgstr "How did Global Affairs Canada spend its budget in 2024?"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:155
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:155
 msgid "How did HICC spend its budget in FY24?"
 msgstr "How did HICC spend its budget in FY24?"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:137
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:137
 msgid "How did IRCC spend its budget in FY24?"
 msgstr "How did IRCC spend its budget in FY24?"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:170
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:170
 msgid "How did ISC and CIRNAC spend their budgets in 2024?"
 msgstr "How did ISC and CIRNAC spend their budgets in 2024?"
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:139
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:139
 msgid "How did ISED spend its budget in FY 24?"
 msgstr "How did ISED spend its budget in FY 24?"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:145
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:145
 msgid "How did PSPC spend its budget in FY24?"
 msgstr "How did PSPC spend its budget in FY24?"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:141
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:141
 msgid "How did Public Safety Canada spend its budget in 2024?"
 msgstr "How did Public Safety Canada spend its budget in 2024?"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:182
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:182
 msgid "How did the Canada Revenue Agency spend its budget in 2024?"
 msgstr "How did the Canada Revenue Agency spend its budget in 2024?"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:165
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:165
 msgid "How did the Department of Finance spend its budget in 2024?"
 msgstr "How did the Department of Finance spend its budget in 2024?"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:168
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:168
 msgid "How did the Department of National Defence spend its budget in 2024?"
 msgstr "How did the Department of National Defence spend its budget in 2024?"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:138
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:138
 msgid "How did Transport Canada spend its budget in FY24?"
 msgstr "How did Transport Canada spend its budget in FY24?"
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:141
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:141
 msgid "How did VAC spend its budget in FY24?"
 msgstr "How did VAC spend its budget in FY24?"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:110
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:110
 msgid "How has Public Safety Canada's spending changed?"
 msgstr "How has Public Safety Canada's spending changed?"
 
@@ -1765,16 +1797,16 @@ msgstr "How to Submit a Tip"
 msgid "Immigration + Border Security"
 msgstr "Immigration + Border Security"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:74
 msgid "Immigration, Refugees and Citizenship"
 msgstr "Immigration, Refugees and Citizenship"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:170
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:170
 msgid "Immigration, Refugees and Citizenship Canada (IRCC) is led by the Minister of Immigration, Refugees and Citizenship, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 msgstr "Immigration, Refugees and Citizenship Canada (IRCC) is led by the Minister of Immigration, Refugees and Citizenship, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:32
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:32
 msgid "Immigration, Refugees and Citizenship Canada | Canada Spends"
 msgstr "Immigration, Refugees and Citizenship Canada | Canada Spends"
 
@@ -1797,66 +1829,66 @@ msgstr "In {0}, you pay <0>{1}</0> in total tax ({2}% effective rate)"
 msgid "In Financial Year {0},"
 msgstr "In Financial Year {0},"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:99
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:99
 msgid "In fiscal year (FY) 2024, ISC and CIRNAC collectively spent <0>$63 billion</0>, accounting for <1>12.3% of the total federal budget</1>. The departments play a critical role in addressing socio-economic disparities, facilitating self-governance agreements, and improving service delivery for Indigenous communities across Canada."
 msgstr "In fiscal year (FY) 2024, ISC and CIRNAC collectively spent <0>$63 billion</0>, accounting for <1>12.3% of the total federal budget</1>. The departments play a critical role in addressing socio-economic disparities, facilitating self-governance agreements, and improving service delivery for Indigenous communities across Canada."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:73
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:78
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:72
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:77
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:74
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:79
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:80
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:85
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:78
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:83
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:80
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:85
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:67
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:72
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:85
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:90
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:68
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:73
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:75
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:82
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:72
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:77
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:70
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:75
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:68
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:73
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:70
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:75
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:73
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:78
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:72
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:77
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:74
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:79
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:80
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:85
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:78
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:83
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:80
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:85
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:67
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:72
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:85
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:90
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:68
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:73
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:75
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:82
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:72
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:77
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:70
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:75
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:68
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:73
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:70
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:75
 msgid "In FY 2024,"
 msgstr "In FY 2024,"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:173
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:173
 msgid "In FY 2024, 55.2% of CRA net spending was allocated to salaries, benefits, and pensions."
 msgstr "In FY 2024, 55.2% of CRA net spending was allocated to salaries, benefits, and pensions."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:173
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:173
 msgid "In FY 2024, ESDC transferred 63% of its total spending to individuals and provinces."
 msgstr "In FY 2024, ESDC transferred 63% of its total spending to individuals and provinces."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:155
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:155
 msgid "In FY 2024, Finance Canada transferred 66.2% of its total spending to provinces and territories. The chart below outlines all departmental spending in 2024."
 msgstr "In FY 2024, Finance Canada transferred 66.2% of its total spending to provinces and territories. The chart below outlines all departmental spending in 2024."
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:162
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:162
 msgid "In FY 2024, ISC and CIRNAC transferred 93.1% of total spending directly to indigenous communities."
 msgstr "In FY 2024, ISC and CIRNAC transferred 93.1% of total spending directly to indigenous communities."
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:146
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:146
 msgid "In FY 2024, Public Safety's budget was allocated across several key areas, including:"
 msgstr "In FY 2024, Public Safety's budget was allocated across several key areas, including:"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:112
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:112
 msgid "In FY 2024, Transport Canada accounted for 1% of all federal spending, 0.74% percentage points lower than in 1995."
 msgstr "In FY 2024, Transport Canada accounted for 1% of all federal spending, 0.74% percentage points lower than in 1995."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:155
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:155
 msgid "In FY 2024, VAC reported total expenditures of $6.07 billion across two entities:"
 msgstr "In FY 2024, VAC reported total expenditures of $6.07 billion across two entities:"
 
@@ -1876,11 +1908,11 @@ msgstr "Indeterminate"
 msgid "Indigenous Priorities"
 msgstr "Indigenous Priorities"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:35
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:35
 msgid "Indigenous Services and Northern Affairs Canada | Canada Spends"
 msgstr "Indigenous Services and Northern Affairs Canada | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:55
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:55
 msgid "Indigenous Services Canada (ISC) and Crown-Indigenous Relations and Northern Affairs Canada (CIRNAC) are two distinct federal departments tasked with advancing Indigenous priorities in Canada. Established in 2017 following the dissolution of Indigenous and Northern Affairs Canada (INAC), these departments manage different aspects of Indigenous policy, service delivery, and governance."
 msgstr "Indigenous Services Canada (ISC) and Crown-Indigenous Relations and Northern Affairs Canada (CIRNAC) are two distinct federal departments tasked with advancing Indigenous priorities in Canada. Established in 2017 following the dissolution of Indigenous and Northern Affairs Canada (INAC), these departments manage different aspects of Indigenous policy, service delivery, and governance."
 
@@ -1900,19 +1932,19 @@ msgstr "Individual Income Tax"
 msgid "Individual Income Taxes"
 msgstr "Individual Income Taxes"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:27
 msgid "Information"
 msgstr "Information"
 
@@ -1924,16 +1956,16 @@ msgstr "Infrastructure Investments"
 msgid "Innovation + Research"
 msgstr "Innovation + Research"
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:62
 msgid "Innovation, Science and Industry"
 msgstr "Innovation, Science and Industry"
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:171
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:171
 msgid "Innovation, Science and Industry Canada (ISED) is led by the Minister of Innovation, Science and Industry, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 msgstr "Innovation, Science and Industry Canada (ISED) is led by the Minister of Innovation, Science and Industry, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:32
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:32
 msgid "Innovation, Science and Industry Canada | Canada Spends"
 msgstr "Innovation, Science and Industry Canada | Canada Spends"
 
@@ -1958,21 +1990,21 @@ msgstr "Interest on Debt"
 msgid "Interim Housing Assistance"
 msgstr "Interim Housing Assistance"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:71
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:67
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:71
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:67
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:71
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:71
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:71
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:71
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:71
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:71
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:71
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:71
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:71
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:71
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:71
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:71
 msgid "Internal Revenues"
 msgstr "Internal Revenues"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:171
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:171
 msgid "International Advocacy and Diplomacy: $1B"
 msgstr "International Advocacy and Diplomacy: $1B"
 
@@ -1996,11 +2028,11 @@ msgstr "Investment, Growth and Commercialization"
 msgid "Involved First Nations"
 msgstr "Involved First Nations"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:89
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:89
 msgid "IRCC accounted for 1.2% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 msgstr "IRCC accounted for 1.2% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:81
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:81
 msgid "IRCC spent $6.3 billion in fiscal year (FY) 2024. This was 1.2% of the $513.9 billion in overall federal spending. The department ranked thirteenth among federal departments in total spending."
 msgstr "IRCC spent $6.3 billion in fiscal year (FY) 2024. This was 1.2% of the $513.9 billion in overall federal spending. The department ranked thirteenth among federal departments in total spending."
 
@@ -2008,23 +2040,23 @@ msgstr "IRCC spent $6.3 billion in fiscal year (FY) 2024. This was 1.2% of the $
 msgid "Is this a lobby group?"
 msgstr "Is this a lobby group?"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:182
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:182
 msgid "ISC + CIRNAC, Spending by Entity, FY 2024"
 msgstr "ISC + CIRNAC, Spending by Entity, FY 2024"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:135
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:135
 msgid "ISC + CIRNAC's share of federal spending in FY 2024 was 592% higher than in FY 1995"
 msgstr "ISC + CIRNAC's share of federal spending in FY 2024 was 592% higher than in FY 1995"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:16
 msgid "ISC and CIRNAC"
 msgstr "ISC and CIRNAC"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:65
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:65
 msgid "ISC is responsible for providing essential services to First Nations, Inuit, and Métis communities, including healthcare, education, housing, and child and family services. It also works to transfer control of these services to Indigenous-led organizations. CIRNAC focuses on treaty negotiations, self-government agreements, land claims, and Northern affairs, aiming to strengthen nation-to-nation relationships and modernize Indigenous governance structures. Together, ISC and CIRNAC oversee key programs that impact Indigenous communities across Canada."
 msgstr "ISC is responsible for providing essential services to First Nations, Inuit, and Métis communities, including healthcare, education, housing, and child and family services. It also works to transfer control of these services to Indigenous-led organizations. CIRNAC focuses on treaty negotiations, self-government agreements, land claims, and Northern affairs, aiming to strengthen nation-to-nation relationships and modernize Indigenous governance structures. Together, ISC and CIRNAC oversee key programs that impact Indigenous communities across Canada."
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:82
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:82
 msgid "ISED spent $10.2 billion in fiscal year (FY) 2024. This was 2% of the $513.9 billion in overall federal spending. The department ranked eleventh among federal departments in total spending."
 msgstr "ISED spent $10.2 billion in fiscal year (FY) 2024. This was 2% of the $513.9 billion in overall federal spending. The department ranked eleventh among federal departments in total spending."
 
@@ -2050,7 +2082,7 @@ msgstr "Key Dates"
 msgid "Keywords"
 msgstr "Keywords"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:217
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:217
 msgid "Labour Market Development Agreements (LMDAs): federal funding to provinces for job training and employment support."
 msgstr "Labour Market Development Agreements (LMDAs): federal funding to provinces for job training and employment support."
 
@@ -2067,7 +2099,7 @@ msgid "Last Update"
 msgstr "Last Update"
 
 #: src/app/[lang]/(main)/budget/page.tsx:248
-#: src/app/[lang]/(main)/federal/budget/page.tsx:285
+#: src/app/[lang]/(main)/federal/budget/page.tsx:287
 msgid "Latest Budget News & Impact"
 msgstr "Latest Budget News & Impact"
 
@@ -2085,40 +2117,40 @@ msgstr "Location"
 msgid "Look back at what {0}'s government made and spent. {1}"
 msgstr "Look back at what {0}'s government made and spent. {1}"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:148
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:148
 msgid "Major international events, trade agreements, foreign aid commitments, and global crises such as the COVID-19 pandemic have influenced fluctuations in spending. In 2020, GAC's budget surged due to emergency international assistance programs, including vaccine distribution and humanitarian relief efforts."
 msgstr "Major international events, trade agreements, foreign aid commitments, and global crises such as the COVID-19 pandemic have influenced fluctuations in spending. In 2020, GAC's budget surged due to emergency international assistance programs, including vaccine distribution and humanitarian relief efforts."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:124
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:124
 msgid "Major legislation, economic conditions, and external factors can impact ESDC's spending."
 msgstr "Major legislation, economic conditions, and external factors can impact ESDC's spending."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:120
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:120
 msgid "Major legislation, internal or global economic conditions, and acute events like the COVID-19 pandemic can affect spending year to year. For example, the federal expenses fluctuated during the pandemic, rising from $410.2 billion (in 2024 dollars) in 2019 to $420 billion in 2020 and $720.3 billion in 2021"
 msgstr "Major legislation, internal or global economic conditions, and acute events like the COVID-19 pandemic can affect spending year to year. For example, the federal expenses fluctuated during the pandemic, rising from $410.2 billion (in 2024 dollars) in 2019 to $420 billion in 2020 and $720.3 billion in 2021"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:131
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:131
 msgid "Major legislation, internal or global economic conditions, and acute events like the COVID-19 pandemic can significantly influence government spending year to year. For example, during the COVID-19 pandemic, federal support programs led to a temporary surge in spending. Health Canada expenditures increased from $5 billion in FY 2019 to $14.2 billion in FY 2021 before stabilizing in recent years."
 msgstr "Major legislation, internal or global economic conditions, and acute events like the COVID-19 pandemic can significantly influence government spending year to year. For example, during the COVID-19 pandemic, federal support programs led to a temporary surge in spending. Health Canada expenditures increased from $5 billion in FY 2019 to $14.2 billion in FY 2021 before stabilizing in recent years."
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:132
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:117
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:119
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:120
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:118
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:121
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:132
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:117
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:119
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:120
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:118
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:121
 msgid "Major legislation, internal or global economic conditions, and acute events like the COVID-19 pandemic can significantly influence government spending year to year. For instance, during the pandemic, the Government of Canada's total expenses rose from $410.2 billion in 2019 to $420 billion in 2020 and further to $720.3 billion in 2021."
 msgstr "Major legislation, internal or global economic conditions, and acute events like the COVID-19 pandemic can significantly influence government spending year to year. For instance, during the pandemic, the Government of Canada's total expenses rose from $410.2 billion in 2019 to $420 billion in 2020 and further to $720.3 billion in 2021."
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:159
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:159
 msgid "Major legislation, shifts in international security dynamics, and acute events such as Russia's invasion of Ukraine or Arctic sovereignty disputes can influence military spending."
 msgstr "Major legislation, shifts in international security dynamics, and acute events such as Russia's invasion of Ukraine or Arctic sovereignty disputes can influence military spending."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:129
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:129
 msgid "Major legislative changes, compliance trends, and digital tax services have influenced CRA spending patterns. For example, compliance initiatives and fraud investigations recovered an estimated $11.5 billion in lost revenue in 2024 due to tax evasion."
 msgstr "Major legislative changes, compliance trends, and digital tax services have influenced CRA spending patterns. For example, compliance initiatives and fraud investigations recovered an estimated $11.5 billion in lost revenue in 2024 due to tax evasion."
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:125
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:125
 msgid "Major policy shifts, unforeseen events such as natural disasters, and global security concerns can significantly impact the department's annual spending. The COVID-19 pandemic, for example, led to a sharp increase in federal emergency response funding in 2020."
 msgstr "Major policy shifts, unforeseen events such as natural disasters, and global security concerns can significantly impact the department's annual spending. The COVID-19 pandemic, for example, led to a sharp increase in federal emergency response funding in 2020."
 
@@ -2168,18 +2200,18 @@ msgstr "Months"
 msgid "More coming soon..."
 msgstr "More coming soon..."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:167
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:167
 msgid "Most CRA spending is dedicated to personnel and IT infrastructure supporting tax filing, compliance, and benefit administration."
 msgstr "Most CRA spending is dedicated to personnel and IT infrastructure supporting tax filing, compliance, and benefit administration."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:155
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:155
 msgid "Most federal spending can be categorized as direct or indirect."
 msgstr "Most federal spending can be categorized as direct or indirect."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:158
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:146
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:153
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:183
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:158
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:146
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:153
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:183
 msgid "Most federal spending can be categorized as direct or indirect. Direct spending refers to money the federal government spends on budget items such as federal programs, employee salaries, and debt interest. Indirect spending refers to federal transfers to other levels of government."
 msgstr "Most federal spending can be categorized as direct or indirect. Direct spending refers to money the federal government spends on budget items such as federal programs, employee salaries, and debt interest. Indirect spending refers to federal transfers to other levels of government."
 
@@ -2197,19 +2229,19 @@ msgstr "Name"
 msgid "National Defence"
 msgstr "National Defence"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:35
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:35
 msgid "National Defence | Canada Spends"
 msgstr "National Defence | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:107
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:107
 msgid "National Defence accounted for 6.7% of all federal spending in FY 2024"
 msgstr "National Defence accounted for 6.7% of all federal spending in FY 2024"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:203
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:203
 msgid "National Defence, Spending by Entity, FY 2024"
 msgstr "National Defence, Spending by Entity, FY 2024"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:144
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:144
 msgid "National Defence's share of federal spending in FY 2024 was lower than in FY 1995"
 msgstr "National Defence's share of federal spending in FY 2024 was lower than in FY 1995"
 
@@ -2287,7 +2319,7 @@ msgid "Newfoundland and Labrador STP"
 msgstr "Newfoundland and Labrador STP"
 
 #: src/app/[lang]/(main)/budget/page.tsx:56
-#: src/app/[lang]/(main)/federal/budget/page.tsx:56
+#: src/app/[lang]/(main)/federal/budget/page.tsx:57
 msgid "News Source & Date"
 msgstr "News Source & Date"
 
@@ -2374,6 +2406,11 @@ msgstr "Note the different salary ranges prior to 2023. Information for small nu
 msgid "Notes to Financial Statements"
 msgstr "Notes to Financial Statements"
 
+#: src/app/[lang]/(main)/notifications/page.tsx:18
+#: src/app/[lang]/(main)/notifications/page.tsx:44
+msgid "Notifications"
+msgstr "Notifications"
+
 #: src/components/Sankey/index.tsx:491
 msgid "Nova Scotia EQP"
 msgstr "Nova Scotia EQP"
@@ -2430,59 +2467,59 @@ msgstr "of {0} municipal spending was by {1}"
 msgid "of {0} provincial spending was by {1}"
 msgstr "of {0} provincial spending was by {1}"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:92
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:92
 msgid "of federal spending was allocated to Indigenous priorities via these Departments. This does not include additional programs in other departments designed specifically for Indigenous beneficiaries."
 msgstr "of federal spending was allocated to Indigenous priorities via these Departments. This does not include additional programs in other departments designed specifically for Indigenous beneficiaries."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:81
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:81
 msgid "of federal spending was by ESDC"
 msgstr "of federal spending was by ESDC"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:79
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:79
 msgid "of federal spending was by Finance Canada"
 msgstr "of federal spending was by Finance Canada"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:85
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:85
 msgid "of federal spending was by Health Canada"
 msgstr "of federal spending was by Health Canada"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:87
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:87
 msgid "of federal spending was by Housing, Infrastructure and Communities Canada"
 msgstr "of federal spending was by Housing, Infrastructure and Communities Canada"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:77
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:77
 msgid "Of federal spending was by Public Services and Procurement Canada"
 msgstr "Of federal spending was by Public Services and Procurement Canada"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:80
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:80
 msgid "of federal spending was by the Canada Revenue Agency"
 msgstr "of federal spending was by the Canada Revenue Agency"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:85
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:85
 msgid "of federal spending was by the Department of National Defence"
 msgstr "of federal spending was by the Department of National Defence"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:74
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:74
 msgid "Of federal spending was by the Dept. of Immigration, Refugees and Citizenship"
 msgstr "Of federal spending was by the Dept. of Immigration, Refugees and Citizenship"
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:75
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:75
 msgid "Of federal spending was by the Dept. of Innovation, Science and Industry"
 msgstr "Of federal spending was by the Dept. of Innovation, Science and Industry"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:75
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:75
 msgid "Of federal spending was by the Dept. of Transport"
 msgstr "Of federal spending was by the Dept. of Transport"
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:77
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:77
 msgid "Of federal spending was by the Dept. of Veterans Affairs"
 msgstr "Of federal spending was by the Dept. of Veterans Affairs"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:87
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:87
 msgid "of federal spending was by the Global Affairs Canada"
 msgstr "of federal spending was by the Global Affairs Canada"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:79
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:79
 msgid "of federal spending was by the Public Safety Canada"
 msgstr "of federal spending was by the Public Safety Canada"
 
@@ -2494,7 +2531,7 @@ msgstr "Office of the Chief Electoral Officer"
 msgid "Office of the Secretary to the Governor General"
 msgstr "Office of the Secretary to the Governor General"
 
-#: src/app/[lang]/(main)/federal/budget/page.tsx:168
+#: src/app/[lang]/(main)/federal/budget/page.tsx:170
 msgid "Official Fall 2025 Federal Budget Released"
 msgstr "Official Fall 2025 Federal Budget Released"
 
@@ -2532,9 +2569,13 @@ msgid "Open Tor Browser and wait for it to connect."
 msgstr "Open Tor Browser and wait for it to connect."
 
 #: src/app/[lang]/(main)/budget/page.tsx:195
-#: src/app/[lang]/(main)/federal/budget/page.tsx:232
+#: src/app/[lang]/(main)/federal/budget/page.tsx:234
 msgid "Operational Spend"
 msgstr "Operational Spend"
+
+#: src/app/[lang]/(main)/login/login-form.tsx:140
+msgid "or"
+msgstr "or"
 
 #: src/app/[lang]/(main)/about/faq.tsx:84
 msgid "or subscribe to"
@@ -2544,7 +2585,7 @@ msgstr "or subscribe to"
 msgid "Organization"
 msgstr "Organization"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/MiniSankey.tsx:35
 #: src/components/Sankey/index.tsx:319
 msgid "Other"
 msgstr "Other"
@@ -2576,7 +2617,7 @@ msgstr "Other Environment and Climate Change Programs"
 msgid "Other Excise Taxes and Duties"
 msgstr "Other Excise Taxes and Duties"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/MiniSankey.tsx:39
 msgid "Other expenditures"
 msgstr "Other expenditures"
 
@@ -2632,22 +2673,22 @@ msgstr "Other Public Services + Procurement"
 msgid "Other Settlement Agreements"
 msgstr "Other Settlement Agreements"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:63
 msgid "Other subsidies and payments"
 msgstr "Other subsidies and payments"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:55
 msgid "Other Subsidies and Payments"
 msgstr "Other Subsidies and Payments"
 
@@ -2681,6 +2722,10 @@ msgstr "Overview"
 msgid "Parliament"
 msgstr "Parliament"
 
+#: src/app/[lang]/(main)/login/login-form.tsx:168
+msgid "Password"
+msgstr "Password"
+
 #: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:338
 msgid "Payment Amount"
 msgstr "Payment Amount"
@@ -2693,7 +2738,7 @@ msgstr "Payroll Contributions"
 msgid "Payroll Taxes"
 msgstr "Payroll Taxes"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:237
+#: src/app/[lang]/(main)/federal/spending/page.tsx:238
 #: src/app/[lang]/(main)/spending/page.tsx:228
 msgid "PBO"
 msgstr "PBO"
@@ -2707,43 +2752,43 @@ msgstr "Per Capita Spending"
 msgid "per resident"
 msgstr "per resident"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:148
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:148
 msgid "Percentage of federal budget dedicated to Canada Revenue Agency, FYs 1995-2024"
 msgstr "Percentage of federal budget dedicated to Canada Revenue Agency, FYs 1995-2024"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:152
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:152
 msgid "Percentage of federal budget dedicated to Defence, FYs 1995-2024"
 msgstr "Percentage of federal budget dedicated to Defence, FYs 1995-2024"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:146
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:146
 msgid "Percentage of federal budget dedicated to ESDC, FYs 1995-2024 (inflation-adjusted)"
 msgstr "Percentage of federal budget dedicated to ESDC, FYs 1995-2024 (inflation-adjusted)"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:138
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:138
 msgid "Percentage of federal budget dedicated to Finance, FYs 1995-2024"
 msgstr "Percentage of federal budget dedicated to Finance, FYs 1995-2024"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:131
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:131
 msgid "Percentage of federal budget dedicated to Global Affairs Canada, FYs 1995-2024"
 msgstr "Percentage of federal budget dedicated to Global Affairs Canada, FYs 1995-2024"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:141
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:141
 msgid "Percentage of federal budget dedicated to Indigenous Priorities, FYs 1995-2024"
 msgstr "Percentage of federal budget dedicated to Indigenous Priorities, FYs 1995-2024"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:19
 msgid "Personnel"
 msgstr "Personnel"
 
@@ -2758,6 +2803,12 @@ msgstr "Pollution pricing"
 #: src/components/Sankey/BudgetSankey.tsx:504
 msgid "Pollution pricing proceeds"
 msgstr "Pollution pricing proceeds"
+
+#. placeholder {0}: populationData[0]?.year
+#. placeholder {1}: populationData[populationData.length - 1]?.year
+#: src/components/first-nations/PopulationCharts.tsx:116
+msgid "Population trends for {bandName} from {0} to {1}."
+msgstr "Population trends for {bandName} from {0} to {1}."
 
 #: src/components/first-nations/RemunerationOverview.tsx:791
 #: src/components/first-nations/RemunerationTable.tsx:107
@@ -2798,22 +2849,22 @@ msgstr "Principal Investigator"
 msgid "Privy Council Office"
 msgstr "Privy Council Office"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:31
 msgid "Professional + Special Services"
 msgstr "Professional + Special Services"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:31
 msgid "Professional and Special Services"
 msgstr "Professional and Special Services"
 
@@ -2830,12 +2881,12 @@ msgid "Project Number"
 msgstr "Project Number"
 
 #: src/app/[lang]/(main)/budget/page.tsx:206
-#: src/app/[lang]/(main)/federal/budget/page.tsx:243
+#: src/app/[lang]/(main)/federal/budget/page.tsx:245
 msgid "Projected capital investments"
 msgstr "Projected capital investments"
 
 #: src/app/[lang]/(main)/budget/page.tsx:197
-#: src/app/[lang]/(main)/federal/budget/page.tsx:234
+#: src/app/[lang]/(main)/federal/budget/page.tsx:236
 msgid "Projected operational spending"
 msgstr "Projected operational spending"
 
@@ -2873,11 +2924,11 @@ msgstr "Provincial"
 msgid "Provincial Tax"
 msgstr "Provincial Tax"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:92
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:92
 msgid "PSPC accounted for 1.6% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 msgstr "PSPC accounted for 1.6% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:84
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:84
 msgid "PSPC spent $8.3 billion in fiscal year (FY) 2024. This was 1.6% of the $513.9 billion in overall federal spending. The department ranked twelfth among federal departments in total spending."
 msgstr "PSPC spent $8.3 billion in fiscal year (FY) 2024. This was 1.6% of the $513.9 billion in overall federal spending. The department ranked twelfth among federal departments in total spending."
 
@@ -2887,19 +2938,19 @@ msgstr "PSPC spent $8.3 billion in fiscal year (FY) 2024. This was 1.6% of the $
 msgid "Public Accounts of {0} FY {1}"
 msgstr "Public Accounts of {0} FY {1}"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:59
 msgid "Public debt charges"
 msgstr "Public debt charges"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:59
 #: src/components/Sankey/BudgetSankey.tsx:427
 msgid "Public Debt Charges"
 msgstr "Public Debt Charges"
@@ -2912,20 +2963,20 @@ msgstr "Public Health + Disease Prevention"
 msgid "Public Safety"
 msgstr "Public Safety"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:50
 msgid "Public Safety Canada"
 msgstr "Public Safety Canada"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:34
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:34
 msgid "Public Safety Canada | Canada Spends"
 msgstr "Public Safety Canada | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:86
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:86
 msgid "Public Safety Canada spent $13.9 billion in fiscal year (FY) 2024, accounting for 2.7% of the $513.9 billion in total federal spending. While not among the largest departments by expenditure, Public Safety Canada plays a crucial role in national security and emergency management, working in tandem with multiple agencies to mitigate threats and enhance public safety."
 msgstr "Public Safety Canada spent $13.9 billion in fiscal year (FY) 2024, accounting for 2.7% of the $513.9 billion in total federal spending. While not among the largest departments by expenditure, Public Safety Canada plays a crucial role in national security and emergency management, working in tandem with multiple agencies to mitigate threats and enhance public safety."
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:52
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:52
 msgid "Public Safety, Democratic Institutions and Intergovernmental Affairs Canada (Public Safety Canada) is the federal department responsible for national security, emergency preparedness, and community safety. Established in 2003, it consolidates security, law enforcement, and emergency management functions. It includes the RCMP, CSIS, and CBSA and coordinates federal responses to threats and develops policies on crime prevention, cyber resilience, and disaster preparedness while overseeing intelligence-sharing with domestic and international partners."
 msgstr "Public Safety, Democratic Institutions and Intergovernmental Affairs Canada (Public Safety Canada) is the federal department responsible for national security, emergency preparedness, and community safety. Established in 2003, it consolidates security, law enforcement, and emergency management functions. It includes the RCMP, CSIS, and CBSA and coordinates federal responses to threats and develops policies on crime prevention, cyber resilience, and disaster preparedness while overseeing intelligence-sharing with domestic and international partners."
 
@@ -2933,16 +2984,16 @@ msgstr "Public Safety, Democratic Institutions and Intergovernmental Affairs Can
 msgid "Public Service Employees"
 msgstr "Public Service Employees"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:68
 msgid "Public Services and Procurement Canada"
 msgstr "Public Services and Procurement Canada"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:177
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:177
 msgid "Public Services and Procurement Canada (PSPC) is led by the Minister of Government Transformation, Public Services and Procurement, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 msgstr "Public Services and Procurement Canada (PSPC) is led by the Minister of Government Transformation, Public Services and Procurement, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:32
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:32
 msgid "Public Services and Procurement Canada | Canada Spends"
 msgstr "Public Services and Procurement Canada | Canada Spends"
 
@@ -2950,7 +3001,7 @@ msgstr "Public Services and Procurement Canada | Canada Spends"
 msgid "Public Works + Government Services"
 msgstr "Public Works + Government Services"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/MiniSankey.tsx:31
 msgid "Quebec abatement"
 msgstr "Quebec abatement"
 
@@ -2989,7 +3040,7 @@ msgid "Ready Forces"
 msgstr "Ready Forces"
 
 #: src/app/[lang]/(main)/budget/page.tsx:251
-#: src/app/[lang]/(main)/federal/budget/page.tsx:288
+#: src/app/[lang]/(main)/federal/budget/page.tsx:290
 msgid "Recent developments and their projected impact on the Fall 2025 Budget"
 msgstr "Recent developments and their projected impact on the Fall 2025 Budget"
 
@@ -3015,38 +3066,38 @@ msgstr "Remuneration"
 msgid "Remuneration and Expenses"
 msgstr "Remuneration and Expenses"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:35
 msgid "Rentals"
 msgstr "Rentals"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:39
 msgid "Repair + Maintenance"
 msgstr "Repair + Maintenance"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:39
 msgid "Repair and Maintenance"
 msgstr "Repair and Maintenance"
 
@@ -3077,7 +3128,7 @@ msgid "Return on Investments"
 msgstr "Return on Investments"
 
 #: src/app/[lang]/(main)/budget/page.tsx:184
-#: src/app/[lang]/(main)/federal/budget/page.tsx:221
+#: src/app/[lang]/(main)/federal/budget/page.tsx:223
 #: src/components/Sankey/BudgetSankey.tsx:456
 #: src/components/Sankey/index.tsx:700
 msgid "Revenue"
@@ -3099,7 +3150,7 @@ msgstr "Safety"
 msgid "Salaries, honoraria, travel, and other expenses paid to elected officials and senior employees during fiscal year {fiscalYear}."
 msgstr "Salaries, honoraria, travel, and other expenses paid to elected officials and senior employees during fiscal year {fiscalYear}."
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:247
+#: src/app/[lang]/(main)/federal/spending/page.tsx:248
 #: src/app/[lang]/(main)/spending/page.tsx:238
 msgid "Salary Distribution"
 msgstr "Salary Distribution"
@@ -3152,7 +3203,7 @@ msgstr "Selection Committee"
 msgid "Selection Mechanism"
 msgstr "Selection Mechanism"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:205
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:205
 msgid "Service Canada: responsible for processing EI, CPP, and OAS benefits."
 msgstr "Service Canada: responsible for processing EI, CPP, and OAS benefits."
 
@@ -3185,23 +3236,44 @@ msgstr "Showing {0} of {1} First Nations"
 msgid "Showing {0} of {1} results"
 msgstr "Showing {0} of {1} results"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:142
+#: src/app/[lang]/(main)/login/login-form.tsx:186
+#: src/app/[lang]/(main)/login/login-form.tsx:198
+#: src/app/[lang]/(main)/login/page.tsx:20
+#: src/app/[lang]/(main)/login/page.tsx:44
+#: src/components/UserMenu.tsx:55
+msgid "Sign In"
+msgstr "Sign In"
+
+#: src/app/[lang]/(main)/login/page.tsx:21
+msgid "Sign in to your CanadaSpends account"
+msgstr "Sign in to your CanadaSpends account"
+
+#: src/components/UserMenu.tsx:45
+msgid "Sign Out"
+msgstr "Sign Out"
+
+#: src/app/[lang]/(main)/login/login-form.tsx:186
+#: src/app/[lang]/(main)/login/login-form.tsx:208
+msgid "Sign Up"
+msgstr "Sign Up"
+
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:142
 msgid "Similarly, HICC expenditures experienced notable fluctuations during this period, surging from approximately $5.9 billion​ in 2019 (adjusted for inflation) to $14.5B in 2024."
 msgstr "Similarly, HICC expenditures experienced notable fluctuations during this period, surging from approximately $5.9 billion​ in 2019 (adjusted for inflation) to $14.5B in 2024."
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:127
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:127
 msgid "Similarly, IRCC's expenditures experienced notable fluctuations during this period, surging from approximately $3.02 billion​ in 2019 to $6.3 billion in 2024."
 msgstr "Similarly, IRCC's expenditures experienced notable fluctuations during this period, surging from approximately $3.02 billion​ in 2019 to $6.3 billion in 2024."
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:129
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:129
 msgid "Similarly, ISED's expenditures have increased during this period, growing from approximately $6.5 billion​ in 2019 (adjusted for inflation) to $10.2 billion in 2024."
 msgstr "Similarly, ISED's expenditures have increased during this period, growing from approximately $6.5 billion​ in 2019 (adjusted for inflation) to $10.2 billion in 2024."
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:130
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:130
 msgid "Similarly, PSPC's expenditures experienced notable fluctuations during this period, decreasing from approximately $6.8 billion​ in 2019 (adjusted for inflation) to $5.3 billion in 2021 before increasing again in 2024."
 msgstr "Similarly, PSPC's expenditures experienced notable fluctuations during this period, decreasing from approximately $6.8 billion​ in 2019 (adjusted for inflation) to $5.3 billion in 2021 before increasing again in 2024."
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:128
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:128
 msgid "Similarly, Transport Canada's expenditures experienced fluctuations during this period, increasing from approximately $3.2 billion​ in 2019 (adjusted for inflation) to $5.1B in 2024."
 msgstr "Similarly, Transport Canada's expenditures experienced fluctuations during this period, increasing from approximately $3.2 billion​ in 2019 (adjusted for inflation) to $5.1B in 2024."
 
@@ -3224,21 +3296,21 @@ msgstr "Source"
 msgid "Source PDF"
 msgstr "Source PDF"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:260
+#: src/app/[lang]/(main)/federal/spending/page.tsx:261
 #: src/app/[lang]/(main)/spending/page.tsx:251
 msgid "Source:"
 msgstr "Source:"
 
 #: src/app/[lang]/(main)/budget/page.tsx:267
-#: src/app/[lang]/(main)/federal/budget/page.tsx:304
-#: src/app/[lang]/(main)/federal/spending/page.tsx:275
+#: src/app/[lang]/(main)/federal/budget/page.tsx:306
+#: src/app/[lang]/(main)/federal/spending/page.tsx:276
 #: src/app/[lang]/(main)/spending/page.tsx:266
 #: src/components/first-nations/FirstNationsPageContent.tsx:473
 #: src/components/JurisdictionPageContent.tsx:504
 msgid "Sources"
 msgstr "Sources"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:235
+#: src/app/[lang]/(main)/federal/spending/page.tsx:236
 #: src/app/[lang]/(main)/spending/page.tsx:226
 #: src/components/JurisdictionPageContent.tsx:436
 #: src/components/JurisdictionPageContent.tsx:451
@@ -3335,7 +3407,7 @@ msgstr "Subtotal - Remuneration"
 msgid "Summary"
 msgstr "Summary"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:183
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:183
 msgid "Support for Canada's Presence Abroad: $1.23B"
 msgstr "Support for Canada's Presence Abroad: $1.23B"
 
@@ -3412,7 +3484,7 @@ msgstr "Term"
 msgid "Territorial Formula Financing"
 msgstr "Territorial Formula Financing"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:208
+#: src/app/[lang]/(main)/federal/spending/page.tsx:209
 #: src/app/[lang]/(main)/spending/page.tsx:199
 msgid "The average employee is 43.3 years old"
 msgstr "The average employee is 43.3 years old"
@@ -3421,19 +3493,19 @@ msgstr "The average employee is 43.3 years old"
 msgid "The best way to support us is to engage with our content. Like, share, and comment on our posts on social media. Even better, share our work with a friend and encourage them to do the same. Together, we can expand the conversation and reach more people with these important facts."
 msgstr "The best way to support us is to engage with our content. Like, share, and comment on our posts on social media. Even better, share our work with a friend and encourage them to do the same. Together, we can expand the conversation and reach more people with these important facts."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:53
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:53
 msgid "The Canada Revenue Agency (CRA) is the federal institution responsible for administering tax laws, enforcing compliance, and delivering key benefit programs to individuals and businesses across Canada. Established in 1999 under the Canada Revenue Agency Act, the CRA operates with a workforce of approximately 59,155 employees (2024) and oversees tax revenues totaling $379 billion annually—which accounts for over 82% of federal revenues. It also administers over $46 billion in benefits and credits to Canadians, including the Canada Child Benefit and the GST/HST credit."
 msgstr "The Canada Revenue Agency (CRA) is the federal institution responsible for administering tax laws, enforcing compliance, and delivering key benefit programs to individuals and businesses across Canada. Established in 1999 under the Canada Revenue Agency Act, the CRA operates with a workforce of approximately 59,155 employees (2024) and oversees tax revenues totaling $379 billion annually—which accounts for over 82% of federal revenues. It also administers over $46 billion in benefits and credits to Canadians, including the Canada Child Benefit and the GST/HST credit."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:212
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:212
 msgid "The Canada Revenue Agency is overseen by the <0>Minister of National Revenue</0>, who is responsible for ensuring tax fairness and benefit program integrity but does not have direct authority over tax law interpretations."
 msgstr "The Canada Revenue Agency is overseen by the <0>Minister of National Revenue</0>, who is responsible for ensuring tax fairness and benefit program integrity but does not have direct authority over tax law interpretations."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:87
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:87
 msgid "The Canada Revenue Agency spent $16.8 billion in fiscal year (FY) 2024, representing 3.2% of the $513.9 billion in total federal spending. The CRA's expenditures primarily support tax administration, benefit program delivery, compliance enforcement, and IT modernization."
 msgstr "The Canada Revenue Agency spent $16.8 billion in fiscal year (FY) 2024, representing 3.2% of the $513.9 billion in total federal spending. The CRA's expenditures primarily support tax administration, benefit program delivery, compliance enforcement, and IT modernization."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:97
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:97
 msgid "The CRA accounted for 3.2% of all federal spending in FY 2024"
 msgstr "The CRA accounted for 3.2% of all federal spending in FY 2024"
 
@@ -3441,83 +3513,83 @@ msgstr "The CRA accounted for 3.2% of all federal spending in FY 2024"
 msgid "The cumulative surplus accumulated over time from operations."
 msgstr "The cumulative surplus accumulated over time from operations."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:230
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:230
 msgid "The Department is currently led by the <0>Minister of Jobs and Families</0> who is appointed by the Governor General on the advice of the Prime Minister and then formally sworn into office at Rideau Hall. They take the Oath of Office and the Oath of Allegiance and become a member of the King's Privy Council for Canada."
 msgstr "The Department is currently led by the <0>Minister of Jobs and Families</0> who is appointed by the Governor General on the advice of the Prime Minister and then formally sworn into office at Rideau Hall. They take the Oath of Office and the Oath of Allegiance and become a member of the King's Privy Council for Canada."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:202
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:202
 msgid "The Department is led by the <0>Minister of Finance</0>, who is appointed by the Governor General on the advice of the Prime Minister and then formally sworn into office at Rideau Hall. They take the Oath of Office and the Oath of Allegiance and become a member of the King's Privy Council for Canada."
 msgstr "The Department is led by the <0>Minister of Finance</0>, who is appointed by the Governor General on the advice of the Prime Minister and then formally sworn into office at Rideau Hall. They take the Oath of Office and the Oath of Allegiance and become a member of the King's Privy Council for Canada."
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:163
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:163
 msgid "The Department is led by the <0>Minister of Public Safety</0>, who is appointed by the Governor General on the advice of the Prime Minister and then formally sworn into office at Rideau Hall. They take the Oath of Office and the Oath of Allegiance and become a member of the King's Privy Council for Canada."
 msgstr "The Department is led by the <0>Minister of Public Safety</0>, who is appointed by the Governor General on the advice of the Prime Minister and then formally sworn into office at Rideau Hall. They take the Oath of Office and the Oath of Allegiance and become a member of the King's Privy Council for Canada."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:54
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:54
 msgid "The Department of Finance (Finance Canada) is a central federal department responsible for overseeing the nation's economic and fiscal policies, ensuring financial stability, and managing the government's fiscal framework. Established in 1867 as one of the original departments following Confederation, it advises the Prime Minister and Cabinet on economic matters, develops tax and tariff policies, and prepares the annual federal budget."
 msgstr "The Department of Finance (Finance Canada) is a central federal department responsible for overseeing the nation's economic and fiscal policies, ensuring financial stability, and managing the government's fiscal framework. Established in 1867 as one of the original departments following Confederation, it advises the Prime Minister and Cabinet on economic matters, develops tax and tariff policies, and prepares the annual federal budget."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:97
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:97
 msgid "The Department of Finance accounted for 26.4% of all federal spending in FY 2024."
 msgstr "The Department of Finance accounted for 26.4% of all federal spending in FY 2024."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:86
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:86
 msgid "The Department of Finance spent $136.1 billion in fiscal year (FY) 2024. This was 26.4% of the $513.9 billion in overall federal spending. The department ranked first among federal departments in total spending."
 msgstr "The Department of Finance spent $136.1 billion in fiscal year (FY) 2024. This was 26.4% of the $513.9 billion in overall federal spending. The department ranked first among federal departments in total spending."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:132
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:132
 msgid "The Department of Finance's share of federal spending in FY 2024 was lower than FY 1995."
 msgstr "The Department of Finance's share of federal spending in FY 2024 was lower than FY 1995."
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:50
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:50
 msgid "The Department of Immigration, Refugees and Citizenship Canada (IRCC) is the federal department responsible for managing immigration policies, issuing passports, processing visas and permanent residency applications, and supporting newcomers to Canada. It plays a key role in shaping Canada's immigration system, refugee protection policies, and pathways to citizenship."
 msgstr "The Department of Immigration, Refugees and Citizenship Canada (IRCC) is the federal department responsible for managing immigration policies, issuing passports, processing visas and permanent residency applications, and supporting newcomers to Canada. It plays a key role in shaping Canada's immigration system, refugee protection policies, and pathways to citizenship."
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:50
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:50
 msgid "The Department of Innovation, Science and Industry (ISED) is the federal department responsible for fostering economic growth, technological advancement, and scientific research in Canada. It plays a key role in supporting businesses, funding research and development, and shaping policies that aim to enhance innovation, industrial competitiveness, and the prosperity of the Canadian economy."
 msgstr "The Department of Innovation, Science and Industry (ISED) is the federal department responsible for fostering economic growth, technological advancement, and scientific research in Canada. It plays a key role in supporting businesses, funding research and development, and shaping policies that aim to enhance innovation, industrial competitiveness, and the prosperity of the Canadian economy."
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:53
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:53
 msgid "The Department of National Defence (DND) and the Canadian Armed Forces (CAF) are responsible for ensuring Canada's security and defence through military operations, infrastructure management, and personnel support. Established in 1923 under the National Defence Act, DND oversees the defence budget, military procurement, and readiness planning, while the CAF executes domestic and international operations. The department provides strategic defence policy guidance and works with international allies, including NATO and NORAD, to ensure national security. DND also administers military health services, housing programs, and recruitment initiatives to support its personnel."
 msgstr "The Department of National Defence (DND) and the Canadian Armed Forces (CAF) are responsible for ensuring Canada's security and defence through military operations, infrastructure management, and personnel support. Established in 1923 under the National Defence Act, DND oversees the defence budget, military procurement, and readiness planning, while the CAF executes domestic and international operations. The department provides strategic defence policy guidance and works with international allies, including NATO and NORAD, to ensure national security. DND also administers military health services, housing programs, and recruitment initiatives to support its personnel."
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:214
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:214
 msgid "The Department of National Defence is led by the <0>Minister of National Defence</0>, who is appointed by the Governor General on the advice of the Prime Minister. The minister is responsible for overseeing national defense policy, military operations, and procurement."
 msgstr "The Department of National Defence is led by the <0>Minister of National Defence</0>, who is appointed by the Governor General on the advice of the Prime Minister. The minister is responsible for overseeing national defense policy, military operations, and procurement."
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:95
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:95
 msgid "The Department of National Defence spent $34.5 billion in fiscal year (FY) 2024. This represented 6.7% of the $513.9 billion in total federal spending. DND ranked among the top federal departments in expenditures, largely driven by personnel costs, military procurement, and operational readiness efforts."
 msgstr "The Department of National Defence spent $34.5 billion in fiscal year (FY) 2024. This represented 6.7% of the $513.9 billion in total federal spending. DND ranked among the top federal departments in expenditures, largely driven by personnel costs, military procurement, and operational readiness efforts."
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:51
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:51
 msgid "The Department of Transport (Transport Canada) is the federal department responsible for developing and enforcing transportation policies, regulations, and infrastructure projects to ensure safe and efficient movement of people and goods across Canada. It oversees aviation, rail, marine, and road transportation systems, working to enhance national connectivity and economic growth."
 msgstr "The Department of Transport (Transport Canada) is the federal department responsible for developing and enforcing transportation policies, regulations, and infrastructure projects to ensure safe and efficient movement of people and goods across Canada. It oversees aviation, rail, marine, and road transportation systems, working to enhance national connectivity and economic growth."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:51
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:51
 msgid "The Department of Veterans Affairs Canada (VAC) is the federal department responsible for supporting and serving Canadian veterans, active-duty military personnel, and their families. It provides financial assistance, healthcare support, rehabilitation services, and recognition programs to honor the contributions of those who have served in the Canadian Armed Forces. Additionally, the department is responsible for remembrance initiatives that preserve Canada's military history."
 msgstr "The Department of Veterans Affairs Canada (VAC) is the federal department responsible for supporting and serving Canadian veterans, active-duty military personnel, and their families. It provides financial assistance, healthcare support, rehabilitation services, and recognition programs to honor the contributions of those who have served in the Canadian Armed Forces. Additionally, the department is responsible for remembrance initiatives that preserve Canada's military history."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:113
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:113
 msgid "The department's spending grew at a rate significantly higher than overall spending, reflecting shifts in federal priorities. In 2024, ESDC accounted for 18.4% of all federal spending, 16.51 percentage points higher than in 2005."
 msgstr "The department's spending grew at a rate significantly higher than overall spending, reflecting shifts in federal priorities. In 2024, ESDC accounted for 18.4% of all federal spending, 16.51 percentage points higher than in 2005."
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:123
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:123
 msgid "The department's spending grew at a rate significantly lower than overall spending, reflecting shifts in federal priorities. In FY 2024, Health Canada accounted for 2.7% of all federal spending, 3.14 percentage points lower than in 1995."
 msgstr "The department's spending grew at a rate significantly lower than overall spending, reflecting shifts in federal priorities. In FY 2024, Health Canada accounted for 2.7% of all federal spending, 3.14 percentage points lower than in 1995."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:113
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:113
 msgid "The department's spending has grown less than overall spending, which means that the department's share of the federal budget has increased. In FY 2024, VAC accounted for 1.1% of all federal spending, about the same share as in 1995."
 msgstr "The department's spending has grown less than overall spending, which means that the department's share of the federal budget has increased. In FY 2024, VAC accounted for 1.1% of all federal spending, about the same share as in 1995."
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:109
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:109
 msgid "The department's spending has grown more than overall spending, which means that the department's share of the federal budget has increased. In FY 2024, IRCC accounted for 1.2% of all federal spending, 0.8 percentage points higher than in 1995."
 msgstr "The department's spending has grown more than overall spending, which means that the department's share of the federal budget has increased. In FY 2024, IRCC accounted for 1.2% of all federal spending, 0.8 percentage points higher than in 1995."
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:111
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:111
 msgid "The department's spending has grown more than overall spending, which means that the department's share of the federal budget has increased. In FY 2024, ISED accounted for 2% of all federal spending, 0.17 percentage points higher than in 1995."
 msgstr "The department's spending has grown more than overall spending, which means that the department's share of the federal budget has increased. In FY 2024, ISED accounted for 2% of all federal spending, 0.17 percentage points higher than in 1995."
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:112
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:112
 msgid "The department's spending has increased less than overall spending has grown and the department's share of the federal budget has decreased over time. In FY 2024, PSPC accounted for 1.6% of all federal spending, 1 percentage point lower than in 1995."
 msgstr "The department's spending has increased less than overall spending has grown and the department's share of the federal budget has decreased over time. In FY 2024, PSPC accounted for 1.6% of all federal spending, 1 percentage point lower than in 1995."
 
@@ -3529,51 +3601,51 @@ msgstr "The difference between revenue and spending. A surplus indicates revenue
 msgid "The difference between total revenue and total expenses. A surplus indicates revenue exceeded expenses."
 msgstr "The difference between total revenue and total expenses. A surplus indicates revenue exceeded expenses."
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:193
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:193
 msgid "The leadership of ISC and CIRNAC are led by the <0>Minister of Indigenous Services Canada</0> and the <1>Minister of Crown-Indigenous Relations and Northern Affairs Canada</1>, respectively. These Ministers are appointed by the Governor General on the advice of the Prime Minister and then formally sworn into office at Rideau Hall. They take the Oath of Office and the Oath of Allegiance and become a member of the King's Privy Council for Canada."
 msgstr "The leadership of ISC and CIRNAC are led by the <0>Minister of Indigenous Services Canada</0> and the <1>Minister of Crown-Indigenous Relations and Northern Affairs Canada</1>, respectively. These Ministers are appointed by the Governor General on the advice of the Prime Minister and then formally sworn into office at Rideau Hall. They take the Oath of Office and the Oath of Allegiance and become a member of the King's Privy Council for Canada."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:189
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:189
 msgid "The Minister is responsible for overseeing benefits and services for veterans, ensuring their well-being, and leading national remembrance initiatives."
 msgstr "The Minister is responsible for overseeing benefits and services for veterans, ensuring their well-being, and leading national remembrance initiatives."
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:188
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:188
 msgid "The Minister is responsible for overseeing Canada's transportation policies, ensuring safety regulations, investing in infrastructure, and leading climate initiatives related to aviation, rail, marine, and road transportation."
 msgstr "The Minister is responsible for overseeing Canada's transportation policies, ensuring safety regulations, investing in infrastructure, and leading climate initiatives related to aviation, rail, marine, and road transportation."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:214
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:214
 msgid "The Minister of Finance is one of the <0>cabinet members</0> who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister takes office and appoints a new cabinet. Outgoing ministers remain in their roles until their successors are sworn in."
 msgstr "The Minister of Finance is one of the <0>cabinet members</0> who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister takes office and appoints a new cabinet. Outgoing ministers remain in their roles until their successors are sworn in."
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:181
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:181
 msgid "The Minister of Immigration, Refugees and Citizenship is one of the cabinet members who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister appoints a new cabinet. Outgoing ministers continue in their roles until their successors are sworn in."
 msgstr "The Minister of Immigration, Refugees and Citizenship is one of the cabinet members who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister appoints a new cabinet. Outgoing ministers continue in their roles until their successors are sworn in."
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:181
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:181
 msgid "The Minister of Innovation, Science and Industry is one of the cabinet members who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister appoints a new cabinet. Outgoing ministers continue in their roles until their successors are sworn in."
 msgstr "The Minister of Innovation, Science and Industry is one of the cabinet members who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister appoints a new cabinet. Outgoing ministers continue in their roles until their successors are sworn in."
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:188
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:188
 msgid "The Minister of Public Services and Procurement is one of the cabinet members who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister appoints a new cabinet. Outgoing ministers continue in their roles until their successors are sworn in."
 msgstr "The Minister of Public Services and Procurement is one of the cabinet members who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister appoints a new cabinet. Outgoing ministers continue in their roles until their successors are sworn in."
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:179
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:179
 msgid "The Minister of Transport is one of the cabinet members who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister appoints a new cabinet. Outgoing ministers continue in their roles until their successors are sworn in."
 msgstr "The Minister of Transport is one of the cabinet members who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister appoints a new cabinet. Outgoing ministers continue in their roles until their successors are sworn in."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:180
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:180
 msgid "The Minister of Veterans Affairs is one of the cabinet members who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister appoints a new cabinet. Outgoing ministers continue in their roles until their successors are sworn in."
 msgstr "The Minister of Veterans Affairs is one of the cabinet members who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister appoints a new cabinet. Outgoing ministers continue in their roles until their successors are sworn in."
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:254
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:254
 msgid "The ministers work alongside the Deputy Minister of Foreign Affairs and the Deputy Minister of International Trade, who manage the department's operational and policy frameworks."
 msgstr "The ministers work alongside the Deputy Minister of Foreign Affairs and the Deputy Minister of International Trade, who manage the department's operational and policy frameworks."
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:52
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:52
 msgid "The Public Services and Procurement Canada (PSPC) is the federal department responsible for providing centralized procurement, real estate management, pay and pension administration for federal employees, and translation services to the Government of Canada. It ensures that government departments have the goods, services, and infrastructure they need to operate efficiently while maintaining transparency, fairness, and value for taxpayers."
 msgstr "The Public Services and Procurement Canada (PSPC) is the federal department responsible for providing centralized procurement, real estate management, pay and pension administration for federal employees, and translation services to the Government of Canada. It ensures that government departments have the goods, services, and infrastructure they need to operate efficiently while maintaining transparency, fairness, and value for taxpayers."
 
-#: src/app/[lang]/(main)/federal/budget/page.tsx:194
+#: src/app/[lang]/(main)/federal/budget/page.tsx:196
 msgid "The values you see here are based on the FY 2024 Budget with preliminary updates based on government announcements, memos, and leaks, and are meant to provide a rough idea of the budget. Once the official Fall 2025 Budget is released on November 4th, we will update this page to reflect the official budget."
 msgstr "The values you see here are based on the FY 2024 Budget with preliminary updates based on government announcements, memos, and leaks, and are meant to provide a rough idea of the budget. Once the official Fall 2025 Budget is released on November 4th, we will update this page to reflect the official budget."
 
@@ -3581,19 +3653,19 @@ msgstr "The values you see here are based on the FY 2024 Budget with preliminary
 msgid "Theme"
 msgstr "Theme"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:223
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:242
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:261
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:183
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:194
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:211
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:225
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:175
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:223
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:242
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:261
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:183
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:194
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:211
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:225
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:175
 msgid "These Ministers are some of the <0>cabinet members</0> who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister takes office and appoints a new cabinet. Outgoing ministers remain in their roles until their successors are sworn in."
 msgstr "These Ministers are some of the <0>cabinet members</0> who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister takes office and appoints a new cabinet. Outgoing ministers remain in their roles until their successors are sworn in."
 
 #: src/app/[lang]/(main)/budget/page.tsx:159
-#: src/app/[lang]/(main)/federal/budget/page.tsx:187
+#: src/app/[lang]/(main)/federal/budget/page.tsx:189
 msgid "This page presents the official Fall 2025 Federal Budget as released by the Government of Canada on November 4th, 2025. All data is sourced directly from official government publications and public accounts from the Government of Canada."
 msgstr "This page presents the official Fall 2025 Federal Budget as released by the Government of Canada on November 4th, 2025. All data is sourced directly from official government publications and public accounts from the Government of Canada."
 
@@ -3609,7 +3681,7 @@ msgstr "This schedule is unaudited."
 msgid "This visualization shows how your income tax contributions are allocated across different government programs and services based on current government spending patterns. Amounts under $20 are grouped into \"Other\" for conciseness."
 msgstr "This visualization shows how your income tax contributions are allocated across different government programs and services based on current government spending patterns. Amounts under $20 are grouped into \"Other\" for conciseness."
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:62
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:62
 msgid "Through the Public Health Agency of Canada (PHAC), Health Canada monitors public health risks, manages disease outbreaks, and promotes health initiatives. It also funds medical research via the Canadian Institutes of Health Research (CIHR) and oversees healthcare services for Indigenous communities."
 msgstr "Through the Public Health Agency of Canada (PHAC), Health Canada monitors public health risks, manages disease outbreaks, and promotes health initiatives. It also funds medical research via the Canadian Institutes of Health Research (CIHR) and oversees healthcare services for Indigenous communities."
 
@@ -3645,7 +3717,7 @@ msgid "Total assets minus total liabilities. This represents the First Nation's 
 msgstr "Total assets minus total liabilities. This represents the First Nation's overall financial position."
 
 #: src/app/[lang]/(main)/budget/page.tsx:175
-#: src/app/[lang]/(main)/federal/budget/page.tsx:212
+#: src/app/[lang]/(main)/federal/budget/page.tsx:214
 msgid "Total Budget"
 msgstr "Total Budget"
 
@@ -3673,7 +3745,7 @@ msgstr "Total Federal Tax"
 msgid "Total Financial Assets"
 msgstr "Total Financial Assets"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:171
+#: src/app/[lang]/(main)/federal/spending/page.tsx:172
 #: src/app/[lang]/(main)/spending/page.tsx:162
 msgid "Total full-time equivalents"
 msgstr "Total full-time equivalents"
@@ -3736,7 +3808,7 @@ msgstr "Total spending in {0}"
 msgid "Total Tax"
 msgstr "Total Tax"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:183
+#: src/app/[lang]/(main)/federal/spending/page.tsx:184
 #: src/app/[lang]/(main)/spending/page.tsx:174
 msgid "Total Wages"
 msgstr "Total Wages"
@@ -3745,23 +3817,23 @@ msgstr "Total Wages"
 msgid "Trade and Investment"
 msgstr "Trade and Investment"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:174
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:174
 msgid "Trade and Investment: $380.3M"
 msgstr "Trade and Investment: $380.3M"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:55
 msgid "Transfer Payments"
 msgstr "Transfer Payments"
 
@@ -3770,24 +3842,24 @@ msgstr "Transfer Payments"
 msgid "Transfers to Provinces"
 msgstr "Transfers to Provinces"
 
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:86
 msgid "Transport Canada"
 msgstr "Transport Canada"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:33
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:33
 msgid "Transport Canada | Canada Spends"
 msgstr "Transport Canada | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:91
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:91
 msgid "Transport Canada accounted for 1% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 msgstr "Transport Canada accounted for 1% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:169
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:169
 msgid "Transport Canada is led by the Minister of Transport, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 msgstr "Transport Canada is led by the Minister of Transport, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:82
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:82
 msgid "Transport Canada spent $5.1 billion in fiscal year (FY) 2024. This was 1% of the $513.9 billion in overall federal spending. The department ranked fourteenth among federal departments in total spending."
 msgstr "Transport Canada spent $5.1 billion in fiscal year (FY) 2024. This was 1% of the $513.9 billion in overall federal spending. The department ranked fourteenth among federal departments in total spending."
 
@@ -3795,27 +3867,27 @@ msgstr "Transport Canada spent $5.1 billion in fiscal year (FY) 2024. This was 1
 msgid "Transportation"
 msgstr "Transportation"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:23
 msgid "Transportation + Communication"
 msgstr "Transportation + Communication"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:23
 msgid "Transportation and Communication"
 msgstr "Transportation and Communication"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:241
-#: src/app/[lang]/(main)/federal/spending/page.tsx:262
+#: src/app/[lang]/(main)/federal/spending/page.tsx:242
+#: src/app/[lang]/(main)/federal/spending/page.tsx:263
 #: src/app/[lang]/(main)/spending/page.tsx:232
 #: src/app/[lang]/(main)/spending/page.tsx:253
 #: src/components/Sankey/index.tsx:346
@@ -3826,7 +3898,7 @@ msgstr "Treasury Board"
 msgid "Tribunal Award"
 msgstr "Tribunal Award"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:191
+#: src/app/[lang]/(main)/federal/spending/page.tsx:192
 #: src/app/[lang]/(main)/spending/page.tsx:182
 msgid "Type of Tenure"
 msgstr "Type of Tenure"
@@ -3839,44 +3911,44 @@ msgstr "Understanding Your Tax Contribution"
 msgid "Use a computer you trust, not one provided by your employer."
 msgstr "Use a computer you trust, not one provided by your employer."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:43
 msgid "Utilities, Materials and Supplies"
 msgstr "Utilities, Materials and Supplies"
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:92
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:92
 msgid "VAC accounted for 1.2% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 msgstr "VAC accounted for 1.2% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:84
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:84
 msgid "VAC spent $6.1 billion in fiscal year (FY) 2024. This was 1.2% of the $513.9 billion in overall federal spending. The department ranked thirteenth among federal departments in total spending."
 msgstr "VAC spent $6.1 billion in fiscal year (FY) 2024. This was 1.2% of the $513.9 billion in overall federal spending. The department ranked thirteenth among federal departments in total spending."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:131
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:131
 msgid "VAC's expenditures also grew slightly during this period, increasing from approximately $5.5B​ in 2019 when adjusted for inflation to $6.3B in 2024."
 msgstr "VAC's expenditures also grew slightly during this period, increasing from approximately $5.5B​ in 2019 when adjusted for inflation to $6.3B in 2024."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:80
 msgid "Veterans Affairs"
 msgstr "Veterans Affairs"
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:170
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:170
 msgid "Veterans Affairs Canada (VAC) is led by the Minister of Veterans Affairs, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 msgstr "Veterans Affairs Canada (VAC) is led by the Minister of Veterans Affairs, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:33
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:33
 msgid "Veterans Affairs Canada | Canada Spends"
 msgstr "Veterans Affairs Canada | Canada Spends"
 
@@ -3890,7 +3962,7 @@ msgstr "View {year} financial statements for {0}{provinceSuffix}. Includes state
 msgid "View detailed tax breakdown"
 msgstr "View detailed tax breakdown"
 
-#: src/app/[lang]/(main)/federal/budget/page.tsx:174
+#: src/app/[lang]/(main)/federal/budget/page.tsx:176
 msgid "View Federal 2025 Budget Details"
 msgstr "View Federal 2025 Budget Details"
 
@@ -3908,8 +3980,8 @@ msgid "View source data"
 msgstr "View source data"
 
 #: src/app/[lang]/(main)/budget/page.tsx:242
-#: src/app/[lang]/(main)/federal/budget/page.tsx:279
-#: src/app/[lang]/(main)/federal/spending/page.tsx:158
+#: src/app/[lang]/(main)/federal/budget/page.tsx:281
+#: src/app/[lang]/(main)/federal/spending/page.tsx:159
 #: src/app/[lang]/(main)/spending/page.tsx:149
 #: src/components/JurisdictionPageContent.tsx:393
 msgid "View this chart in full screen"
@@ -3934,59 +4006,59 @@ msgstr "Want even more anonymity?"
 msgid "was spent by {0}"
 msgstr "was spent by {0}"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:76
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:76
 msgid "was spent by ESDC"
 msgstr "was spent by ESDC"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:74
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:74
 msgid "was spent by Finance Canada"
 msgstr "was spent by Finance Canada"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:80
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:80
 msgid "was spent by Health Canada"
 msgstr "was spent by Health Canada"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:82
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:82
 msgid "was spent by Housing, Infrastructure and Communities Canada"
 msgstr "was spent by Housing, Infrastructure and Communities Canada"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:87
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:87
 msgid "was spent by ISC and CIRNAC"
 msgstr "was spent by ISC and CIRNAC"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:72
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:72
 msgid "Was spent by Public Services and Procurement Canada"
 msgstr "Was spent by Public Services and Procurement Canada"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:75
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:75
 msgid "was spent by the Canada Revenue Agency"
 msgstr "was spent by the Canada Revenue Agency"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:78
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:78
 msgid "was spent by the Department of National Defence"
 msgstr "was spent by the Department of National Defence"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:69
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:69
 msgid "Was spent by the Dept. of Immigration, Refugees and Citizenship"
 msgstr "Was spent by the Dept. of Immigration, Refugees and Citizenship"
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:70
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:70
 msgid "Was spent by the Dept. of Innovation, Science and Industry"
 msgstr "Was spent by the Dept. of Innovation, Science and Industry"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:70
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:70
 msgid "Was spent by the Dept. of Transport"
 msgstr "Was spent by the Dept. of Transport"
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:72
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:72
 msgid "Was spent by the Dept. of Veterans Affairs"
 msgstr "Was spent by the Dept. of Veterans Affairs"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:82
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:82
 msgid "was spent by the Global Affairs Canada"
 msgstr "was spent by the Global Affairs Canada"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:74
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:74
 msgid "was spent by the Public Safety Canada"
 msgstr "was spent by the Public Safety Canada"
 
@@ -4034,6 +4106,11 @@ msgstr "We're strictly non-partisan—we don't judge policies or debate spending
 msgid "Weather Services"
 msgstr "Weather Services"
 
+#. placeholder {0}: user.email
+#: src/app/[lang]/(main)/notifications/page.tsx:47
+msgid "Welcome, {0}!"
+msgstr "Welcome, {0}!"
+
 #: src/components/Sankey/index.tsx:122
 msgid "Western + Northern Economic Development"
 msgstr "Western + Northern Economic Development"
@@ -4058,7 +4135,7 @@ msgstr "What is your methodology?"
 msgid "What Makes a Good Tip?"
 msgstr "What Makes a Good Tip?"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:123
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:123
 msgid "When HICC was founded in FY 2005 as the Office of Infrastructure Canada, the department's spending has grown from $250,000 to over $14 billion, a significant increase in overall spending and mandate. In FY 2024, HICC accounted for 2.8% of all federal spending."
 msgstr "When HICC was founded in FY 2005 as the Office of Infrastructure Canada, the department's spending has grown from $250,000 to over $14 billion, a significant increase in overall spending and mandate. In FY 2024, HICC accounted for 2.8% of all federal spending."
 
@@ -4071,11 +4148,11 @@ msgstr "Where do you get the data on your website?"
 msgid "Where Your Tax Dollars Go"
 msgstr "Where Your Tax Dollars Go"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:140
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:140
 msgid "While GAC's spending has increased in real terms, its share of the federal budget has also increased moderately over the past decades. In 2024, GAC accounted for 3.7% of federal spending, compared to 2% in 1995."
 msgstr "While GAC's spending has increased in real terms, its share of the federal budget has also increased moderately over the past decades. In 2024, GAC accounted for 3.7% of federal spending, compared to 2% in 1995."
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:90
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:90
 msgid "While not in the top 10 departments by spend, ISED accounted for 2% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 msgstr "While not in the top 10 departments by spend, ISED accounted for 2% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 
@@ -4090,59 +4167,59 @@ msgstr "Whistleblowers"
 msgid "Whistleblowers | Secure Anonymous Tips | Canada Spends"
 msgstr "Whistleblowers | Secure Anonymous Tips | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:227
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:227
 msgid "Who leads ESDC?"
 msgstr "Who leads ESDC?"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:224
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:224
 msgid "Who leads Global Affairs Canada?"
 msgstr "Who leads Global Affairs Canada?"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:167
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:167
 msgid "Who leads Health Canada?"
 msgstr "Who leads Health Canada?"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:175
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:175
 msgid "Who leads Housing, Infrastructure and Communities Canada?"
 msgstr "Who leads Housing, Infrastructure and Communities Canada?"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:165
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:165
 msgid "Who Leads Immigration, Refugees and Citizenship Canada (IRCC)?"
 msgstr "Who Leads Immigration, Refugees and Citizenship Canada (IRCC)?"
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:166
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:166
 msgid "Who Leads Innovation, Science and Industry Canada (ISED)?"
 msgstr "Who Leads Innovation, Science and Industry Canada (ISED)?"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:190
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:190
 msgid "Who leads ISC and CIRNAC?"
 msgstr "Who leads ISC and CIRNAC?"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:160
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:160
 msgid "Who leads Public Safety Canada?"
 msgstr "Who leads Public Safety Canada?"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:172
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:172
 msgid "Who Leads Public Services and Procurement Canada (PSPC)?"
 msgstr "Who Leads Public Services and Procurement Canada (PSPC)?"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:209
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:209
 msgid "Who leads the Canada Revenue Agency?"
 msgstr "Who leads the Canada Revenue Agency?"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:199
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:199
 msgid "Who leads the Department of Finance?"
 msgstr "Who leads the Department of Finance?"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:211
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:211
 msgid "Who leads the Department of National Defence?"
 msgstr "Who leads the Department of National Defence?"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:166
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:166
 msgid "Who Leads Transport Canada?"
 msgstr "Who Leads Transport Canada?"
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:167
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:167
 msgid "Who Leads Veterans Affairs Canada (VAC)?"
 msgstr "Who Leads Veterans Affairs Canada (VAC)?"
 
@@ -4166,6 +4243,14 @@ msgstr "You can access our whistleblower platform directly through your web brow
 #: src/app/[lang]/(main)/page.tsx:86
 msgid "You deserve the facts"
 msgstr "You deserve the facts"
+
+#: src/app/[lang]/(main)/notifications/page.tsx:50
+msgid "You have no new notifications."
+msgstr "You have no new notifications."
+
+#: src/app/[lang]/(main)/notifications/page.tsx:19
+msgid "Your notifications"
+msgstr "Your notifications"
 
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:778
 msgid "Your tax contributions are approximated based on employment income. Deductions such as basic personal amount are estimated and included. Other sources of income, such as self-employment, investment income, and capital gains, are not included in the calculations. Deductions such as RRSP and FHSA contributions are also not included."

--- a/src/locales/fr.po
+++ b/src/locales/fr.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:149
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:149
 msgid " How did Health Canada spend its budget in FY24?"
 msgstr "Comment Santé Canada a-t-il dépensé son budget au cours de l'exercice 2024?"
 
@@ -121,22 +121,22 @@ msgstr "Total de {provinceName}"
 msgid "© 2025 Canada Spends. All rights reserved. A Project of <0>Build Canada</0>."
 msgstr "© 2025 Canada Spends. Tous droits réservés. Un projet de <0>Build Canada</0>."
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:235
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:235
 msgid "<0>Minister of Foreign Affairs</0>: Responsible for diplomacy, international security, international development assistance, and global partnerships."
 msgstr "<0>Ministre des Affaires étrangères</0> : Responsable de la diplomatie, de la sécurité internationale, de l'aide au développement international et des partenariats mondiaux."
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:244
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:244
 msgid "<0>Minister of International Trade</0>: Oversees Canada's trade negotiations, export promotion, and economic policy engagement."
 msgstr "<0>Ministre du Commerce international</0> : Supervise les négociations commerciales du Canada, la promotion des exportations et l'engagement en matière de politique économique."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:103
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:103
 msgid "10 government departments accounted for 73.2% of federal spending in FY 2024"
 msgstr "10 ministères gouvernementaux représentaient 73,2 % des dépenses fédérales pour l'exercice 2024"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:103
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:109
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:115
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:97
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:103
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:109
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:115
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:97
 msgid "10 government departments accounted for 73.2% of federal spending in FY 2024."
 msgstr "10 ministères gouvernementaux représentaient 73,2 % des dépenses fédérales pour l'exercice 2024."
 
@@ -144,68 +144,68 @@ msgstr "10 ministères gouvernementaux représentaient 73,2 % des dépenses féd
 msgid "100,000"
 msgstr "100 000"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:194
+#: src/app/[lang]/(main)/federal/spending/page.tsx:195
 #: src/app/[lang]/(main)/spending/page.tsx:185
 msgid "80% of employees are in permanent roles"
 msgstr "80 % des employés occupent des postes permanents"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:37
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:37
 msgid "A look at how Employment and Social Development Canada spends its budget"
 msgstr "Un aperçu de la façon dont Emploi et Développement social Canada dépense son budget"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:34
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:34
 msgid "A look at how Health Canada spends its budget"
 msgstr "Un aperçu de la façon dont Santé Canada dépense son budget"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:35
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:35
 msgid "A look at how Housing, Infrastructure and Communities Canada spends its budget"
 msgstr "Un aperçu de la façon dont Logement, Infrastructure et Collectivités Canada dépense son budget"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:33
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:33
 msgid "A look at how Immigration, Refugees and Citizenship Canada spends its budget"
 msgstr "Un aperçu de la façon dont Immigration, Réfugiés et Citoyenneté Canada dépense son budget"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:36
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:36
 msgid "A look at how Indigenous Services and Northern Affairs Canada spends its budget"
 msgstr "Un aperçu de la façon dont Services aux Autochtones et Affaires du Nord Canada dépense son budget"
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:33
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:33
 msgid "A look at how Innovation, Science and Industry Canada spends its budget"
 msgstr "Un aperçu de la façon dont Innovation, Sciences et Industrie Canada dépense son budget"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:36
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:36
 msgid "A look at how National Defence spends its budget"
 msgstr "Un aperçu de la façon dont la Défense nationale dépense son budget"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:35
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:35
 msgid "A look at how Public Safety Canada spends its budget"
 msgstr "Un aperçu de la façon dont Sécurité publique Canada dépense son budget"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:33
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:33
 msgid "A look at how Public Services and Procurement Canada spends its budget"
 msgstr "Un aperçu de la façon dont Services publics et Approvisionnement Canada dépense son budget"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:35
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:35
 msgid "A look at how the Canada Revenue Agency spends its budget"
 msgstr "Un aperçu de la façon dont l'Agence du revenu du Canada dépense son budget"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:36
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:36
 msgid "A look at how the Department of Finance spends its budget"
 msgstr "Un aperçu de la façon dont le ministère des Finances dépense son budget"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:37
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:37
 msgid "A look at how the Global Affairs Canada spends its budget"
 msgstr "Un aperçu de la façon dont Affaires mondiales Canada dépense son budget"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:34
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:34
 msgid "A look at how Transport Canada spends its budget"
 msgstr "Un aperçu de la façon dont Transports Canada dépense son budget"
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:34
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:34
 msgid "A look at how Veterans Affairs Canada spends its budget"
 msgstr "Un aperçu de la façon dont Anciens Combattants Canada dépense son budget"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:187
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:187
 msgid "A significant portion of GAC's budget supports Canada's international development assistance, with key programs focused on climate adaptation, gender equality, and health initiatives in developing nations. The department also facilitates economic diplomacy and trade agreements that benefit Canadian businesses and secure investment opportunities abroad."
 msgstr "Une partie importante du budget d'AMC soutient l'aide au développement international du Canada, avec des programmes clés axés sur l'adaptation au climat, l'égalité des genres et les initiatives de santé dans les pays en développement. Le ministère facilite également la diplomatie économique et les accords commerciaux qui profitent aux entreprises canadiennes et sécurisent les opportunités d'investissement à l'étranger."
 
@@ -236,36 +236,36 @@ msgstr "Comptes créditeurs, dette à long terme et autres obligations envers de
 msgid "Accumulated Surplus"
 msgstr "Excédent accumulé"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:47
 msgid "Acquisition of Land, Buildings and Works"
 msgstr "Acquisition de terrains, de bâtiments et de travaux"
 
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:47
 msgid "Acquisition of Lands, Buildings and Works"
 msgstr "Acquisition de terrains, de bâtiments et de travaux"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:51
 msgid "Acquisition of Machinery and Equipment"
 msgstr "Acquisition de machines et d'équipement"
 
@@ -277,7 +277,7 @@ msgstr "Ajuster pour l'inflation (dollars de 2025)"
 msgid "Adjust sliders to see how department spending reductions affect the overall Fall 2025 Budget. The Minister of Finance has asked departments to reduce spending by 7.5% in 2026-27, 10% in 2027-28, and 15% in 2028-29."
 msgstr "Ajustez les curseurs pour voir comment les réductions des dépenses ministérielles affectent le budget global de l'automne 2025. Le ministre des Finances a demandé aux ministères de réduire les dépenses de 7,5 % en 2026-27, de 10 % en 2027-28 et de 15 % en 2028-29."
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:205
+#: src/app/[lang]/(main)/federal/spending/page.tsx:206
 #: src/app/[lang]/(main)/spending/page.tsx:196
 msgid "Age"
 msgstr "Âge"
@@ -319,11 +319,11 @@ msgid "All expenses incurred during the fiscal year including program delivery, 
 msgstr "Toutes les dépenses engagées au cours de l'exercice financier, y compris la prestation de programmes, l'administration et les coûts d'immobilisations."
 
 #: src/app/[lang]/(main)/budget/page.tsx:270
-#: src/app/[lang]/(main)/federal/budget/page.tsx:307
+#: src/app/[lang]/(main)/federal/budget/page.tsx:309
 msgid "All government budget data is sourced from official databases, but due to the complexity of these systems, occasional errors may occur despite our best efforts. This page is also based on government memos and leaks, so it is not an official release of the Fall 2025 Budget. We aim to make this information more accessible and accurate, and we welcome feedback. If you notice any issues, please let us know <0>here</0> — we appreciate it and will work to address them promptly."
 msgstr "Toutes les données budgétaires gouvernementales proviennent de bases de données officielles, mais en raison de la complexité de ces systèmes, des erreurs occasionnelles peuvent survenir malgré nos meilleurs efforts. Cette page est également basée sur des notes et des fuites gouvernementales, ce n'est donc pas une publication officielle du budget de l'automne 2025. Nous visons à rendre cette information plus accessible et précise, et nous accueillons vos commentaires. Si vous remarquez des problèmes, veuillez nous en informer <0>ici</0> — nous l'apprécions et nous travaillerons à les résoudre rapidement."
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:278
+#: src/app/[lang]/(main)/federal/spending/page.tsx:279
 #: src/app/[lang]/(main)/spending/page.tsx:269
 #: src/components/JurisdictionPageContent.tsx:507
 msgid "All government spending data is sourced from official databases, but due to the complexity of these systems, occasional errors may occur despite our best efforts. We aim to make this information more accessible and accurate, and we welcome feedback. If you notice any issues, please let us know <0>here</0> — we appreciate it and will work to address them promptly."
@@ -353,8 +353,12 @@ msgstr "Toutes les informations proviennent des bases de données publiques et d
 msgid "All the taxes that apply to your income"
 msgstr "Tous les impôts qui s'appliquent à votre revenu"
 
+#: src/app/[lang]/(main)/login/login-form.tsx:193
+msgid "Already have an account?"
+msgstr "Vous avez déjà un compte?"
+
 #: src/app/[lang]/(main)/budget/page.tsx:62
-#: src/app/[lang]/(main)/federal/budget/page.tsx:62
+#: src/app/[lang]/(main)/federal/budget/page.tsx:63
 msgid "Amount/Change"
 msgstr "Montant/Changement"
 
@@ -376,7 +380,7 @@ msgstr "Paiements d'intérêts annuels sur la dette en cours. Cela représente l
 msgid "Annual municipal spending per {0} resident"
 msgstr "Dépenses municipales annuelles par résident de {0}"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:185
+#: src/app/[lang]/(main)/federal/spending/page.tsx:186
 #: src/app/[lang]/(main)/spending/page.tsx:176
 msgid "Annual payroll"
 msgstr "Masse salariale annuelle"
@@ -423,7 +427,11 @@ msgstr "À la fin de l'exercice financier {fiscalYear}"
 msgid "Assets, liabilities, and net financial position as of the end of fiscal year {fiscalYear}."
 msgstr "Actifs, passifs et situation financière nette à la fin de l'exercice financier {fiscalYear}."
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:178
+#: src/app/[lang]/(main)/login/login-form.tsx:73
+msgid "Authentication failed. Please try again."
+msgstr "L'authentification a échoué. Veuillez réessayer."
+
+#: src/app/[lang]/(main)/federal/spending/page.tsx:179
 #: src/app/[lang]/(main)/spending/page.tsx:169
 msgid "Average annual compensation"
 msgstr "Rémunération annuelle moyenne"
@@ -490,12 +498,12 @@ msgid "Budget"
 msgstr "Budget"
 
 #: src/app/[lang]/(main)/budget/page.tsx:59
-#: src/app/[lang]/(main)/federal/budget/page.tsx:59
+#: src/app/[lang]/(main)/federal/budget/page.tsx:60
 msgid "Budget Impact"
 msgstr "Impact budgétaire"
 
 #: src/app/[lang]/(main)/budget/page.tsx:169
-#: src/app/[lang]/(main)/federal/budget/page.tsx:206
+#: src/app/[lang]/(main)/federal/budget/page.tsx:208
 msgid "Budget Statistics (Projected FY 2025)"
 msgstr "Statistiques budgétaires (exercice 2025 projeté)"
 
@@ -519,20 +527,20 @@ msgstr "Fonds pour la construction communautaire du Canada"
 msgid "Canada Emergency Wage Subsidy"
 msgstr "Subvention salariale d'urgence du Canada"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/MiniSankey.tsx:19
 msgid "Canada health transfer"
 msgstr "Transfert canadien en matière de santé"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:38
 msgid "Canada Revenue Agency"
 msgstr "Agence du revenu du Canada"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:34
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:34
 msgid "Canada Revenue Agency | Canada Spends"
 msgstr "Agence du revenu du Canada | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/MiniSankey.tsx:23
 msgid "Canada social transfer"
 msgstr "Transfert canadien en matière de programmes sociaux"
 
@@ -569,7 +577,7 @@ msgstr "Canada Spends offre un moyen sécurisé aux sources de soumettre des inf
 msgid "Canada Spends, as a project of Build Canada, is funded through donations from our builder network. Donate"
 msgstr "Canada Spends, en tant que projet de Build Canada, est financé par des dons de notre réseau de constructeurs. Faire un don"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:211
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:211
 msgid "Canada Student Loans Program: providing financial aid for post-secondary students."
 msgstr "Programme canadien de prêts aux étudiants : fournir une aide financière aux étudiants de niveau postsecondaire."
 
@@ -582,7 +590,7 @@ msgid "Canada, you need the facts."
 msgstr "Canada, vous avez besoin des faits."
 
 #: src/app/[lang]/(main)/budget/page.tsx:204
-#: src/app/[lang]/(main)/federal/budget/page.tsx:241
+#: src/app/[lang]/(main)/federal/budget/page.tsx:243
 msgid "Capital Investments"
 msgstr "Investissements en capital"
 
@@ -674,7 +682,7 @@ msgstr "Comparez votre fardeau fiscal total dans toutes les provinces et territo
 msgid "Compensation"
 msgstr "Rémunération"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:176
+#: src/app/[lang]/(main)/federal/spending/page.tsx:177
 #: src/app/[lang]/(main)/spending/page.tsx:167
 msgid "Compensation per Employee"
 msgstr "Rémunération par employé"
@@ -699,6 +707,22 @@ msgstr "Connectez-vous avec nous"
 #: src/components/MainLayout/Footer.tsx:54
 msgid "Contact"
 msgstr "Contact"
+
+#: src/app/[lang]/(main)/login/login-form.tsx:130
+msgid "Continue with Discord"
+msgstr "Continuer avec Discord"
+
+#: src/app/[lang]/(main)/login/login-form.tsx:110
+msgid "Continue with GitHub"
+msgstr "Continuer avec GitHub"
+
+#: src/app/[lang]/(main)/login/login-form.tsx:100
+msgid "Continue with Google"
+msgstr "Continuer avec Google"
+
+#: src/app/[lang]/(main)/login/login-form.tsx:120
+msgid "Continue with X"
+msgstr "Continuer avec X"
 
 #: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:257
 msgid "Contributing Organization"
@@ -733,19 +757,19 @@ msgstr "Pays"
 msgid "COVID-19 Income Support"
 msgstr "Soutien au revenu COVID-19"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:187
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:187
 msgid "CRA spending is divided across tax administration, compliance enforcement, benefit program delivery, and intergovernmental agreements with provinces and territories. The largest expenditures in FY 2024 included personal income tax processing, corporate tax audits, and benefit administration."
 msgstr "Les dépenses de l'ARC sont réparties entre l'administration fiscale, l'application de la conformité, la prestation de programmes de prestations et les accords intergouvernementaux avec les provinces et les territoires. Les plus importantes dépenses au cours de l'exercice 2024 comprenaient le traitement de l'impôt sur le revenu des particuliers, les vérifications de l'impôt des sociétés et l'administration des prestations."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:197
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:197
 msgid "CRA spending isolated to FY 2024"
 msgstr "Dépenses de l'ARC isolées pour l'exercice 2024"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:141
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:141
 msgid "CRA's share of federal spending in FY 2024 was higher than in FY 1995"
 msgstr "La part des dépenses fédérales de l'ARC en 2024 était plus élevée qu'en 1995"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:121
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:121
 msgid "CRA's spending grew more than overall spending, meaning its share of the federal budget increased. In 2024, the agency accounted for 3.2% of all federal spending, 1.85 percentage points higher than in 1995."
 msgstr "Les dépenses de l'ARC ont augmenté plus que les dépenses globales, ce qui signifie que sa part du budget fédéral a augmenté. En 2024, l'agence représentait 3,2 % de toutes les dépenses fédérales, soit 1,85 point de pourcentage de plus qu'en 1995."
 
@@ -770,23 +794,23 @@ msgstr "Droits de douane"
 msgid "Customs Import Duties"
 msgstr "Droits de douane à l'importation"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:68
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:68
 msgid "Data updated March 20, 2025"
 msgstr "Données mises à jour le 20 mars 2025"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:69
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:70
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:76
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:74
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:76
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:63
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:81
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:64
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:71
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:68
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:66
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:64
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:66
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:69
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:70
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:76
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:74
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:76
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:63
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:81
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:64
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:71
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:68
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:66
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:64
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:66
 msgid "Data updated March 21, 2025"
 msgstr "Données mises à jour le 21 mars 2025"
 
@@ -807,7 +831,7 @@ msgid "Defence Team"
 msgstr "Équipe de la défense"
 
 #: src/app/[lang]/(main)/budget/page.tsx:215
-#: src/app/[lang]/(main)/federal/budget/page.tsx:252
+#: src/app/[lang]/(main)/federal/budget/page.tsx:254
 msgid "Deficit"
 msgstr "Déficit"
 
@@ -816,19 +840,19 @@ msgstr "Déficit"
 msgid "Department"
 msgstr "Ministère"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/MiniSankey.tsx:16
 msgid "Department of Finance"
 msgstr "Ministère des Finances"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:35
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:35
 msgid "Department of Finance | Canada Spends"
 msgstr "Ministère des Finances | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:188
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:188
 msgid "Department of Finance, Spending by Entity, FY 2024 (in millions)"
 msgstr "Ministère des Finances, Dépenses par entité, exercice 2024 (en millions)"
 
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:16
 msgid "Department of National Defence"
 msgstr "Ministère de la Défense nationale"
 
@@ -841,12 +865,12 @@ msgstr "Dépenses du ministère"
 msgid "Department Spending Reductions"
 msgstr "Réductions des dépenses ministérielles"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:230
+#: src/app/[lang]/(main)/federal/spending/page.tsx:231
 #: src/app/[lang]/(main)/spending/page.tsx:221
 msgid "Departments + Agencies"
 msgstr "Ministères + Organismes"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:125
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:125
 msgid "Despite these increases, significant challenges remain in areas such as housing, healthcare access, and infrastructure in remote Indigenous communities."
 msgstr "Malgré ces augmentations, des défis importants subsistent dans des domaines tels que le logement, l'accès aux soins de santé et l'infrastructure dans les communautés autochtones éloignées."
 
@@ -854,7 +878,7 @@ msgstr "Malgré ces augmentations, des défis importants subsistent dans des dom
 msgid "Development, Peace + Security Programming"
 msgstr "Programmation du développement, de la paix + de la sécurité"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:177
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:177
 msgid "Development, Peace and Security Programming: $5.37B"
 msgstr "Programmation du développement, de la paix et de la sécurité : 5,37 G$"
 
@@ -862,7 +886,7 @@ msgstr "Programmation du développement, de la paix et de la sécurité : 5,37 G
 msgid "Direct program expenses"
 msgstr "Dépenses directes des programmes"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:160
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:160
 msgid "Direct spending refers to money allocated to government programs, employee salaries, and administrative expenses. Indirect spending includes federal transfers to individuals and provinces."
 msgstr "Les dépenses directes font référence à l'argent alloué aux programmes gouvernementaux, aux salaires des employés et aux dépenses administratives. Les dépenses indirectes comprennent les transferts fédéraux aux particuliers et aux provinces."
 
@@ -874,13 +898,17 @@ msgstr "Secours aux sinistrés"
 msgid "Discipline"
 msgstr "Discipline"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:134
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:134
 msgid "DND's spending grew less than overall spending, meaning its share of the federal budget decreased. In 2024, the department accounted for 6.7% of all federal spending, 0.6 percentage points lower than in 1995."
 msgstr "Les dépenses du MDN ont augmenté moins que les dépenses globales, ce qui signifie que sa part du budget fédéral a diminué. En 2024, le ministère représentait 6,7 % de toutes les dépenses fédérales, soit 0,6 point de pourcentage de moins qu'en 1995."
 
 #: src/app/[lang]/(main)/whistleblowers/page.tsx:181
 msgid "Do not discuss your submission with anyone or search for related topics on work devices."
 msgstr "Ne discutez pas de votre soumission avec quiconque et ne recherchez pas de sujets connexes sur des appareils professionnels."
+
+#: src/app/[lang]/(main)/login/login-form.tsx:203
+msgid "Don't have an account?"
+msgstr "Vous n'avez pas de compte?"
 
 #: src/app/[lang]/(main)/whistleblowers/page.tsx:104
 msgid "Download and install the <0>Tor Browser</0> from the official Tor Project website."
@@ -926,6 +954,10 @@ msgstr "Taux effectif"
 msgid "Effective tax rate"
 msgstr "Taux d'imposition effectif"
 
+#: src/app/[lang]/(main)/login/login-form.tsx:151
+msgid "Email"
+msgstr "Courriel"
+
 #: src/app/[lang]/(main)/contact/page.tsx:44
 msgid "Email us at <0>hi@buildcanada.com</0> or connect with us on X <1>@canada_spends</1> and we'll get back to you as soon as we can."
 msgstr "Envoyez-nous un courriel à <0>hi@buildcanada.com</0> ou connectez-vous avec nous sur X <1>@canada_spends</1> et nous vous répondrons dès que possible."
@@ -942,7 +974,7 @@ msgstr "Emploi + Formation"
 msgid "Employment and Social Development Canada"
 msgstr "Emploi et Développement social Canada"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:36
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:36
 msgid "Employment and Social Development Canada | Canada Spends"
 msgstr "Emploi et Développement social Canada | Canada Spends"
 
@@ -977,46 +1009,46 @@ msgstr "Environnement et Changement climatique"
 msgid "Equalization Payments to Provinces"
 msgstr "Paiements de péréquation aux provinces"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:16
 msgid "ESDC"
 msgstr "EDSC"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:95
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:95
 msgid "ESDC accounted for 18.4% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024."
 msgstr "EDSC représentait 18,4 % de toutes les dépenses fédérales pour l'exercice 2024. 10 ministères gouvernementaux représentaient 73,2 % des dépenses fédérales pour l'exercice 2024."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:88
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:88
 msgid "ESDC spent $94.48 billion in fiscal year (FY) 2024. This was 18.4% of the $513.9 billion in overall federal spending, making it one of the highest-spending federal departments."
 msgstr "EDSC a dépensé 94,48 milliards de dollars au cours de l'exercice 2024. Cela représentait 18,4 % des 513,9 milliards de dollars de dépenses fédérales totales, ce qui en fait l'un des ministères fédéraux aux dépenses les plus élevées."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:197
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:197
 msgid "ESDC, Spending by Entity, FY 2024"
 msgstr "EDSC, Dépenses par entité, exercice 2024"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:179
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:179
 msgid "ESDC's share of federal spending in FY 2024"
 msgstr "Part des dépenses fédérales d'EDSC pour l'exercice 2024"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:141
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:141
 msgid "ESDC's share of federal spending in FY 2024 was lower than FY 1995"
 msgstr "La part des dépenses fédérales d'EDSC en 2024 était inférieure à celle de 1995"
 
 #: src/app/[lang]/(main)/budget/page.tsx:217
-#: src/app/[lang]/(main)/federal/budget/page.tsx:254
+#: src/app/[lang]/(main)/federal/budget/page.tsx:256
 msgid "Est. projected budget deficit"
 msgstr "Déficit budgétaire projeté estimé"
 
 #: src/app/[lang]/(main)/budget/page.tsx:177
-#: src/app/[lang]/(main)/federal/budget/page.tsx:214
+#: src/app/[lang]/(main)/federal/budget/page.tsx:216
 msgid "Est. projected government budget"
 msgstr "Budget gouvernemental projeté estimé"
 
 #: src/app/[lang]/(main)/budget/page.tsx:186
-#: src/app/[lang]/(main)/federal/budget/page.tsx:223
+#: src/app/[lang]/(main)/federal/budget/page.tsx:225
 msgid "Est. projected government revenue"
 msgstr "Revenus gouvernementaux projetés estimés"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:57
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:57
 msgid "Established in 2005, ESDC is a federal department responsible for supporting Canadians through social programs and workforce development. It administers key programs such as Employment Insurance (EI), the Canada Pension Plan (CPP), Old Age Security (OAS), and skills training initiatives. ESDC also oversees Service Canada, which delivers government services directly to the public."
 msgstr "Établi en 2005, EDSC est un ministère fédéral responsable du soutien aux Canadiens par le biais de programmes sociaux et de développement de la main-d'œuvre. Il administre des programmes clés tels que l'assurance-emploi (AE), le Régime de pensions du Canada (RPC), la Sécurité de la vieillesse (SV) et des initiatives de formation professionnelle. EDSC supervise également Service Canada, qui fournit des services gouvernementaux directement au public."
 
@@ -1076,12 +1108,12 @@ msgstr "Dépenses"
 msgid "Explore Canada's federal budget with interactive visualizations and detailed analysis of government revenue and expenditures."
 msgstr "Explorez le budget fédéral du Canada avec des visualisations interactives et une analyse détaillée des revenus et dépenses gouvernementales."
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:250
+#: src/app/[lang]/(main)/federal/spending/page.tsx:251
 #: src/app/[lang]/(main)/spending/page.tsx:241
 msgid "Explore federal employee salary distribution by year and demographic group"
 msgstr "Explorez la répartition des salaires des employés fédéraux par année et groupe démographique"
 
-#: src/components/HeroButtons.tsx:34
+#: src/components/HeroButtons.tsx:37
 msgid "Explore Federal Spending"
 msgstr "Explorer les dépenses fédérales"
 
@@ -1097,7 +1129,7 @@ msgstr "Explorez les données financières des Premières Nations à travers le 
 msgid "Explore financial data from First Nations across Canada. View statements of operations, financial positions, and remuneration from annual reports published under the First Nations Financial Transparency Act (FNFTA)."
 msgstr "Explorez les données financières des Premières Nations à travers le Canada. Consultez les états des résultats, les situations financières et la rémunération à partir des rapports annuels publiés en vertu de la Loi sur la transparence financière des Premières Nations (LTFPN)."
 
-#: src/components/HeroButtons.tsx:107
+#: src/components/HeroButtons.tsx:110
 msgid "Explore First Nations Spending"
 msgstr "Explorer les dépenses des Premières Nations"
 
@@ -1109,32 +1141,32 @@ msgstr "Découvrez comment le gouvernement fédéral canadien dépense vos impô
 msgid "Explore in-depth articles about Canadian government spending, budget analysis, and public finance. Stay informed about how your tax dollars are used through Canada Spends."
 msgstr "Explorez des articles approfondis sur les dépenses gouvernementales canadiennes, l'analyse budgétaire et les finances publiques. Restez informé de l'utilisation de vos dollars d'impôt grâce à Canada Spends."
 
-#: src/components/HeroButtons.tsx:70
+#: src/components/HeroButtons.tsx:73
 msgid "Explore Municipal Spending"
 msgstr "Explorer les dépenses municipales"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:239
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:230
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:258
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:277
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:199
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:210
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:194
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:227
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:194
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:241
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:191
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:201
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:199
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:199
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:239
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:230
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:258
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:277
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:199
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:210
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:194
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:227
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:194
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:241
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:191
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:201
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:199
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:199
 msgid "Explore other Federal Departments"
 msgstr "Explorer d'autres ministères fédéraux"
 
-#: src/components/HeroButtons.tsx:43
+#: src/components/HeroButtons.tsx:46
 msgid "Explore Provincial Spending"
 msgstr "Explorer les dépenses provinciales"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:134
+#: src/app/[lang]/(main)/federal/spending/page.tsx:135
 #: src/app/[lang]/(main)/spending/page.tsx:125
 msgid "Explore revenue and spending categories or filter by agency for deeper insights."
 msgstr "Explorez les catégories de revenus et de dépenses ou filtrez par organisme pour des analyses plus approfondies."
@@ -1143,16 +1175,16 @@ msgstr "Explorez les catégories de revenus et de dépenses ou filtrez par organ
 msgid "External ID"
 msgstr "ID externe"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:67
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:67
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:67
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:67
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:67
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:67
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:67
 msgid "External Revenues"
 msgstr "Revenus externes"
 
@@ -1175,48 +1207,48 @@ msgstr "Fédéral"
 msgid "Federal Budget 2025 | Canada Spends"
 msgstr "Budget fédéral 2025 | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:178
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:178
 msgid "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, Department of Finance entities with the highest expenditures were the Office of the Superintendent of Financial Institutions, Office of the Auditor General, and the Financial Transactions and Reports Analysis Centre of Canada."
 msgstr "Les ministères fédéraux comprennent souvent d'autres entités, notamment des bureaux, des sociétés d'État et des organismes. Au cours de l'exercice 2024, les entités du ministère des Finances ayant les dépenses les plus élevées étaient le Bureau du surintendant des institutions financières, le Bureau du vérificateur général et le Centre d'analyse des opérations et déclarations financières du Canada."
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:158
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:158
 msgid "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, HICC entities with the highest expenditures were Office of Infrastructure Canada, the Canada Mortgage and Housing Corporation and the Windsor-Detroit Bridge Authority."
 msgstr "Les ministères fédéraux comprennent souvent d'autres entités, notamment des bureaux, des sociétés d'État et des organismes. Au cours de l'exercice 2024, les entités de LICC ayant les dépenses les plus élevées étaient le Bureau d'Infrastructure Canada, la Société canadienne d'hypothèques et de logement et l'Autorité du pont Windsor-Detroit."
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:151
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:151
 msgid "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, IRCC reported total expenditures of $6.2 billion, broken out as follows:"
 msgstr "Les ministères fédéraux comprennent souvent d'autres entités, notamment des bureaux, des sociétés d'État et des organismes. Au cours de l'exercice 2024, IRCC a déclaré des dépenses totales de 6,2 milliards de dollars, réparties comme suit :"
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:153
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:153
 msgid "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, ISED's budget was split across the following entities:"
 msgstr "Les ministères fédéraux comprennent souvent d'autres entités, notamment des bureaux, des sociétés d'État et des organismes. Au cours de l'exercice 2024, le budget d'ISDE était réparti entre les entités suivantes :"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:159
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:159
 msgid "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, PSPC's budget was split across the following entities:"
 msgstr "Les ministères fédéraux comprennent souvent d'autres entités, notamment des bureaux, des sociétés d'État et des organismes. Au cours de l'exercice 2024, le budget de SPAC était réparti entre les entités suivantes :"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:152
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:152
 msgid "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, Transport Canada reported total expenditures of $5.1 billion across the following entities:"
 msgstr "Les ministères fédéraux comprennent souvent d'autres entités, notamment des bureaux, des sociétés d'État et des organismes. Au cours de l'exercice 2024, Transports Canada a déclaré des dépenses totales de 5,1 milliards de dollars réparties entre les entités suivantes :"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:152
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:152
 msgid "Federal departments often contain other entities including offices, crown corporations and agencies. The Health Canada entities with the biggest expenditures in FY 2024 were"
 msgstr "Les ministères fédéraux comprennent souvent d'autres entités, notamment des bureaux, des sociétés d'État et des organismes. Les entités de Santé Canada ayant les dépenses les plus élevées au cours de l'exercice 2024 étaient"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:208
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:208
 msgid "Federal departments often contain other entities. In FY 2024, Global Affairs Canada's entities with the highest expenditures were:"
 msgstr "Les ministères fédéraux comprennent souvent d'autres entités. Au cours de l'exercice 2024, les entités d'Affaires mondiales Canada ayant les dépenses les plus élevées étaient :"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:194
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:194
 msgid "Federal departments often include additional agencies, commands, and operational divisions. In FY 2024, the largest spending entities within DND were the Canadian Army, the Royal Canadian Navy, and the Royal Canadian Air Force, accounting for the bulk of military expenditures."
 msgstr "Les ministères fédéraux comprennent souvent des agences supplémentaires, des commandements et des divisions opérationnelles. Au cours de l'exercice 2024, les entités ayant les dépenses les plus importantes au sein du MDN étaient l'Armée canadienne, la Marine royale canadienne et l'Aviation royale canadienne, représentant la majeure partie des dépenses militaires."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:190
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:190
 msgid "Federal departments often include multiple agencies and service delivery arms. In FY 2024, ESDC's highest-expenditure entities included:"
 msgstr "Les ministères fédéraux comprennent souvent plusieurs agences et organes de prestation de services. Au cours de l'exercice 2024, les entités d'EDSC ayant les dépenses les plus élevées comprenaient :"
 
 #: src/app/[lang]/(main)/budget/page.tsx:156
-#: src/app/[lang]/(main)/federal/budget/page.tsx:183
+#: src/app/[lang]/(main)/federal/budget/page.tsx:185
 msgid "Federal Fall 2025 Government Budget"
 msgstr "Budget gouvernemental fédéral de l'automne 2025"
 
@@ -1224,78 +1256,78 @@ msgstr "Budget gouvernemental fédéral de l'automne 2025"
 msgid "Federal Government Spending | Canada Spends"
 msgstr "Dépenses du gouvernement fédéral | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:170
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:197
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:173
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:170
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:197
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:173
 msgid "Federal government spending in FY 2024"
 msgstr "Dépenses du gouvernement fédéral pour l'exercice 2024"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:140
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:142
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:148
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:141
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:144
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:140
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:142
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:148
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:141
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:144
 msgid "Federal government spending isolated to FY 2024"
 msgstr "Dépenses du gouvernement fédéral isolées pour l'exercice 2024"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:232
+#: src/app/[lang]/(main)/federal/spending/page.tsx:233
 #: src/app/[lang]/(main)/spending/page.tsx:223
 msgid "Federal organizations"
 msgstr "Organisations fédérales"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:120
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:120
 msgid "Federal spending may shift over time due to changing global circumstances, diplomatic priorities, and Canada's economic relationships. Since 1995, overall federal spending has increased by 74.9%, while Global Affairs Canada's budget has grown by 166.5%, reflecting an expansion in international engagement."
 msgstr "Les dépenses fédérales peuvent évoluer au fil du temps en raison de l'évolution des circonstances mondiales, des priorités diplomatiques et des relations économiques du Canada. Depuis 1995, les dépenses fédérales globales ont augmenté de 74,9 %, tandis que le budget d'Affaires mondiales Canada a augmenté de 166,5 %, reflétant une expansion de l'engagement international."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:113
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:113
 msgid "Federal spending may shift over time due to economic fluctuations, changes in tax policy, and the expansion of benefit programs. Since 1995, overall federal spending has risen 74.9%, while Canada Revenue Agency spending has increased 302%"
 msgstr "Les dépenses fédérales peuvent évoluer au fil du temps en raison des fluctuations économiques, des changements dans la politique fiscale et de l'expansion des programmes de prestations. Depuis 1995, les dépenses fédérales globales ont augmenté de 74,9 %, tandis que les dépenses de l'Agence du revenu du Canada ont augmenté de 302 %"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:126
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:126
 msgid "Federal spending may shift over time due to geopolitical tensions, defence modernization needs, and emerging threats such as cyber warfare. Since 1995, overall federal spending has risen 74.9%, while Department of National Defence spending has increased 59.9%."
 msgstr "Les dépenses fédérales peuvent évoluer au fil du temps en raison des tensions géopolitiques, des besoins de modernisation de la défense et des menaces émergentes telles que la cyberguerre. Depuis 1995, les dépenses fédérales globales ont augmenté de 74,9 %, tandis que les dépenses du ministère de la Défense nationale ont augmenté de 59,9 %."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:105
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:105
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging challenges. Since 2005, when ESDC was first established, overall federal spending has risen 62.9%, while ESDC spending has increased 1,485%."
 msgstr "Les dépenses fédérales peuvent évoluer au fil du temps en raison de la croissance démographique, des changements dans les politiques et les programmes, et des défis émergents. Depuis 2005, lorsque EDSC a été créé, les dépenses fédérales globales ont augmenté de 62,9 %, tandis que les dépenses d'EDSC ont augmenté de 1 485 %."
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:115
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:115
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging challenges. Since FY 1995, overall federal spending has risen 74.9%, while Health Canada spending has decreased 19.9% when adjusted for inflation."
 msgstr "Les dépenses fédérales peuvent évoluer au fil du temps en raison de la croissance démographique, des changements dans les politiques et les programmes, et des défis émergents. Depuis l'exercice 1995, les dépenses fédérales globales ont augmenté de 74,9 %, tandis que les dépenses de Santé Canada ont diminué de 19,9 % après ajustement pour l'inflation."
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:117
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:117
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address."
 msgstr "Les dépenses fédérales peuvent évoluer au fil du temps en raison de la croissance démographique, des changements dans les politiques et les programmes, et des problèmes émergents à résoudre."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:112
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:112
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 74.9%, while Department of Finance spending has increased 41.4%."
 msgstr "Les dépenses fédérales peuvent évoluer au fil du temps en raison de la croissance démographique, des changements dans les politiques et les programmes, et des problèmes émergents à résoudre. Depuis 1995, les dépenses fédérales globales ont augmenté de 74,9 %, tandis que les dépenses du ministère des Finances ont augmenté de 41,4 %."
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:101
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:101
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 74.9%, while IRCC spending has increased 428% (adjusted for inflation)."
 msgstr "Les dépenses fédérales peuvent évoluer au fil du temps en raison de la croissance démographique, des changements dans les politiques et les programmes, et des problèmes émergents à résoudre. Depuis 1995, les dépenses fédérales globales ont augmenté de 74,9 %, tandis que les dépenses d'IRCC ont augmenté de 428 % (ajustées pour l'inflation)."
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:103
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:103
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 74.9%, while ISED spending has increased 90.3%."
 msgstr "Les dépenses fédérales peuvent évoluer au fil du temps en raison de la croissance démographique, des changements dans les politiques et les programmes, et des problèmes émergents à résoudre. Depuis 1995, les dépenses fédérales globales ont augmenté de 74,9 %, tandis que les dépenses d'ISDE ont augmenté de 90,3 %."
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:104
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:104
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 74.9%, while PSPC spending has increased by 7.1% when adjusted for inflation."
 msgstr "Les dépenses fédérales peuvent évoluer au fil du temps en raison de la croissance démographique, des changements dans les politiques et les programmes, et des problèmes émergents à résoudre. Depuis 1995, les dépenses fédérales globales ont augmenté de 74,9 %, tandis que les dépenses de SPAC ont augmenté de 7,1 % après ajustement pour l'inflation."
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:104
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:104
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 74.9%, while Transport spending has remained relatively flat."
 msgstr "Les dépenses fédérales peuvent évoluer au fil du temps en raison de la croissance démographique, des changements dans les politiques et les programmes, et des problèmes émergents à résoudre. Depuis 1995, les dépenses fédérales globales ont augmenté de 74,9 %, tandis que les dépenses de Transport sont restées relativement stables."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:105
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:105
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 77%, while VAC spending has increased 51%."
 msgstr "Les dépenses fédérales peuvent évoluer au fil du temps en raison de la croissance démographique, des changements dans les politiques et les programmes, et des problèmes émergents à résoudre. Depuis 1995, les dépenses fédérales globales ont augmenté de 77 %, tandis que les dépenses d'ACC ont augmenté de 51 %."
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:114
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:114
 msgid "Federal spending on Indigenous priorities may fluctuate over time due to population growth, policy shifts, and emerging challenges such as climate change and infrastructure deficits. Since 1995, total federal spending has risen by 74.9%, while spending on Indigenous priorities has increased by 592%, reflecting expanded program commitments and new governance agreements and claim settlements."
 msgstr "Les dépenses fédérales consacrées aux priorités autochtones peuvent fluctuer au fil du temps en raison de la croissance démographique, des changements de politique et des défis émergents tels que le changement climatique et les déficits d'infrastructure. Depuis 1995, les dépenses fédérales totales ont augmenté de 74,9 %, tandis que les dépenses consacrées aux priorités autochtones ont augmenté de 592 %, reflétant l'expansion des engagements de programme et de nouveaux accords de gouvernance et règlements de revendications."
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:113
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:113
 msgid "Federal spending on public safety fluctuates based on evolving security threats, emergency events, and changes in government policy. Since 2005 shortly after it was established, Public Safety Canada's expenditures have increased by 69.6%, reflecting heightened investments in counterterrorism, cyber defence, and disaster response capabilities. The department's share of the federal budget has remained relatively flat from 2.6% in 2005 to 2.7% in 2024."
 msgstr "Les dépenses fédérales en matière de sécurité publique fluctuent en fonction de l'évolution des menaces pour la sécurité, des événements d'urgence et des changements dans la politique gouvernementale. Depuis 2005, peu après sa création, les dépenses de Sécurité publique Canada ont augmenté de 69,6 %, reflétant des investissements accrus dans les capacités de lutte contre le terrorisme, de cyberdéfense et d'intervention en cas de catastrophe. La part du ministère dans le budget fédéral est restée relativement stable, passant de 2,6 % en 2005 à 2,7 % en 2024."
 
@@ -1398,7 +1430,7 @@ msgstr "Aperçu de la rémunération des Premières Nations"
 msgid "First Nations Remuneration Overview | Canada Spends"
 msgstr "Aperçu de la rémunération des Premières Nations | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/MiniSankey.tsx:27
 msgid "Fiscal arrangements"
 msgstr "Arrangements fiscaux"
 
@@ -1420,7 +1452,7 @@ msgstr "Pêches + Écosystèmes aquatiques"
 msgid "Food Safety"
 msgstr "Sécurité alimentaire"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:130
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:130
 msgid "For example, during the COVID-19 pandemic, federal support programs led to a temporary surge in spending. ESDC expenditures increased from $63.3 billion in 2019 to $169.2 billion in 2021 before stabilizing in recent years."
 msgstr "Par exemple, pendant la pandémie de COVID-19, les programmes de soutien fédéraux ont entraîné une augmentation temporaire des dépenses. Les dépenses d'EDSC sont passées de 63,3 milliards de dollars en 2019 à 169,2 milliards de dollars en 2021 avant de se stabiliser ces dernières années."
 
@@ -1452,16 +1484,16 @@ msgstr "Conception des forces futures"
 msgid "FY"
 msgstr "EF"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:131
+#: src/app/[lang]/(main)/federal/spending/page.tsx:132
 #: src/app/[lang]/(main)/spending/page.tsx:122
 msgid "FY 2024 Government Revenue and Spending"
 msgstr "Revenus et dépenses du gouvernement pour l'exercice 2024"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:103
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:103
 msgid "GAC accounted for 3.7% of all federal spending in FY 2024."
 msgstr "AMC représentait 3,7 % de toutes les dépenses fédérales pour l'exercice 2024."
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:165
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:165
 msgid "GAC's expenditures are divided across five primary categories:"
 msgstr "Les dépenses d'AMC sont réparties en cinq catégories principales :"
 
@@ -1469,7 +1501,7 @@ msgstr "Les dépenses d'AMC sont réparties en cinq catégories principales :"
 msgid "Gender Equality"
 msgstr "Égalité des genres"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:123
+#: src/app/[lang]/(main)/federal/spending/page.tsx:124
 #: src/app/[lang]/(main)/spending/page.tsx:114
 msgid "Get data-driven insights into how governmental revenue and spending affect Canadian lives and programs."
 msgstr "Obtenez des analyses basées sur les données sur la façon dont les revenus et les dépenses gouvernementaux affectent la vie des Canadiens et les programmes."
@@ -1494,28 +1526,28 @@ msgstr "Découvrez les faits sur les dépenses gouvernementales"
 msgid "Get weekly recaps of current events and updates from our team."
 msgstr "Recevez des résumés hebdomadaires des événements actuels et des mises à jour de notre équipe."
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:32
 msgid "Global Affairs Canada"
 msgstr "Affaires mondiales Canada"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:55
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:55
 msgid "Global Affairs Canada (GAC) is the federal department responsible for managing Canada's diplomatic relations, international trade, and development assistance. Established in 1909 as the Department of External Affairs, GAC has evolved to oversee Canada's engagement in global affairs, promoting national interests abroad and ensuring the protection of Canadian citizens overseas. The department negotiates international agreements, administers trade policies, and provides humanitarian aid. Additionally, it supports Canadian businesses in expanding internationally and strengthens diplomatic ties through multilateral organizations like the United Nations, the World Trade Organization (WTO), and NATO. GAC also plays a critical role in crisis response, assisting Canadians abroad during emergencies, and fostering global security and stability."
 msgstr "Affaires mondiales Canada (AMC) est le ministère fédéral responsable de la gestion des relations diplomatiques du Canada, du commerce international et de l'aide au développement. Établi en 1909 sous le nom de ministère des Affaires extérieures, AMC a évolué pour superviser l'engagement du Canada dans les affaires mondiales, promouvoir les intérêts nationaux à l'étranger et assurer la protection des citoyens canadiens à l'étranger. Le ministère négocie des accords internationaux, administre les politiques commerciales et fournit de l'aide humanitaire. De plus, il soutient les entreprises canadiennes dans leur expansion internationale et renforce les liens diplomatiques par le biais d'organisations multilatérales comme les Nations Unies, l'Organisation mondiale du commerce (OMC) et l'OTAN. AMC joue également un rôle crucial dans la réponse aux crises, aidant les Canadiens à l'étranger lors d'urgences et favorisant la sécurité et la stabilité mondiales."
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:36
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:36
 msgid "Global Affairs Canada | Canada Spends"
 msgstr "Affaires mondiales Canada | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:227
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:227
 msgid "Global Affairs Canada is led by two ministers appointed by the Prime Minister and formally sworn into office at Rideau Hall. The department's leadership includes:"
 msgstr "Affaires mondiales Canada est dirigé par deux ministres nommés par le premier ministre et officiellement assermentés à Rideau Hall. La direction du ministère comprend :"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:94
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:94
 msgid "Global Affairs Canada spent $19.2 billion in fiscal year (FY) 2024, representing 3.7% of the $513.9 billion in overall federal spending. This placed GAC among the mid-sized federal departments in terms of total expenditures."
 msgstr "Affaires mondiales Canada a dépensé 19,2 milliards de dollars au cours de l'exercice 2024, représentant 3,7 % des 513,9 milliards de dollars de dépenses fédérales totales. Cela place AMC parmi les ministères fédéraux de taille moyenne en termes de dépenses totales."
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:216
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:216
 msgid "Global Affairs Canada, Spending by Entity, FY 2024"
 msgstr "Affaires mondiales Canada, Dépenses par entité, exercice 2024"
 
@@ -1532,13 +1564,13 @@ msgstr "Taxe sur les produits et services"
 msgid "Gottfriedson Band Class Settlement"
 msgstr "Règlement du recours collectif de la bande Gottfriedson"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:269
+#: src/app/[lang]/(main)/federal/spending/page.tsx:270
 #: src/app/[lang]/(main)/spending/page.tsx:260
 msgid "Government Departments explained"
 msgstr "Explication des ministères gouvernementaux"
 
 #: src/app/[lang]/(main)/budget/page.tsx:261
-#: src/app/[lang]/(main)/federal/budget/page.tsx:298
+#: src/app/[lang]/(main)/federal/budget/page.tsx:300
 msgid "Government Departments Explained"
 msgstr "Ministères gouvernementaux expliqués"
 
@@ -1550,7 +1582,7 @@ msgstr "Opérations informatiques gouvernementales"
 msgid "Government organizations"
 msgstr "Organisations gouvernementales"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:120
+#: src/app/[lang]/(main)/federal/spending/page.tsx:121
 #: src/app/[lang]/(main)/spending/page.tsx:111
 msgid "Government Spending"
 msgstr "Dépenses gouvernementales"
@@ -1568,7 +1600,7 @@ msgstr "Les dépenses gouvernementales ne devraient pas être une boîte noire. 
 msgid "Government spending shouldn't be a black box. We turn complex data into clear, non-partisan insights so every Canadian knows where their money goes."
 msgstr "Les dépenses gouvernementales ne devraient pas être une boîte noire. Nous transformons des données complexes en analyses claires et non partisanes pour que chaque Canadien sache où va son argent."
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:165
+#: src/app/[lang]/(main)/federal/spending/page.tsx:166
 #: src/app/[lang]/(main)/spending/page.tsx:156
 msgid "Government Workforce"
 msgstr "Effectif gouvernemental"
@@ -1593,7 +1625,7 @@ msgstr "Groupe"
 msgid "Have questions or feedback? Email us at hi@canadaspends.com or connect with us on X @canada_spends - we'd love to hear from you!"
 msgstr "Vous avez des questions ou des commentaires? Envoyez-nous un courriel à hi@canadaspends.com ou connectez-vous avec nous sur X @canada_spends - nous aimerions avoir de vos nouvelles!"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:169
+#: src/app/[lang]/(main)/federal/spending/page.tsx:170
 #: src/app/[lang]/(main)/spending/page.tsx:160
 msgid "Headcount"
 msgstr "Effectif"
@@ -1606,28 +1638,28 @@ msgstr "Santé"
 msgid "Health agreements with provinces and territories"
 msgstr "Accords de santé avec les provinces et les territoires"
 
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:56
 msgid "Health Canada"
 msgstr "Santé Canada"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:33
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:33
 msgid "Health Canada | Canada Spends"
 msgstr "Santé Canada | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:101
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:101
 msgid "Health Canada accounted for 2.7% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 msgstr "Santé Canada représentait 2,7 % des dépenses fédérales totales pour l'exercice 2024. 10 ministères gouvernementaux représentaient 73,2 % des dépenses fédérales pour l'exercice 2024"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:170
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:170
 msgid "Health Canada is led by the <0>Minister of Health</0>, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 msgstr "Santé Canada est dirigé par le <0>ministre de la Santé</0>, qui est nommé par le gouverneur général sur l'avis du premier ministre et officiellement assermenté à Rideau Hall. Lors de sa nomination, le ministre prête le serment d'office et le serment d'allégeance, devenant membre du Conseil privé du Roi pour le Canada."
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:51
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:51
 msgid "Health Canada is the federal department responsible for protecting and improving the health of Canadians. It develops health policies, regulates pharmaceuticals and medical devices, enforces food safety standards, and funds public health programs. The department works with provinces and territories to support the healthcare system while ensuring safety standards for drugs, consumer products, and nutrition guidelines."
 msgstr "Santé Canada est le ministère fédéral responsable de la protection et de l'amélioration de la santé des Canadiens. Il élabore des politiques de santé, réglemente les produits pharmaceutiques et les dispositifs médicaux, applique les normes de sécurité alimentaire et finance des programmes de santé publique. Le ministère collabore avec les provinces et les territoires pour soutenir le système de santé tout en assurant le respect des normes de sécurité pour les médicaments, les produits de consommation et les directives en matière de nutrition."
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:92
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:92
 msgid "Health Canada spent $13.7 billion in fiscal year (FY) 2024. This was 2.7% of the $513.9 billion in overall federal spending. The department ranked tenth among federal departments in total spending."
 msgstr "Santé Canada a dépensé 13,7 milliards de dollars au cours de l'exercice 2024. Cela représentait 2,7 % des 513,9 milliards de dollars de dépenses fédérales totales. Le ministère s'est classé dixième parmi les ministères fédéraux en termes de dépenses totales."
 
@@ -1644,23 +1676,23 @@ msgstr "Recherche en santé"
 msgid "Health Transfer to Provinces"
 msgstr "Transfert en matière de santé aux provinces"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:180
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:180
 msgid "Help for Canadians Abroad: $85.98M"
 msgstr "Aide aux Canadiens à l'étranger : 85,98 M$"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:16
 msgid "HICC"
 msgstr "LICC"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:102
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:102
 msgid "HICC accounted for 2.8% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024."
 msgstr "LICC représentait 2,8 % des dépenses fédérales totales pour l'exercice 2024. 10 ministères gouvernementaux représentaient 73,2 % des dépenses fédérales pour l'exercice 2024."
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:62
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:62
 msgid "HICC administers the National Housing Strategy, which funds the construction, repair, and preservation of affordable housing. It also oversees the Canada Mortgage and Housing Corporation (CMHC), which provides mortgage insurance and financing programs. The department supports public transit, clean energy, and community infrastructure through programs like the Canada Infrastructure Bank (CIB)."
 msgstr "LICC administre la Stratégie nationale sur le logement, qui finance la construction, la réparation et la préservation de logements abordables. Il supervise également la Société canadienne d'hypothèques et de logement (SCHL), qui offre des programmes d'assurance hypothécaire et de financement. Le ministère soutient le transport en commun, l'énergie propre et les infrastructures communautaires par le biais de programmes comme la Banque de l'infrastructure du Canada (BIC)."
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:94
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:94
 msgid "HICC spent $14.5 billion in fiscal year (FY) 2024. This was 2.8% of the $513.9 billion in overall federal spending. The department ranked eighth among federal departments in total spending."
 msgstr "LICC a dépensé 14,5 milliards de dollars au cours de l'exercice 2024. Cela représentait 2,8 % des 513,9 milliards de dollars de dépenses fédérales totales. Le ministère s'est classé huitième parmi les ministères fédéraux en termes de dépenses totales."
 
@@ -1681,15 +1713,15 @@ msgstr "Aide au logement"
 msgid "Housing, Infrastructure and Communities Canada"
 msgstr "Logement, Infrastructure et Collectivités Canada"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:180
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:180
 msgid "Housing, Infrastructure and Communities Canada (HICC) is led by the <0>Minister of Housing, Infrastructure and Communities</0>, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 msgstr "Logement, Infrastructure et Collectivités Canada (LICC) est dirigé par le <0>ministre du Logement, de l'Infrastructure et des Collectivités</0>, qui est nommé par le gouverneur général sur l'avis du premier ministre et officiellement assermenté à Rideau Hall. Lors de sa nomination, le ministre prête le serment d'office et le serment d'allégeance, devenant membre du Conseil privé du Roi pour le Canada."
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:52
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:52
 msgid "Housing, Infrastructure and Communities Canada (HICC) is responsible for federal policies and programs that support public infrastructure, affordable housing, and community development. It works with provinces, territories, and municipalities to fund major infrastructure projects and improve housing affordability across Canada."
 msgstr "Logement, Infrastructure et Collectivités Canada (LICC) est responsable des politiques et programmes fédéraux qui soutiennent les infrastructures publiques, le logement abordable et le développement communautaire. Il collabore avec les provinces, les territoires et les municipalités pour financer d'importants projets d'infrastructure et améliorer l'abordabilité du logement partout au Canada."
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:34
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:34
 msgid "Housing, Infrastructure and Communities Canada | Canada Spends"
 msgstr "Logement, Infrastructure et Collectivités Canada | Canada Spends"
 
@@ -1701,59 +1733,59 @@ msgstr "Comment puis-je montrer mon soutien?"
 msgid "How can I stay up to date on your work?"
 msgstr "Comment puis-je rester informé de votre travail?"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:170
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:170
 msgid "How did ESDC spend its budget in 2024?"
 msgstr "Comment EDSC a-t-il dépensé son budget en 2024?"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:160
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:160
 msgid "How did Global Affairs Canada spend its budget in 2024?"
 msgstr "Comment Affaires mondiales Canada a-t-il dépensé son budget en 2024?"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:155
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:155
 msgid "How did HICC spend its budget in FY24?"
 msgstr "Comment LICC a-t-il dépensé son budget pour l'exercice 2024?"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:137
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:137
 msgid "How did IRCC spend its budget in FY24?"
 msgstr "Comment IRCC a-t-il dépensé son budget pour l'exercice 2024?"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:170
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:170
 msgid "How did ISC and CIRNAC spend their budgets in 2024?"
 msgstr "Comment SAC et RCAANC ont-ils dépensé leurs budgets en 2024?"
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:139
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:139
 msgid "How did ISED spend its budget in FY 24?"
 msgstr "Comment ISDE a-t-il dépensé son budget pour l'exercice 2024?"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:145
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:145
 msgid "How did PSPC spend its budget in FY24?"
 msgstr "Comment SPAC a-t-il dépensé son budget pour l'exercice 2024?"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:141
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:141
 msgid "How did Public Safety Canada spend its budget in 2024?"
 msgstr "Comment Sécurité publique Canada a-t-il dépensé son budget en 2024?"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:182
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:182
 msgid "How did the Canada Revenue Agency spend its budget in 2024?"
 msgstr "Comment l'Agence du revenu du Canada a-t-elle dépensé son budget en 2024?"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:165
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:165
 msgid "How did the Department of Finance spend its budget in 2024?"
 msgstr "Comment le ministère des Finances a-t-il dépensé son budget en 2024?"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:168
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:168
 msgid "How did the Department of National Defence spend its budget in 2024?"
 msgstr "Comment le ministère de la Défense nationale a-t-il dépensé son budget en 2024?"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:138
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:138
 msgid "How did Transport Canada spend its budget in FY24?"
 msgstr "Comment Transports Canada a-t-il dépensé son budget pour l'exercice 2024?"
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:141
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:141
 msgid "How did VAC spend its budget in FY24?"
 msgstr "Comment ACC a-t-il dépensé son budget pour l'exercice 2024?"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:110
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:110
 msgid "How has Public Safety Canada's spending changed?"
 msgstr "Comment les dépenses de Sécurité publique Canada ont-elles évolué?"
 
@@ -1765,16 +1797,16 @@ msgstr "Comment soumettre une information"
 msgid "Immigration + Border Security"
 msgstr "Immigration + Sécurité frontalière"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:74
 msgid "Immigration, Refugees and Citizenship"
 msgstr "Immigration, Réfugiés et Citoyenneté"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:170
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:170
 msgid "Immigration, Refugees and Citizenship Canada (IRCC) is led by the Minister of Immigration, Refugees and Citizenship, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 msgstr "Immigration, Réfugiés et Citoyenneté Canada (IRCC) est dirigé par le ministre de l'Immigration, des Réfugiés et de la Citoyenneté, qui est nommé par le gouverneur général sur l'avis du premier ministre et officiellement assermenté à Rideau Hall. Lors de sa nomination, le ministre prête le serment d'office et le serment d'allégeance, devenant membre du Conseil privé du Roi pour le Canada."
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:32
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:32
 msgid "Immigration, Refugees and Citizenship Canada | Canada Spends"
 msgstr "Immigration, Réfugiés et Citoyenneté Canada | Canada Spends"
 
@@ -1797,66 +1829,66 @@ msgstr "En {0}, vous payez <0>{1}</0> en impôts totaux (taux effectif de {2}%)"
 msgid "In Financial Year {0},"
 msgstr "Au cours de l'exercice financier {0},"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:99
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:99
 msgid "In fiscal year (FY) 2024, ISC and CIRNAC collectively spent <0>$63 billion</0>, accounting for <1>12.3% of the total federal budget</1>. The departments play a critical role in addressing socio-economic disparities, facilitating self-governance agreements, and improving service delivery for Indigenous communities across Canada."
 msgstr "Au cours de l'exercice 2024, SAC et RCAANC ont collectivement dépensé <0>63 milliards de dollars</0>, représentant <1>12,3 % du budget fédéral total</1>. Les ministères jouent un rôle essentiel dans la réduction des disparités socio-économiques, la facilitation des accords d'autonomie gouvernementale et l'amélioration de la prestation de services aux communautés autochtones à travers le Canada."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:73
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:78
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:72
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:77
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:74
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:79
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:80
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:85
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:78
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:83
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:80
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:85
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:67
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:72
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:85
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:90
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:68
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:73
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:75
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:82
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:72
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:77
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:70
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:75
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:68
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:73
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:70
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:75
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:73
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:78
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:72
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:77
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:74
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:79
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:80
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:85
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:78
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:83
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:80
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:85
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:67
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:72
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:85
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:90
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:68
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:73
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:75
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:82
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:72
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:77
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:70
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:75
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:68
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:73
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:70
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:75
 msgid "In FY 2024,"
 msgstr "Au cours de l'exercice 2024,"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:173
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:173
 msgid "In FY 2024, 55.2% of CRA net spending was allocated to salaries, benefits, and pensions."
 msgstr "Au cours de l'exercice 2024, 55,2 % des dépenses nettes de l'ARC ont été allouées aux salaires, aux avantages sociaux et aux pensions."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:173
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:173
 msgid "In FY 2024, ESDC transferred 63% of its total spending to individuals and provinces."
 msgstr "Au cours de l'exercice 2024, EDSC a transféré 63 % de ses dépenses totales aux particuliers et aux provinces."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:155
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:155
 msgid "In FY 2024, Finance Canada transferred 66.2% of its total spending to provinces and territories. The chart below outlines all departmental spending in 2024."
 msgstr "Au cours de l'exercice 2024, Finances Canada a transféré 66,2 % de ses dépenses totales aux provinces et aux territoires. Le graphique ci-dessous présente toutes les dépenses ministérielles en 2024."
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:162
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:162
 msgid "In FY 2024, ISC and CIRNAC transferred 93.1% of total spending directly to indigenous communities."
 msgstr "Au cours de l'exercice 2024, SAC et RCAANC ont transféré 93,1 % des dépenses totales directement aux communautés autochtones."
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:146
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:146
 msgid "In FY 2024, Public Safety's budget was allocated across several key areas, including:"
 msgstr "Au cours de l'exercice 2024, le budget de la Sécurité publique a été réparti entre plusieurs domaines clés, notamment :"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:112
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:112
 msgid "In FY 2024, Transport Canada accounted for 1% of all federal spending, 0.74% percentage points lower than in 1995."
 msgstr "Au cours de l'exercice 2024, Transports Canada représentait 1 % des dépenses fédérales totales, soit 0,74 point de pourcentage de moins qu'en 1995."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:155
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:155
 msgid "In FY 2024, VAC reported total expenditures of $6.07 billion across two entities:"
 msgstr "Au cours de l'exercice 2024, ACC a déclaré des dépenses totales de 6,07 milliards de dollars réparties entre deux entités :"
 
@@ -1876,11 +1908,11 @@ msgstr "Indéterminé"
 msgid "Indigenous Priorities"
 msgstr "Priorités autochtones"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:35
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:35
 msgid "Indigenous Services and Northern Affairs Canada | Canada Spends"
 msgstr "Services aux Autochtones et Affaires du Nord Canada | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:55
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:55
 msgid "Indigenous Services Canada (ISC) and Crown-Indigenous Relations and Northern Affairs Canada (CIRNAC) are two distinct federal departments tasked with advancing Indigenous priorities in Canada. Established in 2017 following the dissolution of Indigenous and Northern Affairs Canada (INAC), these departments manage different aspects of Indigenous policy, service delivery, and governance."
 msgstr "Services aux Autochtones Canada (SAC) et Relations Couronne-Autochtones et Affaires du Nord Canada (RCAANC) sont deux ministères fédéraux distincts chargés de faire progresser les priorités autochtones au Canada. Créés en 2017 à la suite de la dissolution d'Affaires autochtones et du Nord Canada (AANC), ces ministères gèrent différents aspects de la politique autochtone, de la prestation de services et de la gouvernance."
 
@@ -1900,19 +1932,19 @@ msgstr "Impôt sur le revenu des particuliers"
 msgid "Individual Income Taxes"
 msgstr "Impôts sur le revenu des particuliers"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:27
 msgid "Information"
 msgstr "Information"
 
@@ -1924,16 +1956,16 @@ msgstr "Investissements en infrastructure"
 msgid "Innovation + Research"
 msgstr "Innovation + Recherche"
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:62
 msgid "Innovation, Science and Industry"
 msgstr "Innovation, Sciences et Industrie"
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:171
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:171
 msgid "Innovation, Science and Industry Canada (ISED) is led by the Minister of Innovation, Science and Industry, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 msgstr "Innovation, Sciences et Industrie Canada (ISIC) est dirigé par le ministre de l'Innovation, des Sciences et de l'Industrie, qui est nommé par le gouverneur général sur l'avis du premier ministre et officiellement assermenté à Rideau Hall. Lors de sa nomination, le ministre prête le serment d'office et le serment d'allégeance, devenant membre du Conseil privé du Roi pour le Canada."
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:32
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:32
 msgid "Innovation, Science and Industry Canada | Canada Spends"
 msgstr "Innovation, Sciences et Industrie Canada | Canada Spends"
 
@@ -1958,21 +1990,21 @@ msgstr "Intérêts sur la dette"
 msgid "Interim Housing Assistance"
 msgstr "Aide temporaire au logement"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:71
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:67
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:71
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:67
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:71
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:71
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:71
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:71
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:71
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:71
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:71
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:71
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:71
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:71
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:71
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:71
 msgid "Internal Revenues"
 msgstr "Revenus internes"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:171
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:171
 msgid "International Advocacy and Diplomacy: $1B"
 msgstr "Plaidoyer international et diplomatie : 1 G$"
 
@@ -1996,11 +2028,11 @@ msgstr "Investissement, croissance et commercialisation"
 msgid "Involved First Nations"
 msgstr "Premières Nations impliquées"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:89
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:89
 msgid "IRCC accounted for 1.2% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 msgstr "IRCC représentait 1,2 % de toutes les dépenses fédérales pour l'exercice 2024. 10 ministères gouvernementaux représentaient 73,2 % des dépenses fédérales pour l'exercice 2024"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:81
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:81
 msgid "IRCC spent $6.3 billion in fiscal year (FY) 2024. This was 1.2% of the $513.9 billion in overall federal spending. The department ranked thirteenth among federal departments in total spending."
 msgstr "IRCC a dépensé 6,3 milliards de dollars au cours de l'exercice 2024. Cela représentait 1,2 % des 513,9 milliards de dollars de dépenses fédérales totales. Le ministère s'est classé treizième parmi les ministères fédéraux en termes de dépenses totales."
 
@@ -2008,23 +2040,23 @@ msgstr "IRCC a dépensé 6,3 milliards de dollars au cours de l'exercice 2024. C
 msgid "Is this a lobby group?"
 msgstr "Est-ce un groupe de pression?"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:182
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:182
 msgid "ISC + CIRNAC, Spending by Entity, FY 2024"
 msgstr "SAC + RCAANC, Dépenses par entité, exercice 2024"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:135
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:135
 msgid "ISC + CIRNAC's share of federal spending in FY 2024 was 592% higher than in FY 1995"
 msgstr "La part des dépenses fédérales de SAC + RCAANC pour l'exercice 2024 était 592 % plus élevée qu'en 1995"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:16
 msgid "ISC and CIRNAC"
 msgstr "SAC et RCAANC"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:65
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:65
 msgid "ISC is responsible for providing essential services to First Nations, Inuit, and Métis communities, including healthcare, education, housing, and child and family services. It also works to transfer control of these services to Indigenous-led organizations. CIRNAC focuses on treaty negotiations, self-government agreements, land claims, and Northern affairs, aiming to strengthen nation-to-nation relationships and modernize Indigenous governance structures. Together, ISC and CIRNAC oversee key programs that impact Indigenous communities across Canada."
 msgstr "SAC est responsable de fournir des services essentiels aux communautés des Premières Nations, des Inuits et des Métis, y compris les soins de santé, l'éducation, le logement et les services à l'enfance et à la famille. Il travaille également à transférer le contrôle de ces services aux organisations dirigées par les Autochtones. RCAANC se concentre sur les négociations de traités, les accords d'autonomie gouvernementale, les revendications territoriales et les affaires du Nord, visant à renforcer les relations de nation à nation et à moderniser les structures de gouvernance autochtone. Ensemble, SAC et RCAANC supervisent des programmes clés qui ont un impact sur les communautés autochtones à travers le Canada."
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:82
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:82
 msgid "ISED spent $10.2 billion in fiscal year (FY) 2024. This was 2% of the $513.9 billion in overall federal spending. The department ranked eleventh among federal departments in total spending."
 msgstr "ISDE a dépensé 10,2 milliards de dollars au cours de l'exercice 2024. Cela représentait 2 % des 513,9 milliards de dollars de dépenses fédérales totales. Le ministère s'est classé onzième parmi les ministères fédéraux en termes de dépenses totales."
 
@@ -2050,7 +2082,7 @@ msgstr "Dates clés"
 msgid "Keywords"
 msgstr "Mots-clés"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:217
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:217
 msgid "Labour Market Development Agreements (LMDAs): federal funding to provinces for job training and employment support."
 msgstr "Ententes sur le développement du marché du travail (EDMT) : financement fédéral aux provinces pour la formation professionnelle et le soutien à l'emploi."
 
@@ -2067,7 +2099,7 @@ msgid "Last Update"
 msgstr "Dernière mise à jour"
 
 #: src/app/[lang]/(main)/budget/page.tsx:248
-#: src/app/[lang]/(main)/federal/budget/page.tsx:285
+#: src/app/[lang]/(main)/federal/budget/page.tsx:287
 msgid "Latest Budget News & Impact"
 msgstr "Dernières nouvelles budgétaires et impact"
 
@@ -2085,40 +2117,40 @@ msgstr "Emplacement"
 msgid "Look back at what {0}'s government made and spent. {1}"
 msgstr "Regardez en arrière ce que le gouvernement de {0} a gagné et dépensé. {1}"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:148
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:148
 msgid "Major international events, trade agreements, foreign aid commitments, and global crises such as the COVID-19 pandemic have influenced fluctuations in spending. In 2020, GAC's budget surged due to emergency international assistance programs, including vaccine distribution and humanitarian relief efforts."
 msgstr "Les événements internationaux majeurs, les accords commerciaux, les engagements d'aide étrangère et les crises mondiales comme la pandémie de COVID-19 ont influencé les fluctuations des dépenses. En 2020, le budget d'AMC a augmenté en raison des programmes d'aide internationale d'urgence, y compris la distribution de vaccins et les efforts d'aide humanitaire."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:124
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:124
 msgid "Major legislation, economic conditions, and external factors can impact ESDC's spending."
 msgstr "Les principales lois, les conditions économiques et les facteurs externes peuvent avoir un impact sur les dépenses d'EDSC."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:120
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:120
 msgid "Major legislation, internal or global economic conditions, and acute events like the COVID-19 pandemic can affect spending year to year. For example, the federal expenses fluctuated during the pandemic, rising from $410.2 billion (in 2024 dollars) in 2019 to $420 billion in 2020 and $720.3 billion in 2021"
 msgstr "Les principales lois, les conditions économiques internes ou mondiales et les événements aigus comme la pandémie de COVID-19 peuvent affecter les dépenses d'une année à l'autre. Par exemple, les dépenses fédérales ont fluctué pendant la pandémie, passant de 410,2 milliards de dollars (en dollars de 2024) en 2019 à 420 milliards en 2020 et 720,3 milliards en 2021"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:131
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:131
 msgid "Major legislation, internal or global economic conditions, and acute events like the COVID-19 pandemic can significantly influence government spending year to year. For example, during the COVID-19 pandemic, federal support programs led to a temporary surge in spending. Health Canada expenditures increased from $5 billion in FY 2019 to $14.2 billion in FY 2021 before stabilizing in recent years."
 msgstr "Les principales lois, les conditions économiques internes ou mondiales et les événements aigus comme la pandémie de COVID-19 peuvent influencer significativement les dépenses gouvernementales d'une année à l'autre. Par exemple, pendant la pandémie de COVID-19, les programmes de soutien fédéraux ont entraîné une augmentation temporaire des dépenses. Les dépenses de Santé Canada sont passées de 5 milliards de dollars pour l'exercice 2019 à 14,2 milliards pour l'exercice 2021 avant de se stabiliser ces dernières années."
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:132
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:117
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:119
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:120
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:118
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:121
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:132
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:117
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:119
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:120
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:118
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:121
 msgid "Major legislation, internal or global economic conditions, and acute events like the COVID-19 pandemic can significantly influence government spending year to year. For instance, during the pandemic, the Government of Canada's total expenses rose from $410.2 billion in 2019 to $420 billion in 2020 and further to $720.3 billion in 2021."
 msgstr "Les principales lois, les conditions économiques internes ou mondiales et les événements aigus comme la pandémie de COVID-19 peuvent influencer significativement les dépenses gouvernementales d'une année à l'autre. Par exemple, pendant la pandémie, les dépenses totales du gouvernement du Canada sont passées de 410,2 milliards de dollars en 2019 à 420 milliards en 2020 et à 720,3 milliards en 2021."
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:159
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:159
 msgid "Major legislation, shifts in international security dynamics, and acute events such as Russia's invasion of Ukraine or Arctic sovereignty disputes can influence military spending."
 msgstr "Les principales lois, les changements dans la dynamique de sécurité internationale et les événements aigus tels que l'invasion de l'Ukraine par la Russie ou les différends sur la souveraineté de l'Arctique peuvent influencer les dépenses militaires."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:129
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:129
 msgid "Major legislative changes, compliance trends, and digital tax services have influenced CRA spending patterns. For example, compliance initiatives and fraud investigations recovered an estimated $11.5 billion in lost revenue in 2024 due to tax evasion."
 msgstr "Les changements législatifs majeurs, les tendances en matière de conformité et les services fiscaux numériques ont influencé les modèles de dépenses de l'ARC. Par exemple, les initiatives de conformité et les enquêtes sur la fraude ont permis de récupérer environ 11,5 milliards de dollars de revenus perdus en 2024 en raison de l'évasion fiscale."
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:125
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:125
 msgid "Major policy shifts, unforeseen events such as natural disasters, and global security concerns can significantly impact the department's annual spending. The COVID-19 pandemic, for example, led to a sharp increase in federal emergency response funding in 2020."
 msgstr "Les changements majeurs de politique, les événements imprévus tels que les catastrophes naturelles et les préoccupations de sécurité mondiale peuvent avoir un impact significatif sur les dépenses annuelles du ministère. La pandémie de COVID-19, par exemple, a entraîné une forte augmentation du financement fédéral d'intervention d'urgence en 2020."
 
@@ -2168,18 +2200,18 @@ msgstr "Mois"
 msgid "More coming soon..."
 msgstr "Plus à venir..."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:167
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:167
 msgid "Most CRA spending is dedicated to personnel and IT infrastructure supporting tax filing, compliance, and benefit administration."
 msgstr "La plupart des dépenses de l'ARC sont consacrées au personnel et à l'infrastructure informatique soutenant la production des déclarations, la conformité et l'administration des prestations."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:155
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:155
 msgid "Most federal spending can be categorized as direct or indirect."
 msgstr "La plupart des dépenses fédérales peuvent être classées comme directes ou indirectes."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:158
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:146
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:153
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:183
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:158
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:146
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:153
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:183
 msgid "Most federal spending can be categorized as direct or indirect. Direct spending refers to money the federal government spends on budget items such as federal programs, employee salaries, and debt interest. Indirect spending refers to federal transfers to other levels of government."
 msgstr "La plupart des dépenses fédérales peuvent être classées comme directes ou indirectes. Les dépenses directes font référence à l'argent que le gouvernement fédéral dépense pour des postes budgétaires tels que les programmes fédéraux, les salaires des employés et les intérêts sur la dette. Les dépenses indirectes font référence aux transferts fédéraux vers d'autres niveaux de gouvernement."
 
@@ -2197,19 +2229,19 @@ msgstr "Nom"
 msgid "National Defence"
 msgstr "Défense nationale"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:35
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:35
 msgid "National Defence | Canada Spends"
 msgstr "Défense nationale | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:107
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:107
 msgid "National Defence accounted for 6.7% of all federal spending in FY 2024"
 msgstr "La Défense nationale représentait 6,7 % de toutes les dépenses fédérales pour l'exercice 2024"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:203
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:203
 msgid "National Defence, Spending by Entity, FY 2024"
 msgstr "Défense nationale, Dépenses par entité, exercice 2024"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:144
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:144
 msgid "National Defence's share of federal spending in FY 2024 was lower than in FY 1995"
 msgstr "La part des dépenses fédérales de la Défense nationale en 2024 était inférieure à celle de 1995"
 
@@ -2287,7 +2319,7 @@ msgid "Newfoundland and Labrador STP"
 msgstr "TPS Terre-Neuve-et-Labrador"
 
 #: src/app/[lang]/(main)/budget/page.tsx:56
-#: src/app/[lang]/(main)/federal/budget/page.tsx:56
+#: src/app/[lang]/(main)/federal/budget/page.tsx:57
 msgid "News Source & Date"
 msgstr "Source d'actualité et date"
 
@@ -2374,6 +2406,11 @@ msgstr "Notez les différentes fourchettes salariales avant 2023. Les informatio
 msgid "Notes to Financial Statements"
 msgstr "Notes aux états financiers"
 
+#: src/app/[lang]/(main)/notifications/page.tsx:18
+#: src/app/[lang]/(main)/notifications/page.tsx:44
+msgid "Notifications"
+msgstr "Notifications"
+
 #: src/components/Sankey/index.tsx:491
 msgid "Nova Scotia EQP"
 msgstr "PÉ Nouvelle-Écosse"
@@ -2430,59 +2467,59 @@ msgstr "des dépenses municipales de {0} ont été effectuées par {1}"
 msgid "of {0} provincial spending was by {1}"
 msgstr "des dépenses provinciales de {0} ont été effectuées par {1}"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:92
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:92
 msgid "of federal spending was allocated to Indigenous priorities via these Departments. This does not include additional programs in other departments designed specifically for Indigenous beneficiaries."
 msgstr "des dépenses fédérales ont été allouées aux priorités autochtones via ces ministères. Cela n'inclut pas les programmes supplémentaires dans d'autres ministères conçus spécifiquement pour les bénéficiaires autochtones."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:81
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:81
 msgid "of federal spending was by ESDC"
 msgstr "des dépenses fédérales ont été effectuées par EDSC"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:79
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:79
 msgid "of federal spending was by Finance Canada"
 msgstr "des dépenses fédérales ont été effectuées par Finances Canada"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:85
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:85
 msgid "of federal spending was by Health Canada"
 msgstr "des dépenses fédérales ont été effectuées par Santé Canada"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:87
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:87
 msgid "of federal spending was by Housing, Infrastructure and Communities Canada"
 msgstr "des dépenses fédérales ont été effectuées par Logement, Infrastructure et Collectivités Canada"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:77
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:77
 msgid "Of federal spending was by Public Services and Procurement Canada"
 msgstr "des dépenses fédérales ont été effectuées par Services publics et Approvisionnement Canada"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:80
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:80
 msgid "of federal spending was by the Canada Revenue Agency"
 msgstr "des dépenses fédérales ont été effectuées par l'Agence du revenu du Canada"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:85
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:85
 msgid "of federal spending was by the Department of National Defence"
 msgstr "des dépenses fédérales étaient du ministère de la Défense nationale"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:74
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:74
 msgid "Of federal spending was by the Dept. of Immigration, Refugees and Citizenship"
 msgstr "des dépenses fédérales ont été effectuées par le ministère de l'Immigration, des Réfugiés et de la Citoyenneté"
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:75
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:75
 msgid "Of federal spending was by the Dept. of Innovation, Science and Industry"
 msgstr "des dépenses fédérales ont été effectuées par le ministère de l'Innovation, des Sciences et de l'Industrie"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:75
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:75
 msgid "Of federal spending was by the Dept. of Transport"
 msgstr "des dépenses fédérales ont été effectuées par le ministère des Transports"
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:77
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:77
 msgid "Of federal spending was by the Dept. of Veterans Affairs"
 msgstr "des dépenses fédérales ont été effectuées par le ministère des Anciens Combattants"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:87
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:87
 msgid "of federal spending was by the Global Affairs Canada"
 msgstr "des dépenses fédérales ont été effectuées par Affaires mondiales Canada"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:79
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:79
 msgid "of federal spending was by the Public Safety Canada"
 msgstr "des dépenses fédérales ont été effectuées par Sécurité publique Canada"
 
@@ -2494,7 +2531,7 @@ msgstr "Bureau du directeur général des élections"
 msgid "Office of the Secretary to the Governor General"
 msgstr "Bureau du secrétaire du gouverneur général"
 
-#: src/app/[lang]/(main)/federal/budget/page.tsx:168
+#: src/app/[lang]/(main)/federal/budget/page.tsx:170
 msgid "Official Fall 2025 Federal Budget Released"
 msgstr "Publication du budget fédéral officiel de l'automne 2025"
 
@@ -2532,9 +2569,13 @@ msgid "Open Tor Browser and wait for it to connect."
 msgstr "Ouvrez le navigateur Tor et attendez qu'il se connecte."
 
 #: src/app/[lang]/(main)/budget/page.tsx:195
-#: src/app/[lang]/(main)/federal/budget/page.tsx:232
+#: src/app/[lang]/(main)/federal/budget/page.tsx:234
 msgid "Operational Spend"
 msgstr "Dépenses opérationnelles"
+
+#: src/app/[lang]/(main)/login/login-form.tsx:140
+msgid "or"
+msgstr "ou"
 
 #: src/app/[lang]/(main)/about/faq.tsx:84
 msgid "or subscribe to"
@@ -2544,7 +2585,7 @@ msgstr "ou abonnez-vous à"
 msgid "Organization"
 msgstr "Organisation"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/MiniSankey.tsx:35
 #: src/components/Sankey/index.tsx:319
 msgid "Other"
 msgstr "Autre"
@@ -2576,7 +2617,7 @@ msgstr "Autres programmes environnementaux et de changement climatique"
 msgid "Other Excise Taxes and Duties"
 msgstr "Autres taxes et droits d'accise"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/MiniSankey.tsx:39
 msgid "Other expenditures"
 msgstr "Autres dépenses"
 
@@ -2632,22 +2673,22 @@ msgstr "Autres services publics + Approvisionnement"
 msgid "Other Settlement Agreements"
 msgstr "Autres accords de règlement"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:63
 msgid "Other subsidies and payments"
 msgstr "Autres subventions et paiements"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:55
 msgid "Other Subsidies and Payments"
 msgstr "Autres subventions et paiements"
 
@@ -2681,6 +2722,10 @@ msgstr "Aperçu"
 msgid "Parliament"
 msgstr "Parlement"
 
+#: src/app/[lang]/(main)/login/login-form.tsx:168
+msgid "Password"
+msgstr "Mot de passe"
+
 #: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:338
 msgid "Payment Amount"
 msgstr "Montant du paiement"
@@ -2693,7 +2738,7 @@ msgstr "Cotisations salariales"
 msgid "Payroll Taxes"
 msgstr "Charges sociales"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:237
+#: src/app/[lang]/(main)/federal/spending/page.tsx:238
 #: src/app/[lang]/(main)/spending/page.tsx:228
 msgid "PBO"
 msgstr "DPB"
@@ -2707,43 +2752,43 @@ msgstr "Dépenses par habitant"
 msgid "per resident"
 msgstr "par résident"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:148
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:148
 msgid "Percentage of federal budget dedicated to Canada Revenue Agency, FYs 1995-2024"
 msgstr "Pourcentage du budget fédéral consacré à l'Agence du revenu du Canada, exercices 1995-2024"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:152
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:152
 msgid "Percentage of federal budget dedicated to Defence, FYs 1995-2024"
 msgstr "Pourcentage du budget fédéral consacré à la Défense, exercices 1995-2024"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:146
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:146
 msgid "Percentage of federal budget dedicated to ESDC, FYs 1995-2024 (inflation-adjusted)"
 msgstr "Pourcentage du budget fédéral consacré à EDSC, exercices 1995-2024 (ajusté à l'inflation)"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:138
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:138
 msgid "Percentage of federal budget dedicated to Finance, FYs 1995-2024"
 msgstr "Pourcentage du budget fédéral consacré à Finances, exercices 1995-2024"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:131
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:131
 msgid "Percentage of federal budget dedicated to Global Affairs Canada, FYs 1995-2024"
 msgstr "Pourcentage du budget fédéral consacré à Affaires mondiales Canada, exercices 1995-2024"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:141
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:141
 msgid "Percentage of federal budget dedicated to Indigenous Priorities, FYs 1995-2024"
 msgstr "Pourcentage du budget fédéral consacré aux priorités autochtones, exercices 1995-2024"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:19
 msgid "Personnel"
 msgstr "Personnel"
 
@@ -2758,6 +2803,12 @@ msgstr "Tarification de la pollution"
 #: src/components/Sankey/BudgetSankey.tsx:504
 msgid "Pollution pricing proceeds"
 msgstr "Produits de la tarification de la pollution"
+
+#. placeholder {0}: populationData[0]?.year
+#. placeholder {1}: populationData[populationData.length - 1]?.year
+#: src/components/first-nations/PopulationCharts.tsx:116
+msgid "Population trends for {bandName} from {0} to {1}."
+msgstr "Tendances démographiques pour {bandName} de {0} à {1}."
 
 #: src/components/first-nations/RemunerationOverview.tsx:791
 #: src/components/first-nations/RemunerationTable.tsx:107
@@ -2798,22 +2849,22 @@ msgstr "Chercheur principal"
 msgid "Privy Council Office"
 msgstr "Bureau du Conseil privé"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:31
 msgid "Professional + Special Services"
 msgstr "Services professionnels + spéciaux"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:31
 msgid "Professional and Special Services"
 msgstr "Services professionnels et spéciaux"
 
@@ -2830,12 +2881,12 @@ msgid "Project Number"
 msgstr "Numéro de projet"
 
 #: src/app/[lang]/(main)/budget/page.tsx:206
-#: src/app/[lang]/(main)/federal/budget/page.tsx:243
+#: src/app/[lang]/(main)/federal/budget/page.tsx:245
 msgid "Projected capital investments"
 msgstr "Investissements en capital projetés"
 
 #: src/app/[lang]/(main)/budget/page.tsx:197
-#: src/app/[lang]/(main)/federal/budget/page.tsx:234
+#: src/app/[lang]/(main)/federal/budget/page.tsx:236
 msgid "Projected operational spending"
 msgstr "Dépenses opérationnelles projetées"
 
@@ -2873,11 +2924,11 @@ msgstr "Provincial"
 msgid "Provincial Tax"
 msgstr "Impôt provincial"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:92
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:92
 msgid "PSPC accounted for 1.6% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 msgstr "SPAC représentait 1,6 % de toutes les dépenses fédérales pour l'exercice 2024. 10 ministères gouvernementaux représentaient 73,2 % des dépenses fédérales pour l'exercice 2024"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:84
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:84
 msgid "PSPC spent $8.3 billion in fiscal year (FY) 2024. This was 1.6% of the $513.9 billion in overall federal spending. The department ranked twelfth among federal departments in total spending."
 msgstr "SPAC a dépensé 8,3 milliards de dollars au cours de l'exercice 2024. Cela représentait 1,6 % des 513,9 milliards de dollars de dépenses fédérales totales. Le ministère s'est classé douzième parmi les ministères fédéraux en termes de dépenses totales."
 
@@ -2887,19 +2938,19 @@ msgstr "SPAC a dépensé 8,3 milliards de dollars au cours de l'exercice 2024. C
 msgid "Public Accounts of {0} FY {1}"
 msgstr "Comptes publics de {0} exercice {1}"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:59
 msgid "Public debt charges"
 msgstr "Frais de la dette publique"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:59
 #: src/components/Sankey/BudgetSankey.tsx:427
 msgid "Public Debt Charges"
 msgstr "Frais de la dette publique"
@@ -2912,20 +2963,20 @@ msgstr "Santé publique + Prévention des maladies"
 msgid "Public Safety"
 msgstr "Sécurité publique"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:50
 msgid "Public Safety Canada"
 msgstr "Sécurité publique Canada"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:34
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:34
 msgid "Public Safety Canada | Canada Spends"
 msgstr "Sécurité publique Canada | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:86
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:86
 msgid "Public Safety Canada spent $13.9 billion in fiscal year (FY) 2024, accounting for 2.7% of the $513.9 billion in total federal spending. While not among the largest departments by expenditure, Public Safety Canada plays a crucial role in national security and emergency management, working in tandem with multiple agencies to mitigate threats and enhance public safety."
 msgstr "Sécurité publique Canada a dépensé 13,9 milliards de dollars au cours de l'exercice 2024, soit 2,7 % des 513,9 milliards de dollars de dépenses fédérales totales. Bien qu'il ne figure pas parmi les plus grands ministères en termes de dépenses, Sécurité publique Canada joue un rôle crucial dans la sécurité nationale et la gestion des urgences, travaillant en tandem avec plusieurs organismes pour atténuer les menaces et améliorer la sécurité publique."
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:52
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:52
 msgid "Public Safety, Democratic Institutions and Intergovernmental Affairs Canada (Public Safety Canada) is the federal department responsible for national security, emergency preparedness, and community safety. Established in 2003, it consolidates security, law enforcement, and emergency management functions. It includes the RCMP, CSIS, and CBSA and coordinates federal responses to threats and develops policies on crime prevention, cyber resilience, and disaster preparedness while overseeing intelligence-sharing with domestic and international partners."
 msgstr "Sécurité publique, Institutions démocratiques et Affaires intergouvernementales Canada (Sécurité publique Canada) est le ministère fédéral responsable de la sécurité nationale, de la préparation aux urgences et de la sécurité communautaire. Établi en 2003, il regroupe les fonctions de sécurité, d'application de la loi et de gestion des urgences. Il comprend la GRC, le SCRS et l'ASFC et coordonne les réponses fédérales aux menaces et élabore des politiques sur la prévention du crime, la cyber-résilience et la préparation aux catastrophes tout en supervisant le partage de renseignements avec les partenaires nationaux et internationaux."
 
@@ -2933,16 +2984,16 @@ msgstr "Sécurité publique, Institutions démocratiques et Affaires intergouver
 msgid "Public Service Employees"
 msgstr "Employés de la fonction publique"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:68
 msgid "Public Services and Procurement Canada"
 msgstr "Services publics et Approvisionnement Canada"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:177
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:177
 msgid "Public Services and Procurement Canada (PSPC) is led by the Minister of Government Transformation, Public Services and Procurement, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 msgstr "Services publics et Approvisionnement Canada (SPAC) est dirigé par le ministre de la Transformation gouvernementale, des Services publics et de l'Approvisionnement, qui est nommé par le gouverneur général sur l'avis du premier ministre et officiellement assermenté à Rideau Hall. Lors de sa nomination, le ministre prête le serment d'office et le serment d'allégeance, devenant membre du Conseil privé du Roi pour le Canada."
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:32
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:32
 msgid "Public Services and Procurement Canada | Canada Spends"
 msgstr "Services publics et Approvisionnement Canada | Canada Spends"
 
@@ -2950,7 +3001,7 @@ msgstr "Services publics et Approvisionnement Canada | Canada Spends"
 msgid "Public Works + Government Services"
 msgstr "Travaux publics + Services gouvernementaux"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/MiniSankey.tsx:31
 msgid "Quebec abatement"
 msgstr "Abattement du Québec"
 
@@ -2989,7 +3040,7 @@ msgid "Ready Forces"
 msgstr "Forces prêtes"
 
 #: src/app/[lang]/(main)/budget/page.tsx:251
-#: src/app/[lang]/(main)/federal/budget/page.tsx:288
+#: src/app/[lang]/(main)/federal/budget/page.tsx:290
 msgid "Recent developments and their projected impact on the Fall 2025 Budget"
 msgstr "Développements récents et leur impact projeté sur le budget de l'automne 2025"
 
@@ -3015,38 +3066,38 @@ msgstr "Rémunération"
 msgid "Remuneration and Expenses"
 msgstr "Rémunération et dépenses"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:35
 msgid "Rentals"
 msgstr "Locations"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:39
 msgid "Repair + Maintenance"
 msgstr "Réparation + Entretien"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:39
 msgid "Repair and Maintenance"
 msgstr "Réparation et entretien"
 
@@ -3077,7 +3128,7 @@ msgid "Return on Investments"
 msgstr "Rendement des investissements"
 
 #: src/app/[lang]/(main)/budget/page.tsx:184
-#: src/app/[lang]/(main)/federal/budget/page.tsx:221
+#: src/app/[lang]/(main)/federal/budget/page.tsx:223
 #: src/components/Sankey/BudgetSankey.tsx:456
 #: src/components/Sankey/index.tsx:700
 msgid "Revenue"
@@ -3099,7 +3150,7 @@ msgstr "Sécurité"
 msgid "Salaries, honoraria, travel, and other expenses paid to elected officials and senior employees during fiscal year {fiscalYear}."
 msgstr "Salaires, honoraires, déplacements et autres dépenses versés aux élus et aux cadres supérieurs au cours de l'exercice financier {fiscalYear}."
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:247
+#: src/app/[lang]/(main)/federal/spending/page.tsx:248
 #: src/app/[lang]/(main)/spending/page.tsx:238
 msgid "Salary Distribution"
 msgstr "Répartition des salaires"
@@ -3152,7 +3203,7 @@ msgstr "Comité de sélection"
 msgid "Selection Mechanism"
 msgstr "Mécanisme de sélection"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:205
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:205
 msgid "Service Canada: responsible for processing EI, CPP, and OAS benefits."
 msgstr "Service Canada : responsable du traitement des prestations d'AE, du RPC et de la SV."
 
@@ -3185,23 +3236,44 @@ msgstr "Affichage de {0} sur {1} Premières Nations"
 msgid "Showing {0} of {1} results"
 msgstr "Affichage de {0} sur {1} résultats"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:142
+#: src/app/[lang]/(main)/login/login-form.tsx:186
+#: src/app/[lang]/(main)/login/login-form.tsx:198
+#: src/app/[lang]/(main)/login/page.tsx:20
+#: src/app/[lang]/(main)/login/page.tsx:44
+#: src/components/UserMenu.tsx:55
+msgid "Sign In"
+msgstr "Se connecter"
+
+#: src/app/[lang]/(main)/login/page.tsx:21
+msgid "Sign in to your CanadaSpends account"
+msgstr "Connectez-vous à votre compte CanadaSpends"
+
+#: src/components/UserMenu.tsx:45
+msgid "Sign Out"
+msgstr "Se déconnecter"
+
+#: src/app/[lang]/(main)/login/login-form.tsx:186
+#: src/app/[lang]/(main)/login/login-form.tsx:208
+msgid "Sign Up"
+msgstr "S'inscrire"
+
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:142
 msgid "Similarly, HICC expenditures experienced notable fluctuations during this period, surging from approximately $5.9 billion​ in 2019 (adjusted for inflation) to $14.5B in 2024."
 msgstr "De même, les dépenses de HICC ont connu des fluctuations notables au cours de cette période, passant d'environ 5,9 milliards de dollars en 2019 (ajusté à l'inflation) à 14,5 milliards de dollars en 2024."
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:127
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:127
 msgid "Similarly, IRCC's expenditures experienced notable fluctuations during this period, surging from approximately $3.02 billion​ in 2019 to $6.3 billion in 2024."
 msgstr "De même, les dépenses d'IRCC ont connu des fluctuations notables au cours de cette période, passant d'environ 3,02 milliards de dollars en 2019 à 6,3 milliards de dollars en 2024."
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:129
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:129
 msgid "Similarly, ISED's expenditures have increased during this period, growing from approximately $6.5 billion​ in 2019 (adjusted for inflation) to $10.2 billion in 2024."
 msgstr "De même, les dépenses d'ISIC ont augmenté au cours de cette période, passant d'environ 6,5 milliards de dollars en 2019 (ajusté à l'inflation) à 10,2 milliards de dollars en 2024."
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:130
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:130
 msgid "Similarly, PSPC's expenditures experienced notable fluctuations during this period, decreasing from approximately $6.8 billion​ in 2019 (adjusted for inflation) to $5.3 billion in 2021 before increasing again in 2024."
 msgstr "De même, les dépenses de SPAC ont connu des fluctuations notables au cours de cette période, diminuant d'environ 6,8 milliards de dollars en 2019 (ajusté à l'inflation) à 5,3 milliards de dollars en 2021 avant d'augmenter à nouveau en 2024."
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:128
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:128
 msgid "Similarly, Transport Canada's expenditures experienced fluctuations during this period, increasing from approximately $3.2 billion​ in 2019 (adjusted for inflation) to $5.1B in 2024."
 msgstr "De même, les dépenses de Transports Canada ont connu des fluctuations au cours de cette période, passant d'environ 3,2 milliards de dollars en 2019 (ajusté à l'inflation) à 5,1 milliards de dollars en 2024."
 
@@ -3224,21 +3296,21 @@ msgstr "Source"
 msgid "Source PDF"
 msgstr "PDF source"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:260
+#: src/app/[lang]/(main)/federal/spending/page.tsx:261
 #: src/app/[lang]/(main)/spending/page.tsx:251
 msgid "Source:"
 msgstr "Source :"
 
 #: src/app/[lang]/(main)/budget/page.tsx:267
-#: src/app/[lang]/(main)/federal/budget/page.tsx:304
-#: src/app/[lang]/(main)/federal/spending/page.tsx:275
+#: src/app/[lang]/(main)/federal/budget/page.tsx:306
+#: src/app/[lang]/(main)/federal/spending/page.tsx:276
 #: src/app/[lang]/(main)/spending/page.tsx:266
 #: src/components/first-nations/FirstNationsPageContent.tsx:473
 #: src/components/JurisdictionPageContent.tsx:504
 msgid "Sources"
 msgstr "Sources"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:235
+#: src/app/[lang]/(main)/federal/spending/page.tsx:236
 #: src/app/[lang]/(main)/spending/page.tsx:226
 #: src/components/JurisdictionPageContent.tsx:436
 #: src/components/JurisdictionPageContent.tsx:451
@@ -3335,7 +3407,7 @@ msgstr "Sous-total - Rémunération"
 msgid "Summary"
 msgstr "Résumé"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:183
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:183
 msgid "Support for Canada's Presence Abroad: $1.23B"
 msgstr "Soutien à la présence du Canada à l'étranger : 1,23 G$"
 
@@ -3412,7 +3484,7 @@ msgstr "Durée déterminée"
 msgid "Territorial Formula Financing"
 msgstr "Financement des territoires par formule"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:208
+#: src/app/[lang]/(main)/federal/spending/page.tsx:209
 #: src/app/[lang]/(main)/spending/page.tsx:199
 msgid "The average employee is 43.3 years old"
 msgstr "L'âge moyen des employés est de 43,3 ans"
@@ -3421,19 +3493,19 @@ msgstr "L'âge moyen des employés est de 43,3 ans"
 msgid "The best way to support us is to engage with our content. Like, share, and comment on our posts on social media. Even better, share our work with a friend and encourage them to do the same. Together, we can expand the conversation and reach more people with these important facts."
 msgstr "La meilleure façon de nous soutenir est d'interagir avec notre contenu. Aimez, partagez et commentez nos publications sur les réseaux sociaux. Mieux encore, partagez notre travail avec un ami et encouragez-le à faire de même. Ensemble, nous pouvons élargir la conversation et atteindre plus de gens avec ces faits importants."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:53
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:53
 msgid "The Canada Revenue Agency (CRA) is the federal institution responsible for administering tax laws, enforcing compliance, and delivering key benefit programs to individuals and businesses across Canada. Established in 1999 under the Canada Revenue Agency Act, the CRA operates with a workforce of approximately 59,155 employees (2024) and oversees tax revenues totaling $379 billion annually—which accounts for over 82% of federal revenues. It also administers over $46 billion in benefits and credits to Canadians, including the Canada Child Benefit and the GST/HST credit."
 msgstr "L'Agence du revenu du Canada (ARC) est l'institution fédérale responsable de l'administration des lois fiscales, de l'application de la conformité et de la prestation de programmes de prestations clés aux particuliers et aux entreprises à travers le Canada. Établie en 1999 en vertu de la Loi sur l'Agence du revenu du Canada, l'ARC fonctionne avec un effectif d'environ 59 155 employés (2024) et supervise des recettes fiscales totalisant 379 milliards de dollars annuellement—ce qui représente plus de 82 % des revenus fédéraux. Elle administre également plus de 46 milliards de dollars en prestations et crédits aux Canadiens, y compris l'Allocation canadienne pour enfants et le crédit pour la TPS/TVH."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:212
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:212
 msgid "The Canada Revenue Agency is overseen by the <0>Minister of National Revenue</0>, who is responsible for ensuring tax fairness and benefit program integrity but does not have direct authority over tax law interpretations."
 msgstr "L'Agence du revenu du Canada est supervisée par le <0>ministre du Revenu national</0>, qui est responsable d'assurer l'équité fiscale et l'intégrité des programmes de prestations, mais n'a pas d'autorité directe sur les interprétations des lois fiscales."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:87
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:87
 msgid "The Canada Revenue Agency spent $16.8 billion in fiscal year (FY) 2024, representing 3.2% of the $513.9 billion in total federal spending. The CRA's expenditures primarily support tax administration, benefit program delivery, compliance enforcement, and IT modernization."
 msgstr "L'Agence du revenu du Canada a dépensé 16,8 milliards de dollars au cours de l'exercice 2024, ce qui représente 3,2 % des 513,9 milliards de dollars de dépenses fédérales totales. Les dépenses de l'ARC soutiennent principalement l'administration fiscale, la prestation de programmes de prestations, l'application de la conformité et la modernisation des TI."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:97
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:97
 msgid "The CRA accounted for 3.2% of all federal spending in FY 2024"
 msgstr "L'ARC représentait 3,2 % de toutes les dépenses fédérales pour l'exercice 2024"
 
@@ -3441,83 +3513,83 @@ msgstr "L'ARC représentait 3,2 % de toutes les dépenses fédérales pour l'exe
 msgid "The cumulative surplus accumulated over time from operations."
 msgstr "L'excédent cumulé accumulé au fil du temps à partir des opérations."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:230
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:230
 msgid "The Department is currently led by the <0>Minister of Jobs and Families</0> who is appointed by the Governor General on the advice of the Prime Minister and then formally sworn into office at Rideau Hall. They take the Oath of Office and the Oath of Allegiance and become a member of the King's Privy Council for Canada."
 msgstr "Le ministère est actuellement dirigé par le <0>ministre des Emplois et des Familles</0> qui est nommé par le gouverneur général sur l'avis du premier ministre et ensuite officiellement assermenté à Rideau Hall. Il prête le serment d'office et le serment d'allégeance et devient membre du Conseil privé du Roi pour le Canada."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:202
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:202
 msgid "The Department is led by the <0>Minister of Finance</0>, who is appointed by the Governor General on the advice of the Prime Minister and then formally sworn into office at Rideau Hall. They take the Oath of Office and the Oath of Allegiance and become a member of the King's Privy Council for Canada."
 msgstr "Le ministère est dirigé par le <0>ministre des Finances</0>, qui est nommé par le gouverneur général sur l'avis du premier ministre et ensuite officiellement assermenté à Rideau Hall. Il prête le serment d'office et le serment d'allégeance et devient membre du Conseil privé du Roi pour le Canada."
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:163
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:163
 msgid "The Department is led by the <0>Minister of Public Safety</0>, who is appointed by the Governor General on the advice of the Prime Minister and then formally sworn into office at Rideau Hall. They take the Oath of Office and the Oath of Allegiance and become a member of the King's Privy Council for Canada."
 msgstr "Le ministère est dirigé par le <0>ministre de la Sécurité publique</0>, qui est nommé par le gouverneur général sur l'avis du premier ministre et ensuite officiellement assermenté à Rideau Hall. Il prête le serment d'office et le serment d'allégeance et devient membre du Conseil privé du Roi pour le Canada."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:54
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:54
 msgid "The Department of Finance (Finance Canada) is a central federal department responsible for overseeing the nation's economic and fiscal policies, ensuring financial stability, and managing the government's fiscal framework. Established in 1867 as one of the original departments following Confederation, it advises the Prime Minister and Cabinet on economic matters, develops tax and tariff policies, and prepares the annual federal budget."
 msgstr "Le ministère des Finances (Finances Canada) est un ministère fédéral central responsable de la supervision des politiques économiques et fiscales du pays, d'assurer la stabilité financière et de gérer le cadre fiscal du gouvernement. Établi en 1867 comme l'un des ministères originaux après la Confédération, il conseille le premier ministre et le Cabinet sur les questions économiques, élabore les politiques fiscales et tarifaires, et prépare le budget fédéral annuel."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:97
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:97
 msgid "The Department of Finance accounted for 26.4% of all federal spending in FY 2024."
 msgstr "Le ministère des Finances représentait 26,4 % de toutes les dépenses fédérales pour l'exercice 2024."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:86
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:86
 msgid "The Department of Finance spent $136.1 billion in fiscal year (FY) 2024. This was 26.4% of the $513.9 billion in overall federal spending. The department ranked first among federal departments in total spending."
 msgstr "Le ministère des Finances a dépensé 136,1 milliards de dollars au cours de l'exercice 2024. Cela représentait 26,4 % des 513,9 milliards de dollars de dépenses fédérales totales. Le ministère s'est classé premier parmi les ministères fédéraux en termes de dépenses totales."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:132
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:132
 msgid "The Department of Finance's share of federal spending in FY 2024 was lower than FY 1995."
 msgstr "La part des dépenses fédérales du ministère des Finances pour l'exercice 2024 était inférieure à celle de l'exercice 1995."
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:50
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:50
 msgid "The Department of Immigration, Refugees and Citizenship Canada (IRCC) is the federal department responsible for managing immigration policies, issuing passports, processing visas and permanent residency applications, and supporting newcomers to Canada. It plays a key role in shaping Canada's immigration system, refugee protection policies, and pathways to citizenship."
 msgstr "Le ministère de l'Immigration, des Réfugiés et de la Citoyenneté Canada (IRCC) est le ministère fédéral responsable de la gestion des politiques d'immigration, de la délivrance des passeports, du traitement des demandes de visa et de résidence permanente, et du soutien aux nouveaux arrivants au Canada. Il joue un rôle clé dans l'élaboration du système d'immigration du Canada, des politiques de protection des réfugiés et des voies d'accès à la citoyenneté."
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:50
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:50
 msgid "The Department of Innovation, Science and Industry (ISED) is the federal department responsible for fostering economic growth, technological advancement, and scientific research in Canada. It plays a key role in supporting businesses, funding research and development, and shaping policies that aim to enhance innovation, industrial competitiveness, and the prosperity of the Canadian economy."
 msgstr "Le ministère de l'Innovation, des Sciences et de l'Industrie (ISIC) est le ministère fédéral responsable de favoriser la croissance économique, l'avancement technologique et la recherche scientifique au Canada. Il joue un rôle clé dans le soutien aux entreprises, le financement de la recherche et du développement, et l'élaboration de politiques visant à améliorer l'innovation, la compétitivité industrielle et la prospérité de l'économie canadienne."
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:53
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:53
 msgid "The Department of National Defence (DND) and the Canadian Armed Forces (CAF) are responsible for ensuring Canada's security and defence through military operations, infrastructure management, and personnel support. Established in 1923 under the National Defence Act, DND oversees the defence budget, military procurement, and readiness planning, while the CAF executes domestic and international operations. The department provides strategic defence policy guidance and works with international allies, including NATO and NORAD, to ensure national security. DND also administers military health services, housing programs, and recruitment initiatives to support its personnel."
 msgstr "Le ministère de la Défense nationale (MDN) et les Forces armées canadiennes (FAC) sont responsables d'assurer la sécurité et la défense du Canada par le biais d'opérations militaires, de gestion des infrastructures et de soutien au personnel. Établi en 1923 en vertu de la Loi sur la défense nationale, le MDN supervise le budget de la défense, l'approvisionnement militaire et la planification de la disponibilité opérationnelle, tandis que les FAC exécutent des opérations nationales et internationales. Le ministère fournit des orientations stratégiques en matière de politique de défense et travaille avec des alliés internationaux, y compris l'OTAN et le NORAD, pour assurer la sécurité nationale. Le MDN administre également les services de santé militaires, les programmes de logement et les initiatives de recrutement pour soutenir son personnel."
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:214
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:214
 msgid "The Department of National Defence is led by the <0>Minister of National Defence</0>, who is appointed by the Governor General on the advice of the Prime Minister. The minister is responsible for overseeing national defense policy, military operations, and procurement."
 msgstr "Le ministère de la Défense nationale est dirigé par le <0>ministre de la Défense nationale</0>, qui est nommé par le gouverneur général sur l'avis du premier ministre. Le ministre est responsable de la supervision de la politique de défense nationale, des opérations militaires et de l'approvisionnement."
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:95
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:95
 msgid "The Department of National Defence spent $34.5 billion in fiscal year (FY) 2024. This represented 6.7% of the $513.9 billion in total federal spending. DND ranked among the top federal departments in expenditures, largely driven by personnel costs, military procurement, and operational readiness efforts."
 msgstr "Le ministère de la Défense nationale a dépensé 34,5 milliards de dollars au cours de l'exercice 2024. Cela représentait 6,7 % des 513,9 milliards de dollars de dépenses fédérales totales. Le MDN s'est classé parmi les principaux ministères fédéraux en termes de dépenses, largement motivées par les coûts de personnel, l'approvisionnement militaire et les efforts de disponibilité opérationnelle."
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:51
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:51
 msgid "The Department of Transport (Transport Canada) is the federal department responsible for developing and enforcing transportation policies, regulations, and infrastructure projects to ensure safe and efficient movement of people and goods across Canada. It oversees aviation, rail, marine, and road transportation systems, working to enhance national connectivity and economic growth."
 msgstr "Le ministère des Transports (Transports Canada) est le ministère fédéral responsable de l'élaboration et de l'application des politiques, des règlements et des projets d'infrastructure en matière de transport pour assurer le déplacement sûr et efficace des personnes et des biens à travers le Canada. Il supervise les systèmes de transport aérien, ferroviaire, maritime et routier, travaillant à améliorer la connectivité nationale et la croissance économique."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:51
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:51
 msgid "The Department of Veterans Affairs Canada (VAC) is the federal department responsible for supporting and serving Canadian veterans, active-duty military personnel, and their families. It provides financial assistance, healthcare support, rehabilitation services, and recognition programs to honor the contributions of those who have served in the Canadian Armed Forces. Additionally, the department is responsible for remembrance initiatives that preserve Canada's military history."
 msgstr "Le ministère des Anciens Combattants Canada (ACC) est le ministère fédéral responsable du soutien et du service aux anciens combattants canadiens, au personnel militaire en service actif et à leurs familles. Il fournit une aide financière, un soutien en matière de soins de santé, des services de réadaptation et des programmes de reconnaissance pour honorer les contributions de ceux qui ont servi dans les Forces armées canadiennes. De plus, le ministère est responsable des initiatives de commémoration qui préservent l'histoire militaire du Canada."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:113
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:113
 msgid "The department's spending grew at a rate significantly higher than overall spending, reflecting shifts in federal priorities. In 2024, ESDC accounted for 18.4% of all federal spending, 16.51 percentage points higher than in 2005."
 msgstr "Les dépenses du ministère ont augmenté à un rythme significativement plus élevé que les dépenses globales, reflétant les changements dans les priorités fédérales. En 2024, EDSC représentait 18,4 % de toutes les dépenses fédérales, soit 16,51 points de pourcentage de plus qu'en 2005."
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:123
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:123
 msgid "The department's spending grew at a rate significantly lower than overall spending, reflecting shifts in federal priorities. In FY 2024, Health Canada accounted for 2.7% of all federal spending, 3.14 percentage points lower than in 1995."
 msgstr "Les dépenses du ministère ont augmenté à un rythme significativement plus faible que les dépenses globales, reflétant les changements dans les priorités fédérales. Au cours de l'exercice 2024, Santé Canada représentait 2,7 % de toutes les dépenses fédérales, soit 3,14 points de pourcentage de moins qu'en 1995."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:113
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:113
 msgid "The department's spending has grown less than overall spending, which means that the department's share of the federal budget has increased. In FY 2024, VAC accounted for 1.1% of all federal spending, about the same share as in 1995."
 msgstr "Les dépenses du ministère ont augmenté moins que les dépenses globales, ce qui signifie que la part du ministère dans le budget fédéral a augmenté. Au cours de l'exercice 2024, ACC représentait 1,1 % de toutes les dépenses fédérales, soit environ la même part qu'en 1995."
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:109
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:109
 msgid "The department's spending has grown more than overall spending, which means that the department's share of the federal budget has increased. In FY 2024, IRCC accounted for 1.2% of all federal spending, 0.8 percentage points higher than in 1995."
 msgstr "Les dépenses du ministère ont augmenté plus que les dépenses globales, ce qui signifie que la part du ministère dans le budget fédéral a augmenté. Au cours de l'exercice 2024, IRCC représentait 1,2 % de toutes les dépenses fédérales, soit 0,8 point de pourcentage de plus qu'en 1995."
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:111
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:111
 msgid "The department's spending has grown more than overall spending, which means that the department's share of the federal budget has increased. In FY 2024, ISED accounted for 2% of all federal spending, 0.17 percentage points higher than in 1995."
 msgstr "Les dépenses du ministère ont augmenté plus que les dépenses globales, ce qui signifie que la part du ministère dans le budget fédéral a augmenté. Au cours de l'exercice 2024, ISIC représentait 2 % de toutes les dépenses fédérales, soit 0,17 point de pourcentage de plus qu'en 1995."
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:112
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:112
 msgid "The department's spending has increased less than overall spending has grown and the department's share of the federal budget has decreased over time. In FY 2024, PSPC accounted for 1.6% of all federal spending, 1 percentage point lower than in 1995."
 msgstr "Les dépenses du ministère ont augmenté moins que les dépenses globales et la part du ministère dans le budget fédéral a diminué au fil du temps. Au cours de l'exercice 2024, SPAC représentait 1,6 % de toutes les dépenses fédérales, soit 1 point de pourcentage de moins qu'en 1995."
 
@@ -3529,51 +3601,51 @@ msgstr "La différence entre les revenus et les dépenses. Un excédent indique 
 msgid "The difference between total revenue and total expenses. A surplus indicates revenue exceeded expenses."
 msgstr "La différence entre les revenus totaux et les dépenses totales. Un excédent indique que les revenus ont dépassé les dépenses."
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:193
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:193
 msgid "The leadership of ISC and CIRNAC are led by the <0>Minister of Indigenous Services Canada</0> and the <1>Minister of Crown-Indigenous Relations and Northern Affairs Canada</1>, respectively. These Ministers are appointed by the Governor General on the advice of the Prime Minister and then formally sworn into office at Rideau Hall. They take the Oath of Office and the Oath of Allegiance and become a member of the King's Privy Council for Canada."
 msgstr "La direction de SAC et RCAANC est assurée respectivement par le <0>ministre des Services aux Autochtones Canada</0> et le <1>ministre des Relations Couronne-Autochtones et des Affaires du Nord Canada</1>. Ces ministres sont nommés par le gouverneur général sur l'avis du premier ministre et sont ensuite officiellement assermentés à Rideau Hall. Ils prêtent le serment d'office et le serment d'allégeance et deviennent membres du Conseil privé du Roi pour le Canada."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:189
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:189
 msgid "The Minister is responsible for overseeing benefits and services for veterans, ensuring their well-being, and leading national remembrance initiatives."
 msgstr "Le ministre est responsable de la supervision des prestations et des services aux anciens combattants, d'assurer leur bien-être et de diriger les initiatives nationales de commémoration."
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:188
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:188
 msgid "The Minister is responsible for overseeing Canada's transportation policies, ensuring safety regulations, investing in infrastructure, and leading climate initiatives related to aviation, rail, marine, and road transportation."
 msgstr "Le ministre est responsable de la supervision des politiques de transport du Canada, d'assurer les règlements de sécurité, d'investir dans l'infrastructure et de diriger les initiatives climatiques liées au transport aérien, ferroviaire, maritime et routier."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:214
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:214
 msgid "The Minister of Finance is one of the <0>cabinet members</0> who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister takes office and appoints a new cabinet. Outgoing ministers remain in their roles until their successors are sworn in."
 msgstr "Le ministre des Finances est l'un des <0>membres du cabinet</0> qui servent à la discrétion du premier ministre. Leur mandat se termine généralement lorsqu'ils démissionnent, sont remplacés ou lorsqu'un nouveau premier ministre prend ses fonctions et nomme un nouveau cabinet. Les ministres sortants restent en fonction jusqu'à ce que leurs successeurs soient assermentés."
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:181
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:181
 msgid "The Minister of Immigration, Refugees and Citizenship is one of the cabinet members who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister appoints a new cabinet. Outgoing ministers continue in their roles until their successors are sworn in."
 msgstr "Le ministre de l'Immigration, des Réfugiés et de la Citoyenneté est l'un des membres du cabinet qui servent à la discrétion du premier ministre. Leur mandat se termine généralement lorsqu'ils démissionnent, sont remplacés ou lorsqu'un nouveau premier ministre nomme un nouveau cabinet. Les ministres sortants continuent dans leurs rôles jusqu'à ce que leurs successeurs soient assermentés."
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:181
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:181
 msgid "The Minister of Innovation, Science and Industry is one of the cabinet members who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister appoints a new cabinet. Outgoing ministers continue in their roles until their successors are sworn in."
 msgstr "Le ministre de l'Innovation, des Sciences et de l'Industrie est l'un des membres du cabinet qui servent à la discrétion du premier ministre. Leur mandat se termine généralement lorsqu'ils démissionnent, sont remplacés ou lorsqu'un nouveau premier ministre nomme un nouveau cabinet. Les ministres sortants continuent dans leurs rôles jusqu'à ce que leurs successeurs soient assermentés."
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:188
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:188
 msgid "The Minister of Public Services and Procurement is one of the cabinet members who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister appoints a new cabinet. Outgoing ministers continue in their roles until their successors are sworn in."
 msgstr "Le ministre des Services publics et de l'Approvisionnement est l'un des membres du cabinet qui servent à la discrétion du premier ministre. Leur mandat se termine généralement lorsqu'ils démissionnent, sont remplacés ou lorsqu'un nouveau premier ministre nomme un nouveau cabinet. Les ministres sortants continuent dans leurs rôles jusqu'à ce que leurs successeurs soient assermentés."
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:179
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:179
 msgid "The Minister of Transport is one of the cabinet members who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister appoints a new cabinet. Outgoing ministers continue in their roles until their successors are sworn in."
 msgstr "Le ministre des Transports est l'un des membres du cabinet qui servent à la discrétion du premier ministre. Leur mandat se termine généralement lorsqu'ils démissionnent, sont remplacés ou lorsqu'un nouveau premier ministre nomme un nouveau cabinet. Les ministres sortants continuent dans leurs rôles jusqu'à ce que leurs successeurs soient assermentés."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:180
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:180
 msgid "The Minister of Veterans Affairs is one of the cabinet members who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister appoints a new cabinet. Outgoing ministers continue in their roles until their successors are sworn in."
 msgstr "Le ministre des Anciens Combattants est l'un des membres du cabinet qui servent à la discrétion du premier ministre. Leur mandat se termine généralement lorsqu'ils démissionnent, sont remplacés ou lorsqu'un nouveau premier ministre nomme un nouveau cabinet. Les ministres sortants continuent dans leurs rôles jusqu'à ce que leurs successeurs soient assermentés."
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:254
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:254
 msgid "The ministers work alongside the Deputy Minister of Foreign Affairs and the Deputy Minister of International Trade, who manage the department's operational and policy frameworks."
 msgstr "Les ministres travaillent aux côtés du sous-ministre des Affaires étrangères et du sous-ministre du Commerce international, qui gèrent les cadres opérationnels et politiques du ministère."
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:52
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:52
 msgid "The Public Services and Procurement Canada (PSPC) is the federal department responsible for providing centralized procurement, real estate management, pay and pension administration for federal employees, and translation services to the Government of Canada. It ensures that government departments have the goods, services, and infrastructure they need to operate efficiently while maintaining transparency, fairness, and value for taxpayers."
 msgstr "Services publics et Approvisionnement Canada (SPAC) est le ministère fédéral responsable de l'approvisionnement centralisé, de la gestion immobilière, de l'administration de la paye et des pensions pour les employés fédéraux, et des services de traduction pour le gouvernement du Canada. Il s'assure que les ministères gouvernementaux disposent des biens, des services et de l'infrastructure dont ils ont besoin pour fonctionner efficacement tout en maintenant la transparence, l'équité et la valeur pour les contribuables."
 
-#: src/app/[lang]/(main)/federal/budget/page.tsx:194
+#: src/app/[lang]/(main)/federal/budget/page.tsx:196
 msgid "The values you see here are based on the FY 2024 Budget with preliminary updates based on government announcements, memos, and leaks, and are meant to provide a rough idea of the budget. Once the official Fall 2025 Budget is released on November 4th, we will update this page to reflect the official budget."
 msgstr "Les valeurs que vous voyez ici sont basées sur le budget de l'exercice 2024 avec des mises à jour préliminaires basées sur les annonces gouvernementales, les notes de service et les fuites, et sont destinées à donner une idée générale du budget. Une fois le budget officiel de l'automne 2025 publié le 4 novembre, nous mettrons à jour cette page pour refléter le budget officiel."
 
@@ -3581,19 +3653,19 @@ msgstr "Les valeurs que vous voyez ici sont basées sur le budget de l'exercice 
 msgid "Theme"
 msgstr "Thème"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:223
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:242
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:261
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:183
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:194
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:211
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:225
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:175
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:223
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:242
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:261
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:183
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:194
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:211
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:225
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:175
 msgid "These Ministers are some of the <0>cabinet members</0> who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister takes office and appoints a new cabinet. Outgoing ministers remain in their roles until their successors are sworn in."
 msgstr "Ces ministres sont parmi les <0>membres du cabinet</0> qui servent à la discrétion du premier ministre. Leur mandat se termine généralement lorsqu'ils démissionnent, sont remplacés ou lorsqu'un nouveau premier ministre prend ses fonctions et nomme un nouveau cabinet. Les ministres sortants restent en fonction jusqu'à ce que leurs successeurs soient assermentés."
 
 #: src/app/[lang]/(main)/budget/page.tsx:159
-#: src/app/[lang]/(main)/federal/budget/page.tsx:187
+#: src/app/[lang]/(main)/federal/budget/page.tsx:189
 msgid "This page presents the official Fall 2025 Federal Budget as released by the Government of Canada on November 4th, 2025. All data is sourced directly from official government publications and public accounts from the Government of Canada."
 msgstr "Cette page présente le budget fédéral officiel de l'automne 2025 tel que publié par le gouvernement du Canada le 4 novembre 2025. Toutes les données proviennent directement des publications officielles du gouvernement et des comptes publics du gouvernement du Canada."
 
@@ -3609,7 +3681,7 @@ msgstr "Ce tableau n'a pas été vérifié."
 msgid "This visualization shows how your income tax contributions are allocated across different government programs and services based on current government spending patterns. Amounts under $20 are grouped into \"Other\" for conciseness."
 msgstr "Cette visualisation montre comment vos contributions d'impôt sur le revenu sont allouées à différents programmes et services gouvernementaux en fonction des modèles de dépenses gouvernementales actuels. Les montants inférieurs à 20 $ sont regroupés dans \"Autre\" pour plus de concision."
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:62
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:62
 msgid "Through the Public Health Agency of Canada (PHAC), Health Canada monitors public health risks, manages disease outbreaks, and promotes health initiatives. It also funds medical research via the Canadian Institutes of Health Research (CIHR) and oversees healthcare services for Indigenous communities."
 msgstr "Par l'intermédiaire de l'Agence de la santé publique du Canada (ASPC), Santé Canada surveille les risques pour la santé publique, gère les éclosions de maladies et fait la promotion d'initiatives en matière de santé. Il finance également la recherche médicale par l'entremise des Instituts de recherche en santé du Canada (IRSC) et supervise les services de santé pour les communautés autochtones."
 
@@ -3645,7 +3717,7 @@ msgid "Total assets minus total liabilities. This represents the First Nation's 
 msgstr "Total des actifs moins total des passifs. Ceci représente la situation financière globale de la Première Nation."
 
 #: src/app/[lang]/(main)/budget/page.tsx:175
-#: src/app/[lang]/(main)/federal/budget/page.tsx:212
+#: src/app/[lang]/(main)/federal/budget/page.tsx:214
 msgid "Total Budget"
 msgstr "Budget total"
 
@@ -3673,7 +3745,7 @@ msgstr "Total impôt fédéral"
 msgid "Total Financial Assets"
 msgstr "Total des actifs financiers"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:171
+#: src/app/[lang]/(main)/federal/spending/page.tsx:172
 #: src/app/[lang]/(main)/spending/page.tsx:162
 msgid "Total full-time equivalents"
 msgstr "Équivalents temps plein totaux"
@@ -3736,7 +3808,7 @@ msgstr "Dépenses totales en {0}"
 msgid "Total Tax"
 msgstr "Impôt total"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:183
+#: src/app/[lang]/(main)/federal/spending/page.tsx:184
 #: src/app/[lang]/(main)/spending/page.tsx:174
 msgid "Total Wages"
 msgstr "Salaires totaux"
@@ -3745,23 +3817,23 @@ msgstr "Salaires totaux"
 msgid "Trade and Investment"
 msgstr "Commerce et investissement"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:174
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:174
 msgid "Trade and Investment: $380.3M"
 msgstr "Commerce et investissement : 380,3 M$"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:55
 msgid "Transfer Payments"
 msgstr "Paiements de transfert"
 
@@ -3770,24 +3842,24 @@ msgstr "Paiements de transfert"
 msgid "Transfers to Provinces"
 msgstr "Transferts aux provinces"
 
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:86
 msgid "Transport Canada"
 msgstr "Transports Canada"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:33
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:33
 msgid "Transport Canada | Canada Spends"
 msgstr "Transports Canada | Canada Dépense"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:91
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:91
 msgid "Transport Canada accounted for 1% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 msgstr "Transports Canada représentait 1 % de toutes les dépenses fédérales pour l'exercice 2024. 10 ministères gouvernementaux représentaient 73,2 % des dépenses fédérales pour l'exercice 2024"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:169
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:169
 msgid "Transport Canada is led by the Minister of Transport, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 msgstr "Transports Canada est dirigé par le ministre des Transports, qui est nommé par le gouverneur général sur l'avis du premier ministre et officiellement assermenté à Rideau Hall. Lors de sa nomination, le ministre prête le serment d'office et le serment d'allégeance, devenant membre du Conseil privé du Roi pour le Canada."
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:82
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:82
 msgid "Transport Canada spent $5.1 billion in fiscal year (FY) 2024. This was 1% of the $513.9 billion in overall federal spending. The department ranked fourteenth among federal departments in total spending."
 msgstr "Transports Canada a dépensé 5,1 milliards de dollars au cours de l'exercice 2024. Cela représentait 1 % des 513,9 milliards de dollars de dépenses fédérales totales. Le ministère s'est classé quatorzième parmi les ministères fédéraux en termes de dépenses totales."
 
@@ -3795,27 +3867,27 @@ msgstr "Transports Canada a dépensé 5,1 milliards de dollars au cours de l'exe
 msgid "Transportation"
 msgstr "Transport"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:23
 msgid "Transportation + Communication"
 msgstr "Transport + Communication"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:23
 msgid "Transportation and Communication"
 msgstr "Transport et Communication"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:241
-#: src/app/[lang]/(main)/federal/spending/page.tsx:262
+#: src/app/[lang]/(main)/federal/spending/page.tsx:242
+#: src/app/[lang]/(main)/federal/spending/page.tsx:263
 #: src/app/[lang]/(main)/spending/page.tsx:232
 #: src/app/[lang]/(main)/spending/page.tsx:253
 #: src/components/Sankey/index.tsx:346
@@ -3826,7 +3898,7 @@ msgstr "Conseil du Trésor"
 msgid "Tribunal Award"
 msgstr "Décision du tribunal"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:191
+#: src/app/[lang]/(main)/federal/spending/page.tsx:192
 #: src/app/[lang]/(main)/spending/page.tsx:182
 msgid "Type of Tenure"
 msgstr "Type d'emploi"
@@ -3839,44 +3911,44 @@ msgstr "Comprendre votre contribution fiscale"
 msgid "Use a computer you trust, not one provided by your employer."
 msgstr "Utilisez un ordinateur en qui vous avez confiance, pas un ordinateur fourni par votre employeur."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:43
 msgid "Utilities, Materials and Supplies"
 msgstr "Services publics, matériel et fournitures"
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:92
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:92
 msgid "VAC accounted for 1.2% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 msgstr "ACC représentait 1,2 % de toutes les dépenses fédérales pour l'exercice 2024. 10 ministères gouvernementaux représentaient 73,2 % des dépenses fédérales pour l'exercice 2024"
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:84
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:84
 msgid "VAC spent $6.1 billion in fiscal year (FY) 2024. This was 1.2% of the $513.9 billion in overall federal spending. The department ranked thirteenth among federal departments in total spending."
 msgstr "ACC a dépensé 6,1 milliards de dollars au cours de l'exercice 2024. Cela représentait 1,2 % des 513,9 milliards de dollars de dépenses fédérales totales. Le ministère s'est classé treizième parmi les ministères fédéraux en termes de dépenses totales."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:131
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:131
 msgid "VAC's expenditures also grew slightly during this period, increasing from approximately $5.5B​ in 2019 when adjusted for inflation to $6.3B in 2024."
 msgstr "Les dépenses d'ACC ont également légèrement augmenté pendant cette période, passant d'environ 5,5 milliards de dollars en 2019, après ajustement pour l'inflation, à 6,3 milliards de dollars en 2024."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:80
 msgid "Veterans Affairs"
 msgstr "Anciens Combattants"
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:170
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:170
 msgid "Veterans Affairs Canada (VAC) is led by the Minister of Veterans Affairs, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 msgstr "Anciens Combattants Canada (ACC) est dirigé par le ministre des Anciens Combattants, qui est nommé par le gouverneur général sur l'avis du premier ministre et officiellement assermenté à Rideau Hall. Lors de sa nomination, le ministre prête le serment d'office et le serment d'allégeance, devenant membre du Conseil privé du Roi pour le Canada."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:33
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:33
 msgid "Veterans Affairs Canada | Canada Spends"
 msgstr "Anciens Combattants Canada | Canada Dépense"
 
@@ -3890,7 +3962,7 @@ msgstr "Consultez les états financiers {year} pour {0}{provinceSuffix}. Compren
 msgid "View detailed tax breakdown"
 msgstr "Voir le détail des impôts"
 
-#: src/app/[lang]/(main)/federal/budget/page.tsx:174
+#: src/app/[lang]/(main)/federal/budget/page.tsx:176
 msgid "View Federal 2025 Budget Details"
 msgstr "Voir les détails du budget fédéral 2025"
 
@@ -3908,8 +3980,8 @@ msgid "View source data"
 msgstr "Voir les données sources"
 
 #: src/app/[lang]/(main)/budget/page.tsx:242
-#: src/app/[lang]/(main)/federal/budget/page.tsx:279
-#: src/app/[lang]/(main)/federal/spending/page.tsx:158
+#: src/app/[lang]/(main)/federal/budget/page.tsx:281
+#: src/app/[lang]/(main)/federal/spending/page.tsx:159
 #: src/app/[lang]/(main)/spending/page.tsx:149
 #: src/components/JurisdictionPageContent.tsx:393
 msgid "View this chart in full screen"
@@ -3934,59 +4006,59 @@ msgstr "Vous voulez encore plus d'anonymat?"
 msgid "was spent by {0}"
 msgstr "a été dépensé par {0}"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:76
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:76
 msgid "was spent by ESDC"
 msgstr "a été dépensé par EDSC"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:74
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:74
 msgid "was spent by Finance Canada"
 msgstr "a été dépensé par Finances Canada"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:80
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:80
 msgid "was spent by Health Canada"
 msgstr "a été dépensé par Santé Canada"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:82
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:82
 msgid "was spent by Housing, Infrastructure and Communities Canada"
 msgstr "a été dépensé par Logement, Infrastructure et Collectivités Canada"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:87
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:87
 msgid "was spent by ISC and CIRNAC"
 msgstr "a été dépensé par SAC et RCAANC"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:72
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:72
 msgid "Was spent by Public Services and Procurement Canada"
 msgstr "A été dépensé par Services publics et Approvisionnement Canada"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:75
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:75
 msgid "was spent by the Canada Revenue Agency"
 msgstr "a été dépensé par l'Agence du revenu du Canada"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:78
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:78
 msgid "was spent by the Department of National Defence"
 msgstr "ont été dépensés par le ministère de la Défense nationale"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:69
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:69
 msgid "Was spent by the Dept. of Immigration, Refugees and Citizenship"
 msgstr "A été dépensé par le ministère de l'Immigration, des Réfugiés et de la Citoyenneté"
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:70
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:70
 msgid "Was spent by the Dept. of Innovation, Science and Industry"
 msgstr "A été dépensé par le ministère de l'Innovation, des Sciences et de l'Industrie"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:70
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:70
 msgid "Was spent by the Dept. of Transport"
 msgstr "A été dépensé par le ministère des Transports"
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:72
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:72
 msgid "Was spent by the Dept. of Veterans Affairs"
 msgstr "A été dépensé par le ministère des Anciens Combattants"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:82
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:82
 msgid "was spent by the Global Affairs Canada"
 msgstr "a été dépensé par Affaires mondiales Canada"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:74
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:74
 msgid "was spent by the Public Safety Canada"
 msgstr "a été dépensé par Sécurité publique Canada"
 
@@ -4034,6 +4106,11 @@ msgstr "Nous sommes strictement non partisans—nous ne jugeons pas les politiqu
 msgid "Weather Services"
 msgstr "Services météorologiques"
 
+#. placeholder {0}: user.email
+#: src/app/[lang]/(main)/notifications/page.tsx:47
+msgid "Welcome, {0}!"
+msgstr "Bienvenue, {0}!"
+
 #: src/components/Sankey/index.tsx:122
 msgid "Western + Northern Economic Development"
 msgstr "Développement économique de l'Ouest + du Nord"
@@ -4058,7 +4135,7 @@ msgstr "Quelle est votre méthodologie?"
 msgid "What Makes a Good Tip?"
 msgstr "Qu'est-ce qui fait une bonne information?"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:123
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:123
 msgid "When HICC was founded in FY 2005 as the Office of Infrastructure Canada, the department's spending has grown from $250,000 to over $14 billion, a significant increase in overall spending and mandate. In FY 2024, HICC accounted for 2.8% of all federal spending."
 msgstr "Lorsque LGIC a été fondé au cours de l'exercice 2005 en tant que Bureau de l'infrastructure du Canada, les dépenses du ministère sont passées de 250 000 $ à plus de 14 milliards de dollars, une augmentation significative des dépenses globales et du mandat. Au cours de l'exercice 2024, LGIC représentait 2,8 % de toutes les dépenses fédérales."
 
@@ -4071,11 +4148,11 @@ msgstr "D'où proviennent les données sur votre site web?"
 msgid "Where Your Tax Dollars Go"
 msgstr "Où vont vos dollars d'impôt"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:140
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:140
 msgid "While GAC's spending has increased in real terms, its share of the federal budget has also increased moderately over the past decades. In 2024, GAC accounted for 3.7% of federal spending, compared to 2% in 1995."
 msgstr "Bien que les dépenses d'AMC aient augmenté en termes réels, sa part du budget fédéral a également augmenté modérément au cours des dernières décennies. En 2024, AMC représentait 3,7 % des dépenses fédérales, contre 2 % en 1995."
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:90
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:90
 msgid "While not in the top 10 departments by spend, ISED accounted for 2% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 msgstr "Bien que ne figurant pas parmi les 10 premiers ministères en termes de dépenses, ISIC représentait 2 % de toutes les dépenses fédérales pour l'exercice 2024. 10 ministères gouvernementaux représentaient 73,2 % des dépenses fédérales pour l'exercice 2024"
 
@@ -4090,59 +4167,59 @@ msgstr "Lanceurs d'alerte"
 msgid "Whistleblowers | Secure Anonymous Tips | Canada Spends"
 msgstr "Lanceurs d'alerte | Informations anonymes sécurisées | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:227
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:227
 msgid "Who leads ESDC?"
 msgstr "Qui dirige EDSC?"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:224
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:224
 msgid "Who leads Global Affairs Canada?"
 msgstr "Qui dirige Affaires mondiales Canada?"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:167
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:167
 msgid "Who leads Health Canada?"
 msgstr "Qui dirige Santé Canada?"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:175
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:175
 msgid "Who leads Housing, Infrastructure and Communities Canada?"
 msgstr "Qui dirige Logement, Infrastructure et Collectivités Canada?"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:165
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:165
 msgid "Who Leads Immigration, Refugees and Citizenship Canada (IRCC)?"
 msgstr "Qui dirige Immigration, Réfugiés et Citoyenneté Canada (IRCC)?"
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:166
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:166
 msgid "Who Leads Innovation, Science and Industry Canada (ISED)?"
 msgstr "Qui dirige Innovation, Sciences et Industrie Canada (ISIC)?"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:190
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:190
 msgid "Who leads ISC and CIRNAC?"
 msgstr "Qui dirige SAC et RCAANC?"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:160
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:160
 msgid "Who leads Public Safety Canada?"
 msgstr "Qui dirige Sécurité publique Canada?"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:172
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:172
 msgid "Who Leads Public Services and Procurement Canada (PSPC)?"
 msgstr "Qui dirige Services publics et Approvisionnement Canada (SPAC)?"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:209
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:209
 msgid "Who leads the Canada Revenue Agency?"
 msgstr "Qui dirige l'Agence du revenu du Canada?"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:199
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:199
 msgid "Who leads the Department of Finance?"
 msgstr "Qui dirige le ministère des Finances?"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:211
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:211
 msgid "Who leads the Department of National Defence?"
 msgstr "Qui dirige le ministère de la Défense nationale?"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:166
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:166
 msgid "Who Leads Transport Canada?"
 msgstr "Qui dirige Transports Canada?"
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:167
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:167
 msgid "Who Leads Veterans Affairs Canada (VAC)?"
 msgstr "Qui dirige Anciens Combattants Canada (ACC)?"
 
@@ -4166,6 +4243,14 @@ msgstr "Vous pouvez accéder à notre plateforme de dénonciation directement vi
 #: src/app/[lang]/(main)/page.tsx:86
 msgid "You deserve the facts"
 msgstr "Vous méritez les faits"
+
+#: src/app/[lang]/(main)/notifications/page.tsx:50
+msgid "You have no new notifications."
+msgstr "Vous n'avez aucune nouvelle notification."
+
+#: src/app/[lang]/(main)/notifications/page.tsx:19
+msgid "Your notifications"
+msgstr "Vos notifications"
 
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:778
 msgid "Your tax contributions are approximated based on employment income. Deductions such as basic personal amount are estimated and included. Other sources of income, such as self-employment, investment income, and capital gains, are not included in the calculations. Deductions such as RRSP and FHSA contributions are also not included."

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,13 +2,41 @@
  * For more info see
  * https://nextjs.org/docs/app/building-your-application/routing/internationalization
  * */
+import { createServerClient } from "@supabase/ssr";
 import { type NextRequest, NextResponse } from "next/server";
 
 import Negotiator from "negotiator";
 import { locales } from "./locales";
 
-export function middleware(request: NextRequest) {
+export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
+
+  // Refresh Supabase auth session on every request
+  let supabaseResponse = NextResponse.next({ request });
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value }) =>
+            request.cookies.set(name, value),
+          );
+          supabaseResponse = NextResponse.next({ request });
+          cookiesToSet.forEach(({ name, value, options }) =>
+            supabaseResponse.cookies.set(name, value, options),
+          );
+        },
+      },
+    },
+  );
+
+  // Refresh the session — this is required for Server Components to read the session
+  await supabase.auth.getUser();
 
   const pathnameHasLocale = locales.some(
     (locale) => pathname.startsWith(`/${locale}/`) || pathname === `/${locale}`,
@@ -17,21 +45,30 @@ export function middleware(request: NextRequest) {
   const pathnameIsPostHog = pathname.startsWith("/ph");
   const pathnameIsSitemap = pathname === "/sitemap.xml";
   const pathnameIsRobots = pathname === "/robots.txt";
+  const pathnameIsAuthCallback = pathname.startsWith("/auth/callback");
 
   if (
     pathnameHasLocale ||
     pathnameIsPostHog ||
     pathnameIsSitemap ||
-    pathnameIsRobots
+    pathnameIsRobots ||
+    pathnameIsAuthCallback
   )
-    return;
+    return supabaseResponse;
 
   // Redirect if there is no locale
   const locale = getRequestLocale(request.headers);
   request.nextUrl.pathname = `/${locale}${pathname}`;
   // e.g. incoming request is /products
   // The new URL is now /en/products
-  return NextResponse.redirect(request.nextUrl);
+  const redirectResponse = NextResponse.redirect(request.nextUrl);
+
+  // Copy Supabase cookies to the redirect response
+  supabaseResponse.cookies.getAll().forEach((cookie) => {
+    redirectResponse.cookies.set(cookie.name, cookie.value);
+  });
+
+  return redirectResponse;
 }
 
 function getRequestLocale(requestHeaders: Headers): string {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,32 @@
+/**
+ * For more details on how to configure Wrangler, refer to:
+ * https://developers.cloudflare.com/workers/wrangler/configuration/
+ */
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "canadaspends",
+  "account_id": "af43b5869a980d4edc6c18f15cd7aa2d",
+  "main": ".open-next/worker.js",
+  "compatibility_date": "2025-12-01",
+  "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
+  "assets": {
+    "binding": "ASSETS",
+    "directory": ".open-next/assets"
+  },
+  "images": {
+    // Enable image optimization
+    // see https://opennext.js.org/cloudflare/howtos/image
+    "binding": "IMAGES"
+  },
+  "services": [
+    {
+      // Self-reference service binding, the service name must match the worker name
+      // see https://opennext.js.org/cloudflare/caching
+      "binding": "WORKER_SELF_REFERENCE",
+      "service": "canadaspends"
+    }
+  ],
+  "observability": {
+    "enabled": true
+  }
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -26,6 +26,33 @@
       "service": "canadaspends"
     }
   ],
+  "r2_buckets": [
+    {
+      "binding": "NEXT_INC_CACHE_R2_BUCKET",
+      "bucket_name": "canadaspends-cache"
+    }
+  ],
+  "d1_databases": [
+    {
+      "binding": "NEXT_TAG_CACHE_D1",
+      "database_name": "canadaspends-tag-cache",
+      "database_id": "76a608a6-4754-4beb-a153-ba9dc2cabda0"
+    }
+  ],
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "NEXT_CACHE_DO_QUEUE",
+        "class_name": "DOQueueHandler"
+      }
+    ]
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["DOQueueHandler"]
+    }
+  ],
   "observability": {
     "enabled": false,
     "head_sampling_rate": 1,

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -27,6 +27,18 @@
     }
   ],
   "observability": {
-    "enabled": true
+    "enabled": false,
+    "head_sampling_rate": 1,
+    "logs": {
+      "enabled": true,
+      "head_sampling_rate": 1,
+      "persist": true,
+      "invocation_logs": true
+    },
+    "traces": {
+      "enabled": true,
+      "persist": true,
+      "head_sampling_rate": 1
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Adds Supabase Auth with four OAuth providers (Google, GitHub, X, Discord) plus email/password sign-in
- Integrates with PostHog — calls `posthog.identify()` on sign-in and `posthog.reset()` on sign-out
- Adds a protected `/notifications` page that redirects unauthenticated users to login
- Shows a "Sign Out" button in the nav only when logged in
- **Adds Cloudflare Workers deployment with OpenNext**

## Cloudflare Workers Deployment

New files for Cloudflare Workers deployment via OpenNext:
- `wrangler.jsonc` — Cloudflare Workers configuration
- `open-next.config.ts` — OpenNext Cloudflare adapter config
- `public/_headers` — Static asset caching headers

New scripts:
- `pnpm preview` — Build and preview locally with Wrangler
- `pnpm deploy` — Build and deploy to Cloudflare Workers
- `pnpm upload` — Build and upload a version

Setup: Connect repo to Cloudflare Workers Builds in the dashboard for automatic deployments and preview URLs on PRs.

## Auth files
- `src/lib/supabase/client.ts` — Browser client
- `src/lib/supabase/server.ts` — Server client (cookies-based)
- `src/app/auth/callback/route.ts` — OAuth callback handler
- `src/components/AuthListener.tsx` — PostHog identify/reset on auth state change
- `src/components/UserMenu.tsx` — Sign out button (hidden when logged out)
- `src/app/[lang]/(main)/login/page.tsx` + `login-form.tsx` — Login page
- `src/app/[lang]/(main)/notifications/page.tsx` — Sample protected page

## Modified files
- `src/middleware.ts` — Supabase session refresh on every request
- `src/app/layout.tsx` + `src/app/[lang]/layout.tsx` — Added AuthListener
- `DesktopNav.tsx` + `MobileMenu.tsx` — Added UserMenu
- `src/locales/fr.po` — French translations for all new strings
- `next.config.ts` — Added `initOpenNextCloudflareForDev()`
- `.gitignore` — Added `.open-next` and `.dev.vars`

## Prerequisites
- Supabase Auth enabled on the project
- OAuth providers configured in Supabase dashboard (Google, GitHub, X, Discord)
- `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` set in `.env`

## Test plan
- [ ] Visit `/en/login` — see login form with 4 OAuth buttons + email/password
- [ ] Sign up with email/password, verify toast confirmation
- [ ] Sign in with each OAuth provider
- [ ] Verify "Sign Out" appears in nav after login
- [ ] Visit `/en/notifications` while logged in — see welcome page
- [ ] Visit `/en/notifications` while logged out — redirected to login
- [ ] Sign out, verify nav button disappears
- [ ] Verify PostHog identify/reset via browser console
- [ ] Run `pnpm preview` to test Cloudflare Workers build locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)