### PR TITLE
Add Quebec-specific tax overrides (QPP, QPIP, reduced EI)

### DIFF
--- a/src/app/[lang]/(main)/tax-visualizer/page.tsx
+++ b/src/app/[lang]/(main)/tax-visualizer/page.tsx
@@ -292,10 +292,16 @@ function FederalTaxCard({
   );
   const incomeTaxAmount = Math.max(0, incomeTaxBeforeCredit - bpaCredit);
 
+  // Resolve province-level overrides for pension and EI (e.g., Quebec QPP, reduced Quebec EI)
+  const pensionConfig = provincialConfig.pensionPlanOverride ?? config.cpp;
+  const pensionAdditionalConfig =
+    provincialConfig.pensionPlanAdditionalOverride ?? config.cpp2;
+  const eiConfig = provincialConfig.eiOverride ?? config.ei;
+
   // Calculate payroll contributions
-  const cppAmount = calculateCappedContribution(income, config.cpp);
-  const cpp2Amount = calculateCpp2Contribution(income, config.cpp2);
-  const eiAmount = calculateCappedContribution(income, config.ei);
+  const cppAmount = calculateCappedContribution(income, pensionConfig);
+  const cpp2Amount = calculateCpp2Contribution(income, pensionAdditionalConfig);
+  const eiAmount = calculateCappedContribution(income, eiConfig);
   const payrollTotal = cppAmount + cpp2Amount + eiAmount;
 
   // Calculate federal abatement (Quebec Abatement)
@@ -351,14 +357,14 @@ function FederalTaxCard({
             <tbody>
               <tr>
                 <td className="py-1 text-muted-foreground">
-                  <div>{config.cpp.shortName}</div>
+                  <div>{pensionConfig.shortName}</div>
                   <div className="text-xs text-muted-foreground/70">
-                    {formatAmount(config.cpp.exemption)} -{" "}
-                    {formatAmount(config.cpp.maxEarnings)}
+                    {formatAmount(pensionConfig.exemption)} -{" "}
+                    {formatAmount(pensionConfig.maxEarnings)}
                   </div>
                 </td>
                 <td className="py-1 text-right align-top w-20">
-                  {formatPercent(config.cpp.rate)}
+                  {formatPercent(pensionConfig.rate)}
                 </td>
                 <td className="py-1 text-right font-medium align-top w-20">
                   {formatAmount(cppAmount)}
@@ -366,14 +372,14 @@ function FederalTaxCard({
               </tr>
               <tr className={cpp2Amount === 0 ? "opacity-40" : ""}>
                 <td className="py-1 text-muted-foreground">
-                  <div>{config.cpp2.shortName}</div>
+                  <div>{pensionAdditionalConfig.shortName}</div>
                   <div className="text-xs text-muted-foreground/70">
-                    {formatAmount(config.cpp2.ympe)} -{" "}
-                    {formatAmount(config.cpp2.yampe)}
+                    {formatAmount(pensionAdditionalConfig.ympe)} -{" "}
+                    {formatAmount(pensionAdditionalConfig.yampe)}
                   </div>
                 </td>
                 <td className="py-1 text-right align-top w-20">
-                  {formatPercent(config.cpp2.rate)}
+                  {formatPercent(pensionAdditionalConfig.rate)}
                 </td>
                 <td className="py-1 text-right font-medium align-top w-20">
                   {formatAmount(cpp2Amount)}
@@ -381,13 +387,13 @@ function FederalTaxCard({
               </tr>
               <tr>
                 <td className="py-1 text-muted-foreground">
-                  <div>{config.ei.shortName}</div>
+                  <div>{eiConfig.shortName}</div>
                   <div className="text-xs text-muted-foreground/70">
-                    <Trans>First</Trans> {formatAmount(config.ei.maxEarnings)}
+                    <Trans>First</Trans> {formatAmount(eiConfig.maxEarnings)}
                   </div>
                 </td>
                 <td className="py-1 text-right align-top w-20">
-                  {formatPercent(config.ei.rate)}
+                  {formatPercent(eiConfig.rate)}
                 </td>
                 <td className="py-1 text-right font-medium align-top w-20">
                   {formatAmount(eiAmount)}
@@ -447,9 +453,16 @@ function ProvincialTaxCard({
   const healthPremiumAmount = config.healthPremium
     ? calculateHealthPremium(income, config.healthPremium)
     : 0;
+  const parentalInsuranceAmount = config.parentalInsurance
+    ? calculateCappedContribution(income, config.parentalInsurance)
+    : 0;
 
   // Overall total
-  const totalProvincialTax = provincialTax + surtaxAmount + healthPremiumAmount;
+  const totalProvincialTax =
+    provincialTax +
+    surtaxAmount +
+    healthPremiumAmount +
+    parentalInsuranceAmount;
 
   return (
     <div className="bg-card rounded-lg shadow-sm border p-6 flex flex-col">
@@ -531,6 +544,34 @@ function ProvincialTaxCard({
                 {formatAmount(healthPremiumAmount)}
               </span>
             </div>
+          </div>
+        )}
+
+        {/* Provincial parental insurance (e.g., Quebec QPIP) */}
+        {config.parentalInsurance && (
+          <div className="mt-6 pt-4 border-t border-border">
+            <h4 className="font-semibold text-base mb-3">
+              {config.parentalInsurance.name}
+            </h4>
+            <table className="w-full text-left text-sm">
+              <tbody>
+                <tr>
+                  <td className="py-1 text-muted-foreground">
+                    <div>{config.parentalInsurance.shortName}</div>
+                    <div className="text-xs text-muted-foreground/70">
+                      <Trans>First</Trans>{" "}
+                      {formatAmount(config.parentalInsurance.maxEarnings)}
+                    </div>
+                  </td>
+                  <td className="py-1 text-right align-top w-20">
+                    {formatPercent(config.parentalInsurance.rate)}
+                  </td>
+                  <td className="py-1 text-right font-medium align-top w-20">
+                    {formatAmount(parentalInsuranceAmount)}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
           </div>
         )}
       </div>

--- a/src/app/[lang]/(main)/tax-visualizer/page.tsx
+++ b/src/app/[lang]/(main)/tax-visualizer/page.tsx
@@ -292,15 +292,17 @@ function FederalTaxCard({
   );
   const incomeTaxAmount = Math.max(0, incomeTaxBeforeCredit - bpaCredit);
 
-  // Resolve province-level overrides for pension and EI (e.g., Quebec QPP, reduced Quebec EI)
-  const pensionConfig = provincialConfig.pensionPlanOverride ?? config.cpp;
-  const pensionAdditionalConfig =
-    provincialConfig.pensionPlanAdditionalOverride ?? config.cpp2;
+  // Resolve EI override (Quebec residents pay a reduced rate). The pension
+  // plan, when overridden, is administered provincially (Retraite Québec)
+  // and is rendered in the Provincial card instead.
   const eiConfig = provincialConfig.eiOverride ?? config.ei;
-
-  // Calculate payroll contributions
-  const cppAmount = calculateCappedContribution(income, pensionConfig);
-  const cpp2Amount = calculateCpp2Contribution(income, pensionAdditionalConfig);
+  const hasProvincialPension = !!provincialConfig.pensionPlanOverride;
+  const cppAmount = hasProvincialPension
+    ? 0
+    : calculateCappedContribution(income, config.cpp);
+  const cpp2Amount = hasProvincialPension
+    ? 0
+    : calculateCpp2Contribution(income, config.cpp2);
   const eiAmount = calculateCappedContribution(income, eiConfig);
   const payrollTotal = cppAmount + cpp2Amount + eiAmount;
 
@@ -355,36 +357,40 @@ function FederalTaxCard({
           </h4>
           <table className="w-full text-left text-sm">
             <tbody>
-              <tr>
-                <td className="py-1 text-muted-foreground">
-                  <div>{pensionConfig.shortName}</div>
-                  <div className="text-xs text-muted-foreground/70">
-                    {formatAmount(pensionConfig.exemption)} -{" "}
-                    {formatAmount(pensionConfig.maxEarnings)}
-                  </div>
-                </td>
-                <td className="py-1 text-right align-top w-20">
-                  {formatPercent(pensionConfig.rate)}
-                </td>
-                <td className="py-1 text-right font-medium align-top w-20">
-                  {formatAmount(cppAmount)}
-                </td>
-              </tr>
-              <tr className={cpp2Amount === 0 ? "opacity-40" : ""}>
-                <td className="py-1 text-muted-foreground">
-                  <div>{pensionAdditionalConfig.shortName}</div>
-                  <div className="text-xs text-muted-foreground/70">
-                    {formatAmount(pensionAdditionalConfig.ympe)} -{" "}
-                    {formatAmount(pensionAdditionalConfig.yampe)}
-                  </div>
-                </td>
-                <td className="py-1 text-right align-top w-20">
-                  {formatPercent(pensionAdditionalConfig.rate)}
-                </td>
-                <td className="py-1 text-right font-medium align-top w-20">
-                  {formatAmount(cpp2Amount)}
-                </td>
-              </tr>
+              {!hasProvincialPension && (
+                <>
+                  <tr>
+                    <td className="py-1 text-muted-foreground">
+                      <div>{config.cpp.shortName}</div>
+                      <div className="text-xs text-muted-foreground/70">
+                        {formatAmount(config.cpp.exemption)} -{" "}
+                        {formatAmount(config.cpp.maxEarnings)}
+                      </div>
+                    </td>
+                    <td className="py-1 text-right align-top w-20">
+                      {formatPercent(config.cpp.rate)}
+                    </td>
+                    <td className="py-1 text-right font-medium align-top w-20">
+                      {formatAmount(cppAmount)}
+                    </td>
+                  </tr>
+                  <tr className={cpp2Amount === 0 ? "opacity-40" : ""}>
+                    <td className="py-1 text-muted-foreground">
+                      <div>{config.cpp2.shortName}</div>
+                      <div className="text-xs text-muted-foreground/70">
+                        {formatAmount(config.cpp2.ympe)} -{" "}
+                        {formatAmount(config.cpp2.yampe)}
+                      </div>
+                    </td>
+                    <td className="py-1 text-right align-top w-20">
+                      {formatPercent(config.cpp2.rate)}
+                    </td>
+                    <td className="py-1 text-right font-medium align-top w-20">
+                      {formatAmount(cpp2Amount)}
+                    </td>
+                  </tr>
+                </>
+              )}
               <tr>
                 <td className="py-1 text-muted-foreground">
                   <div>{eiConfig.shortName}</div>
@@ -456,13 +462,22 @@ function ProvincialTaxCard({
   const parentalInsuranceAmount = config.parentalInsurance
     ? calculateCappedContribution(income, config.parentalInsurance)
     : 0;
+  // Province-administered pension plan (e.g., Quebec QPP / QPP2)
+  const provincialPensionAmount = config.pensionPlanOverride
+    ? calculateCappedContribution(income, config.pensionPlanOverride)
+    : 0;
+  const provincialPensionAdditionalAmount = config.pensionPlanAdditionalOverride
+    ? calculateCpp2Contribution(income, config.pensionPlanAdditionalOverride)
+    : 0;
 
   // Overall total
   const totalProvincialTax =
     provincialTax +
     surtaxAmount +
     healthPremiumAmount +
-    parentalInsuranceAmount;
+    parentalInsuranceAmount +
+    provincialPensionAmount +
+    provincialPensionAdditionalAmount;
 
   return (
     <div className="bg-card rounded-lg shadow-sm border p-6 flex flex-col">
@@ -544,6 +559,64 @@ function ProvincialTaxCard({
                 {formatAmount(healthPremiumAmount)}
               </span>
             </div>
+          </div>
+        )}
+
+        {/* Province-administered pension plan (e.g., Quebec QPP / QPP2) */}
+        {config.pensionPlanOverride && (
+          <div className="mt-6 pt-4 border-t border-border">
+            <h4 className="font-semibold text-base mb-3">
+              {config.pensionPlanOverride.name}
+            </h4>
+            <table className="w-full text-left text-sm">
+              <tbody>
+                <tr>
+                  <td className="py-1 text-muted-foreground">
+                    <div>{config.pensionPlanOverride.shortName}</div>
+                    <div className="text-xs text-muted-foreground/70">
+                      {formatAmount(config.pensionPlanOverride.exemption)} -{" "}
+                      {formatAmount(config.pensionPlanOverride.maxEarnings)}
+                    </div>
+                  </td>
+                  <td className="py-1 text-right align-top w-20">
+                    {formatPercent(config.pensionPlanOverride.rate)}
+                  </td>
+                  <td className="py-1 text-right font-medium align-top w-20">
+                    {formatAmount(provincialPensionAmount)}
+                  </td>
+                </tr>
+                {config.pensionPlanAdditionalOverride && (
+                  <tr
+                    className={
+                      provincialPensionAdditionalAmount === 0
+                        ? "opacity-40"
+                        : ""
+                    }
+                  >
+                    <td className="py-1 text-muted-foreground">
+                      <div>
+                        {config.pensionPlanAdditionalOverride.shortName}
+                      </div>
+                      <div className="text-xs text-muted-foreground/70">
+                        {formatAmount(
+                          config.pensionPlanAdditionalOverride.ympe,
+                        )}{" "}
+                        -{" "}
+                        {formatAmount(
+                          config.pensionPlanAdditionalOverride.yampe,
+                        )}
+                      </div>
+                    </td>
+                    <td className="py-1 text-right align-top w-20">
+                      {formatPercent(config.pensionPlanAdditionalOverride.rate)}
+                    </td>
+                    <td className="py-1 text-right font-medium align-top w-20">
+                      {formatAmount(provincialPensionAdditionalAmount)}
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
           </div>
         )}
 

--- a/src/lib/tax/calculator.quebec.test.ts
+++ b/src/lib/tax/calculator.quebec.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import { calculateDetailedTax } from "./calculator";
+
+// These tests verify that Quebec residents are charged QPP (not CPP), QPIP,
+// and a reduced EI rate, per the published Revenu Québec / CRA rates.
+
+describe("Quebec calculator overrides", () => {
+  describe("2024", () => {
+    it("uses QPP (6.40% rate) instead of CPP (5.95%) for Quebec", () => {
+      const detailed = calculateDetailedTax(80000, "quebec", "2024");
+      // 2024 max QPP1 = ($68,500 - $3,500) * 6.40% = $4,160.00.
+      // At $80,000 income, the worker is over the YMPE so the max applies.
+      expect(detailed.cppContribution).toBeCloseTo(4160, 2);
+
+      const cppLine = detailed.lineItems.find(
+        (l) => l.id === "cpp-contribution",
+      );
+      expect(cppLine?.name).toBe("Québec Pension Plan");
+    });
+
+    it("uses QPP2 (4% on $68,500-$73,200) instead of CPP2 for Quebec", () => {
+      const detailed = calculateDetailedTax(80000, "quebec", "2024");
+      // Max QPP2 = ($73,200 - $68,500) * 4% = $188.00.
+      expect(detailed.cpp2Contribution).toBeCloseTo(188, 2);
+    });
+
+    it("uses reduced Quebec EI rate (1.32%) on max $63,200", () => {
+      const detailed = calculateDetailedTax(80000, "quebec", "2024");
+      // Max Quebec EI = $63,200 * 1.32% = $834.24.
+      expect(detailed.eiContribution).toBeCloseTo(834.24, 2);
+    });
+
+    it("charges QPIP (0.494% on max $94,000)", () => {
+      const detailed = calculateDetailedTax(100000, "quebec", "2024");
+      // Max QPIP = $94,000 * 0.494% = $464.36.
+      expect(detailed.parentalInsuranceContribution).toBeCloseTo(464.36, 2);
+    });
+
+    it("does NOT charge QPIP for Ontario residents", () => {
+      const detailed = calculateDetailedTax(100000, "ontario", "2024");
+      expect(detailed.parentalInsuranceContribution).toBe(0);
+    });
+
+    it("uses CPP (not QPP) for Ontario residents", () => {
+      const detailed = calculateDetailedTax(80000, "ontario", "2024");
+      // 2024 max CPP1 = ($68,500 - $3,500) * 5.95% = $3,867.50.
+      expect(detailed.cppContribution).toBeCloseTo(3867.5, 2);
+
+      const cppLine = detailed.lineItems.find(
+        (l) => l.id === "cpp-contribution",
+      );
+      expect(cppLine?.name).toBe("Canada Pension Plan");
+    });
+  });
+
+  describe("2025", () => {
+    it("uses QPP (6.40%) with YMPE $71,300 → max $4,339.20", () => {
+      const detailed = calculateDetailedTax(100000, "quebec", "2025");
+      expect(detailed.cppContribution).toBeCloseTo(4339.2, 2);
+    });
+
+    it("uses QPP2 (4% on $71,300-$81,200) → max $396", () => {
+      const detailed = calculateDetailedTax(100000, "quebec", "2025");
+      expect(detailed.cpp2Contribution).toBeCloseTo(396, 2);
+    });
+
+    it("uses reduced Quebec EI rate (1.31%) on max $65,700 → max $860.67", () => {
+      const detailed = calculateDetailedTax(100000, "quebec", "2025");
+      expect(detailed.eiContribution).toBeCloseTo(860.67, 2);
+    });
+
+    it("charges QPIP (0.494% on max $98,000) → max $484.12", () => {
+      const detailed = calculateDetailedTax(100000, "quebec", "2025");
+      expect(detailed.parentalInsuranceContribution).toBeCloseTo(484.12, 2);
+    });
+  });
+
+  describe("2023 (no QPP2)", () => {
+    it("uses QPP (6.40%) with YMPE $66,600 → max $4,038.40", () => {
+      const detailed = calculateDetailedTax(80000, "quebec", "2023");
+      expect(detailed.cppContribution).toBeCloseTo(4038.4, 2);
+    });
+
+    it("does not charge QPP2 in 2023 (introduced in 2024)", () => {
+      const detailed = calculateDetailedTax(80000, "quebec", "2023");
+      expect(detailed.cpp2Contribution).toBe(0);
+    });
+  });
+
+  it("low income only pays the rated portion (proportional)", () => {
+    // At $30,000 income for Quebec 2024:
+    // QPP = ($30,000 - $3,500) * 6.40% = $1,696.00
+    // EI = $30,000 * 1.32% = $396.00
+    // QPIP = $30,000 * 0.494% = $148.20
+    const detailed = calculateDetailedTax(30000, "quebec", "2024");
+    expect(detailed.cppContribution).toBeCloseTo(1696, 2);
+    expect(detailed.eiContribution).toBeCloseTo(396, 2);
+    expect(detailed.parentalInsuranceContribution).toBeCloseTo(148.2, 2);
+  });
+});

--- a/src/lib/tax/calculator.quebec.test.ts
+++ b/src/lib/tax/calculator.quebec.test.ts
@@ -88,6 +88,40 @@ describe("Quebec calculator overrides", () => {
     });
   });
 
+  it("counts QPP/QPP2 as provincial, not federal", () => {
+    // Quebec QPP is administered by Retraite Québec (provincial program), so
+    // QPP and QPP2 contributions belong in provincialTax, not federalTax.
+    const detailed = calculateDetailedTax(80000, "quebec", "2024");
+    const cppLine = detailed.lineItems.find((l) => l.id === "cpp-contribution");
+    const cpp2Line = detailed.lineItems.find(
+      (l) => l.id === "cpp2-contribution",
+    );
+    expect(cppLine?.level).toBe("provincial");
+    expect(cpp2Line?.level).toBe("provincial");
+
+    // Federal total excludes QPP/QPP2; provincial total includes them.
+    // Federal: federal income tax + Quebec EI − Quebec abatement
+    // Provincial: Quebec income tax + QPP + QPP2 + QPIP
+    const expectedFederal =
+      detailed.federalIncomeTax +
+      detailed.eiContribution -
+      detailed.federalAbatement;
+    expect(detailed.federalTax).toBeCloseTo(expectedFederal, 2);
+
+    const expectedProvincial =
+      detailed.provincialIncomeTax +
+      detailed.cppContribution +
+      detailed.cpp2Contribution +
+      detailed.parentalInsuranceContribution;
+    expect(detailed.provincialTax).toBeCloseTo(expectedProvincial, 2);
+  });
+
+  it("counts CPP/CPP2 as federal for non-Quebec provinces", () => {
+    const detailed = calculateDetailedTax(80000, "ontario", "2024");
+    const cppLine = detailed.lineItems.find((l) => l.id === "cpp-contribution");
+    expect(cppLine?.level).toBe("federal");
+  });
+
   it("low income only pays the rated portion (proportional)", () => {
     // At $30,000 income for Quebec 2024:
     // QPP = ($30,000 - $3,500) * 6.40% = $1,696.00

--- a/src/lib/tax/calculator.ts
+++ b/src/lib/tax/calculator.ts
@@ -42,6 +42,16 @@ function calculateWithConfig(
 ): DetailedTaxCalculation {
   const lineItems: TaxLineItem[] = [];
 
+  // Resolve province-level overrides for pension plan and EI
+  // (e.g., Quebec residents pay QPP instead of CPP, and a reduced EI rate
+  // because Quebec administers QPIP).
+  const pensionConfig =
+    config.provincial.pensionPlanOverride ?? config.federal.cpp;
+  const pensionAdditionalConfig =
+    config.provincial.pensionPlanAdditionalOverride ?? config.federal.cpp2;
+  const eiConfig = config.provincial.eiOverride ?? config.federal.ei;
+  const parentalInsuranceConfig = config.provincial.parentalInsurance;
+
   // Federal income tax
   const federalIncomeTax = calculateBracketTax(
     income,
@@ -56,45 +66,62 @@ function calculateWithConfig(
     category: "incomeTax",
   });
 
-  // EI contribution
-  const eiContribution = calculateCappedContribution(income, config.federal.ei);
+  // EI contribution (Quebec residents pay a reduced rate; see eiConfig)
+  const eiContribution = calculateCappedContribution(income, eiConfig);
   lineItems.push({
     id: "ei-contribution",
-    name: "Employment Insurance",
+    name: eiConfig.name,
     level: "federal",
     amount: eiContribution,
     effectiveRate: income > 0 ? (eiContribution / income) * 100 : 0,
     category: "ei",
   });
 
-  // CPP contribution
-  const cppContribution = calculateCappedContribution(
-    income,
-    config.federal.cpp,
-  );
+  // Pension plan contribution (CPP for most provinces, QPP for Quebec)
+  const cppContribution = calculateCappedContribution(income, pensionConfig);
   lineItems.push({
     id: "cpp-contribution",
-    name: "Canada Pension Plan",
+    name: pensionConfig.name,
     level: "federal",
     amount: cppContribution,
     effectiveRate: income > 0 ? (cppContribution / income) * 100 : 0,
     category: "cpp",
   });
 
-  // CPP2 contribution (second additional CPP)
+  // Second additional pension contribution (CPP2 / QPP2)
   const cpp2Contribution = calculateCpp2Contribution(
     income,
-    config.federal.cpp2,
+    pensionAdditionalConfig,
   );
   if (cpp2Contribution > 0) {
     lineItems.push({
       id: "cpp2-contribution",
-      name: "CPP Second Additional",
+      name: pensionAdditionalConfig.name,
       level: "federal",
       amount: cpp2Contribution,
       effectiveRate: income > 0 ? (cpp2Contribution / income) * 100 : 0,
       category: "cpp2",
     });
+  }
+
+  // Provincial parental insurance (Quebec QPIP)
+  let parentalInsuranceContribution = 0;
+  if (parentalInsuranceConfig) {
+    parentalInsuranceContribution = calculateCappedContribution(
+      income,
+      parentalInsuranceConfig,
+    );
+    if (parentalInsuranceContribution > 0) {
+      lineItems.push({
+        id: "parental-insurance-contribution",
+        name: parentalInsuranceConfig.name,
+        level: "provincial",
+        amount: parentalInsuranceContribution,
+        effectiveRate:
+          income > 0 ? (parentalInsuranceContribution / income) * 100 : 0,
+        category: "parentalInsurance",
+      });
+    }
   }
 
   // Provincial income tax
@@ -174,7 +201,11 @@ function calculateWithConfig(
     cppContribution +
     cpp2Contribution -
     federalAbatement;
-  const provincialTax = provincialIncomeTax + surtax + healthPremium;
+  const provincialTax =
+    provincialIncomeTax +
+    surtax +
+    healthPremium +
+    parentalInsuranceContribution;
   const totalTax = federalTax + provincialTax;
   const netIncome = income - totalTax;
   const effectiveTaxRate = income > 0 ? (totalTax / income) * 100 : 0;
@@ -197,6 +228,7 @@ function calculateWithConfig(
     eiContribution,
     cppContribution,
     cpp2Contribution,
+    parentalInsuranceContribution,
     surtax,
     healthPremium,
     federalAbatement,

--- a/src/lib/tax/calculator.ts
+++ b/src/lib/tax/calculator.ts
@@ -51,6 +51,12 @@ function calculateWithConfig(
     config.provincial.pensionPlanAdditionalOverride ?? config.federal.cpp2;
   const eiConfig = config.provincial.eiOverride ?? config.federal.ei;
   const parentalInsuranceConfig = config.provincial.parentalInsurance;
+  // The pension plan is a provincial program when the province administers
+  // its own (e.g., Quebec's QPP via Retraite Québec).
+  const pensionLevel: "federal" | "provincial" = config.provincial
+    .pensionPlanOverride
+    ? "provincial"
+    : "federal";
 
   // Federal income tax
   const federalIncomeTax = calculateBracketTax(
@@ -82,7 +88,7 @@ function calculateWithConfig(
   lineItems.push({
     id: "cpp-contribution",
     name: pensionConfig.name,
-    level: "federal",
+    level: pensionLevel,
     amount: cppContribution,
     effectiveRate: income > 0 ? (cppContribution / income) * 100 : 0,
     category: "cpp",
@@ -97,7 +103,7 @@ function calculateWithConfig(
     lineItems.push({
       id: "cpp2-contribution",
       name: pensionAdditionalConfig.name,
-      level: "federal",
+      level: pensionLevel,
       amount: cpp2Contribution,
       effectiveRate: income > 0 ? (cpp2Contribution / income) * 100 : 0,
       category: "cpp2",
@@ -194,18 +200,21 @@ function calculateWithConfig(
     }
   }
 
-  // Calculate totals
+  // Calculate totals. Pension contributions count toward provincial tax
+  // when the province administers its own plan (e.g., Quebec QPP/QPP2),
+  // and toward federal tax otherwise (CPP/CPP2).
+  const pensionFederalAmount =
+    pensionLevel === "federal" ? cppContribution + cpp2Contribution : 0;
+  const pensionProvincialAmount =
+    pensionLevel === "provincial" ? cppContribution + cpp2Contribution : 0;
   const federalTax =
-    federalIncomeTax +
-    eiContribution +
-    cppContribution +
-    cpp2Contribution -
-    federalAbatement;
+    federalIncomeTax + eiContribution + pensionFederalAmount - federalAbatement;
   const provincialTax =
     provincialIncomeTax +
     surtax +
     healthPremium +
-    parentalInsuranceContribution;
+    parentalInsuranceContribution +
+    pensionProvincialAmount;
   const totalTax = federalTax + provincialTax;
   const netIncome = income - totalTax;
   const effectiveTaxRate = income > 0 ? (totalTax / income) * 100 : 0;

--- a/src/lib/tax/configs/2023/quebec.ts
+++ b/src/lib/tax/configs/2023/quebec.ts
@@ -1,5 +1,20 @@
 import { ProvincialTaxConfig } from "../../types";
 
+// Sources (verified):
+// - Income tax brackets & basic personal amount: Revenu Québec — Income Tax Rates
+//   https://www.revenuquebec.ca/en/citizens/income-tax-return/completing-your-income-tax-return/income-tax-rates/
+// - QPP rate, YMPE, basic exemption, max contribution: Retraite Québec — QPP figures
+//   https://www.rrq.gouv.qc.ca/en/programmes/regime_rentes/regime_chiffres/Pages/regime_chiffres.aspx
+//   2023: rate 6.40% (5.40% base + 1.00% additional), YMPE $66,600, basic exemption $3,500.
+//   Max employee QPP = ($66,600 − $3,500) × 6.40% = $4,038.40.
+//   No QPP2 / second additional in 2023 (introduced in 2024).
+// - EI (Quebec): Canada.ca — EI premium rates (Quebec rate is reduced because of QPIP)
+//   https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/payroll/payroll-deductions-contributions/employment-insurance-ei/ei-premium-rates-maximums.html
+//   2023 Quebec EI rate 1.27% on max insurable $61,500 → max $781.05.
+// - QPIP (employee): Conseil de gestion de l’assurance parentale / Revenu Québec
+//   https://www.rqap.gouv.qc.ca/en/about-the-plan/general-information/premiums-and-maximum-insurable-earnings
+//   2023: employee rate 0.494%, max insurable $91,000 → max $449.54.
+
 export const QUEBEC_TAX_CONFIG: ProvincialTaxConfig = {
   incomeTax: {
     type: "bracket",
@@ -16,5 +31,33 @@ export const QUEBEC_TAX_CONFIG: ProvincialTaxConfig = {
     type: "federalAbatement",
     name: "Quebec Abatement",
     rate: 0.165, // 16.5% reduction in federal income tax
+  },
+  pensionPlanOverride: {
+    type: "capped",
+    name: "Québec Pension Plan",
+    shortName: "QPP",
+    rate: 0.064,
+    exemption: 3500,
+    maxEarnings: 66600,
+    maxContribution: 4038.4,
+  },
+  // No QPP2 in 2023 — second additional contribution begins in 2024.
+  eiOverride: {
+    type: "capped",
+    name: "Employment Insurance (Quebec)",
+    shortName: "EI",
+    rate: 0.0127,
+    exemption: 0,
+    maxEarnings: 61500,
+    maxContribution: 781.05,
+  },
+  parentalInsurance: {
+    type: "capped",
+    name: "Québec Parental Insurance Plan",
+    shortName: "QPIP",
+    rate: 0.00494,
+    exemption: 0,
+    maxEarnings: 91000,
+    maxContribution: 449.54,
   },
 };

--- a/src/lib/tax/configs/2024/quebec.ts
+++ b/src/lib/tax/configs/2024/quebec.ts
@@ -1,5 +1,22 @@
 import { ProvincialTaxConfig } from "../../types";
 
+// Sources (verified):
+// - Income tax brackets & basic personal amount: Revenu Québec — Income Tax Rates
+//   https://www.revenuquebec.ca/en/citizens/income-tax-return/completing-your-income-tax-return/income-tax-rates/
+// - QPP rate, YMPE, basic exemption, max contribution: Retraite Québec / Revenu Québec
+//   https://www.revenuquebec.ca/en/businesses/source-deductions-and-employer-contributions/calculating-source-deductions-and-employer-contributions/quebec-pension-plan-contributions/maximum-pensionable-salary-or-wages-and-contribution-rate/
+//   2024: rate 6.40%, YMPE $68,500, basic exemption $3,500.
+//   Max employee QPP1 = ($68,500 − $3,500) × 6.40% = $4,160.00.
+// - QPP2 (second additional): introduced in 2024.
+//   2024: rate 4%, YMPE $68,500, YAMPE $73,200 (107% of YMPE).
+//   Max employee QPP2 = ($73,200 − $68,500) × 4% = $188.00.
+// - EI (Quebec): Canada.ca — EI premium rates (Quebec rate reduced due to QPIP)
+//   https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/payroll/payroll-deductions-contributions/employment-insurance-ei/ei-premium-rates-maximums.html
+//   2024 Quebec EI rate 1.32% on max insurable $63,200 → max $834.24.
+// - QPIP (employee): Conseil de gestion de l’assurance parentale
+//   https://www.rqap.gouv.qc.ca/en/about-the-plan/general-information/premiums-and-maximum-insurable-earnings
+//   2024: employee rate 0.494%, max insurable $94,000 → max $464.36.
+
 export const QUEBEC_TAX_CONFIG: ProvincialTaxConfig = {
   incomeTax: {
     type: "bracket",
@@ -16,5 +33,41 @@ export const QUEBEC_TAX_CONFIG: ProvincialTaxConfig = {
     type: "federalAbatement",
     name: "Quebec Abatement",
     rate: 0.165, // 16.5% reduction in federal income tax
+  },
+  pensionPlanOverride: {
+    type: "capped",
+    name: "Québec Pension Plan",
+    shortName: "QPP",
+    rate: 0.064,
+    exemption: 3500,
+    maxEarnings: 68500,
+    maxContribution: 4160,
+  },
+  pensionPlanAdditionalOverride: {
+    type: "cpp2",
+    name: "QPP Second Additional",
+    shortName: "QPP2",
+    rate: 0.04,
+    ympe: 68500,
+    yampe: 73200,
+    maxContribution: 188,
+  },
+  eiOverride: {
+    type: "capped",
+    name: "Employment Insurance (Quebec)",
+    shortName: "EI",
+    rate: 0.0132,
+    exemption: 0,
+    maxEarnings: 63200,
+    maxContribution: 834.24,
+  },
+  parentalInsurance: {
+    type: "capped",
+    name: "Québec Parental Insurance Plan",
+    shortName: "QPIP",
+    rate: 0.00494,
+    exemption: 0,
+    maxEarnings: 94000,
+    maxContribution: 464.36,
   },
 };

--- a/src/lib/tax/configs/2025/quebec.ts
+++ b/src/lib/tax/configs/2025/quebec.ts
@@ -1,5 +1,21 @@
 import { ProvincialTaxConfig } from "../../types";
 
+// Sources (verified):
+// - Income tax brackets & basic personal amount: Revenu Québec — Income Tax Rates
+//   https://www.revenuquebec.ca/en/citizens/income-tax-return/completing-your-income-tax-return/income-tax-rates/
+// - QPP rate, YMPE, basic exemption, max contribution: Revenu Québec / Retraite Québec
+//   https://www.revenuquebec.ca/en/businesses/source-deductions-and-employer-contributions/calculating-source-deductions-and-employer-contributions/quebec-pension-plan-contributions/maximum-pensionable-salary-or-wages-and-contribution-rate/
+//   2025: rate 6.40%, YMPE $71,300, basic exemption $3,500.
+//   Max employee QPP1 = ($71,300 − $3,500) × 6.40% = $4,339.20.
+// - QPP2 (second additional): 2025 rate 4% on earnings between YMPE $71,300 and
+//   YAMPE $81,200 (114% of YMPE). Max employee QPP2 = ($81,200 − $71,300) × 4% = $396.00.
+// - EI (Quebec): Canada.ca — EI premium rates 2025 (Quebec reduced due to QPIP)
+//   https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/payroll/payroll-deductions-contributions/employment-insurance-ei/ei-premium-rates-maximums.html
+//   2025 Quebec EI rate 1.31% on max insurable $65,700 → max $860.67.
+// - QPIP (employee): Conseil de gestion de l’assurance parentale
+//   https://www.rqap.gouv.qc.ca/en/about-the-plan/general-information/premiums-and-maximum-insurable-earnings
+//   2025: employee rate 0.494%, max insurable $98,000 → max $484.12.
+
 export const QUEBEC_TAX_CONFIG: ProvincialTaxConfig = {
   incomeTax: {
     type: "bracket",
@@ -16,5 +32,41 @@ export const QUEBEC_TAX_CONFIG: ProvincialTaxConfig = {
     type: "federalAbatement",
     name: "Quebec Abatement",
     rate: 0.165, // 16.5% reduction in federal income tax
+  },
+  pensionPlanOverride: {
+    type: "capped",
+    name: "Québec Pension Plan",
+    shortName: "QPP",
+    rate: 0.064,
+    exemption: 3500,
+    maxEarnings: 71300,
+    maxContribution: 4339.2,
+  },
+  pensionPlanAdditionalOverride: {
+    type: "cpp2",
+    name: "QPP Second Additional",
+    shortName: "QPP2",
+    rate: 0.04,
+    ympe: 71300,
+    yampe: 81200,
+    maxContribution: 396,
+  },
+  eiOverride: {
+    type: "capped",
+    name: "Employment Insurance (Quebec)",
+    shortName: "EI",
+    rate: 0.0131,
+    exemption: 0,
+    maxEarnings: 65700,
+    maxContribution: 860.67,
+  },
+  parentalInsurance: {
+    type: "capped",
+    name: "Québec Parental Insurance Plan",
+    shortName: "QPIP",
+    rate: 0.00494,
+    exemption: 0,
+    maxEarnings: 98000,
+    maxContribution: 484.12,
   },
 };

--- a/src/lib/tax/configs/2026/quebec.ts
+++ b/src/lib/tax/configs/2026/quebec.ts
@@ -1,5 +1,21 @@
 import { ProvincialTaxConfig } from "../../types";
 
+// Sources (verified):
+// - Income tax brackets & basic personal amount: Revenu Québec — Income Tax Rates
+//   https://www.revenuquebec.ca/en/citizens/income-tax-return/completing-your-income-tax-return/income-tax-rates/
+// - QPP YMPE / YAMPE 2026: Retraite Québec / SAI publications
+//   https://saiinc.ca/en/publications/news/quebec-pension-plan-key-data-2026
+//   2026: rate 6.40%, YMPE $74,600, basic exemption $3,500.
+//   Max employee QPP1 = ($74,600 − $3,500) × 6.40% = $4,550.40.
+// - QPP2 (second additional): 2026 rate 4% on earnings between YMPE $74,600 and
+//   YAMPE $85,000 (114% of YMPE). Max employee QPP2 = ($85,000 − $74,600) × 4% = $416.00.
+// - EI (Quebec) 2026: Canada.ca — EI premium rates 2026 (Quebec reduced rate)
+//   https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/payroll/payroll-deductions-contributions/employment-insurance-ei/ei-premium-rates-maximums.html
+//   2026 Quebec EI rate 1.30% on max insurable $68,900 → max $895.70.
+// - QPIP (employee) 2026: Conseil de gestion de l’assurance parentale
+//   https://www.rqap.gouv.qc.ca/en/news/reduction-in-premium-rates-for-the-quebec-parental-insurance-plan-in-2026
+//   2026: employee rate 0.455%, max insurable $103,000 → max $468.65.
+
 export const QUEBEC_TAX_CONFIG: ProvincialTaxConfig = {
   incomeTax: {
     type: "bracket",
@@ -16,5 +32,41 @@ export const QUEBEC_TAX_CONFIG: ProvincialTaxConfig = {
     type: "federalAbatement",
     name: "Quebec Abatement",
     rate: 0.165, // 16.5% reduction in federal income tax
+  },
+  pensionPlanOverride: {
+    type: "capped",
+    name: "Québec Pension Plan",
+    shortName: "QPP",
+    rate: 0.064,
+    exemption: 3500,
+    maxEarnings: 74600,
+    maxContribution: 4550.4,
+  },
+  pensionPlanAdditionalOverride: {
+    type: "cpp2",
+    name: "QPP Second Additional",
+    shortName: "QPP2",
+    rate: 0.04,
+    ympe: 74600,
+    yampe: 85000,
+    maxContribution: 416,
+  },
+  eiOverride: {
+    type: "capped",
+    name: "Employment Insurance (Quebec)",
+    shortName: "EI",
+    rate: 0.013,
+    exemption: 0,
+    maxEarnings: 68900,
+    maxContribution: 895.7,
+  },
+  parentalInsurance: {
+    type: "capped",
+    name: "Québec Parental Insurance Plan",
+    shortName: "QPIP",
+    rate: 0.00455,
+    exemption: 0,
+    maxEarnings: 103000,
+    maxContribution: 468.65,
   },
 };

--- a/src/lib/tax/types.ts
+++ b/src/lib/tax/types.ts
@@ -89,6 +89,18 @@ export interface ProvincialTaxConfig {
   surtax?: SurtaxConfig;
   healthPremium?: HealthPremiumConfig;
   federalAbatement?: FederalAbatementConfig;
+  // Province-specific pension plan that replaces the federal CPP
+  // (e.g., Quebec residents pay QPP instead of CPP).
+  pensionPlanOverride?: CappedContributionConfig;
+  // Province-specific second additional pension plan that replaces CPP2
+  // (e.g., Quebec QPP2).
+  pensionPlanAdditionalOverride?: Cpp2Config;
+  // Province-specific Employment Insurance rate that replaces the federal
+  // EI rate (Quebec residents pay a reduced EI rate because the province
+  // administers its own parental insurance plan via QPIP).
+  eiOverride?: CappedContributionConfig;
+  // Province-administered parental insurance plan (e.g., Quebec QPIP).
+  parentalInsurance?: CappedContributionConfig;
 }
 
 // Spending data for a province
@@ -122,7 +134,8 @@ export interface TaxLineItem {
     | "surtax"
     | "healthPremium"
     | "incomeTaxProvincial"
-    | "federalAbatement";
+    | "federalAbatement"
+    | "parentalInsurance";
 }
 
 // Detailed calculation result
@@ -144,6 +157,7 @@ export interface DetailedTaxCalculation {
   eiContribution: number;
   cppContribution: number;
   cpp2Contribution: number;
+  parentalInsuranceContribution: number;
   surtax: number;
   healthPremium: number;
   federalAbatement: number;

--- a/src/locales/en.po
+++ b/src/locales/en.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:149
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:149
 msgid " How did Health Canada spend its budget in FY24?"
 msgstr " How did Health Canada spend its budget in FY24?"
 
@@ -72,7 +72,7 @@ msgid "{0} is a First Nation{1}."
 msgstr "{0} is a First Nation{1}."
 
 #. placeholder {0}: formatPercent(federalAbatementConfig.rate)
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:333
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:339
 msgid "{0} of federal income tax"
 msgstr "{0} of federal income tax"
 
@@ -108,7 +108,7 @@ msgstr "{0}{provinceSuffix} - No financial data is currently available under the
 msgid "{paragraph}"
 msgstr "{paragraph}"
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:458
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:471
 #: src/components/TaxBreakdownAccordion.tsx:112
 msgid "{provinceName} Taxes"
 msgstr "{provinceName} Taxes"
@@ -121,22 +121,22 @@ msgstr "{provinceName} Total"
 msgid "© 2025 Canada Spends. All rights reserved. A Project of <0>Build Canada</0>."
 msgstr "© 2025 Canada Spends. All rights reserved. A Project of <0>Build Canada</0>."
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:235
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:235
 msgid "<0>Minister of Foreign Affairs</0>: Responsible for diplomacy, international security, international development assistance, and global partnerships."
 msgstr "<0>Minister of Foreign Affairs</0>: Responsible for diplomacy, international security, international development assistance, and global partnerships."
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:244
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:244
 msgid "<0>Minister of International Trade</0>: Oversees Canada's trade negotiations, export promotion, and economic policy engagement."
 msgstr "<0>Minister of International Trade</0>: Oversees Canada's trade negotiations, export promotion, and economic policy engagement."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:103
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:103
 msgid "10 government departments accounted for 73.2% of federal spending in FY 2024"
 msgstr "10 government departments accounted for 73.2% of federal spending in FY 2024"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:103
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:109
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:115
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:97
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:103
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:109
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:115
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:97
 msgid "10 government departments accounted for 73.2% of federal spending in FY 2024."
 msgstr "10 government departments accounted for 73.2% of federal spending in FY 2024."
 
@@ -144,68 +144,68 @@ msgstr "10 government departments accounted for 73.2% of federal spending in FY 
 msgid "100,000"
 msgstr "100,000"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:194
+#: src/app/[lang]/(main)/federal/spending/page.tsx:195
 #: src/app/[lang]/(main)/spending/page.tsx:185
 msgid "80% of employees are in permanent roles"
 msgstr "80% of employees are in permanent roles"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:37
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:37
 msgid "A look at how Employment and Social Development Canada spends its budget"
 msgstr "A look at how Employment and Social Development Canada spends its budget"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:34
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:34
 msgid "A look at how Health Canada spends its budget"
 msgstr "A look at how Health Canada spends its budget"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:35
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:35
 msgid "A look at how Housing, Infrastructure and Communities Canada spends its budget"
 msgstr "A look at how Housing, Infrastructure and Communities Canada spends its budget"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:33
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:33
 msgid "A look at how Immigration, Refugees and Citizenship Canada spends its budget"
 msgstr "A look at how Immigration, Refugees and Citizenship Canada spends its budget"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:36
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:36
 msgid "A look at how Indigenous Services and Northern Affairs Canada spends its budget"
 msgstr "A look at how Indigenous Services and Northern Affairs Canada spends its budget"
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:33
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:33
 msgid "A look at how Innovation, Science and Industry Canada spends its budget"
 msgstr "A look at how Innovation, Science and Industry Canada spends its budget"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:36
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:36
 msgid "A look at how National Defence spends its budget"
 msgstr "A look at how National Defence spends its budget"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:35
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:35
 msgid "A look at how Public Safety Canada spends its budget"
 msgstr "A look at how Public Safety Canada spends its budget"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:33
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:33
 msgid "A look at how Public Services and Procurement Canada spends its budget"
 msgstr "A look at how Public Services and Procurement Canada spends its budget"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:35
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:35
 msgid "A look at how the Canada Revenue Agency spends its budget"
 msgstr "A look at how the Canada Revenue Agency spends its budget"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:36
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:36
 msgid "A look at how the Department of Finance spends its budget"
 msgstr "A look at how the Department of Finance spends its budget"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:37
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:37
 msgid "A look at how the Global Affairs Canada spends its budget"
 msgstr "A look at how the Global Affairs Canada spends its budget"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:34
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:34
 msgid "A look at how Transport Canada spends its budget"
 msgstr "A look at how Transport Canada spends its budget"
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:34
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:34
 msgid "A look at how Veterans Affairs Canada spends its budget"
 msgstr "A look at how Veterans Affairs Canada spends its budget"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:187
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:187
 msgid "A significant portion of GAC's budget supports Canada's international development assistance, with key programs focused on climate adaptation, gender equality, and health initiatives in developing nations. The department also facilitates economic diplomacy and trade agreements that benefit Canadian businesses and secure investment opportunities abroad."
 msgstr "A significant portion of GAC's budget supports Canada's international development assistance, with key programs focused on climate adaptation, gender equality, and health initiatives in developing nations. The department also facilitates economic diplomacy and trade agreements that benefit Canadian businesses and secure investment opportunities abroad."
 
@@ -224,7 +224,7 @@ msgid "About Us"
 msgstr "About Us"
 
 #. placeholder {0}: formatAmount(tier.threshold)
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:496
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:509
 msgid "Above {0}"
 msgstr "Above {0}"
 
@@ -236,36 +236,36 @@ msgstr "Accounts payable, long-term debt, and other obligations owed to external
 msgid "Accumulated Surplus"
 msgstr "Accumulated Surplus"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:47
 msgid "Acquisition of Land, Buildings and Works"
 msgstr "Acquisition of Land, Buildings and Works"
 
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:47
 msgid "Acquisition of Lands, Buildings and Works"
 msgstr "Acquisition of Lands, Buildings and Works"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:51
 msgid "Acquisition of Machinery and Equipment"
 msgstr "Acquisition of Machinery and Equipment"
 
@@ -277,7 +277,7 @@ msgstr "Adjust for inflation (2025 dollars)"
 msgid "Adjust sliders to see how department spending reductions affect the overall Fall 2025 Budget. The Minister of Finance has asked departments to reduce spending by 7.5% in 2026-27, 10% in 2027-28, and 15% in 2028-29."
 msgstr "Adjust sliders to see how department spending reductions affect the overall Fall 2025 Budget. The Minister of Finance has asked departments to reduce spending by 7.5% in 2026-27, 10% in 2027-28, and 15% in 2028-29."
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:205
+#: src/app/[lang]/(main)/federal/spending/page.tsx:206
 #: src/app/[lang]/(main)/spending/page.tsx:196
 msgid "Age"
 msgstr "Age"
@@ -319,11 +319,11 @@ msgid "All expenses incurred during the fiscal year including program delivery, 
 msgstr "All expenses incurred during the fiscal year including program delivery, administration, and capital costs."
 
 #: src/app/[lang]/(main)/budget/page.tsx:270
-#: src/app/[lang]/(main)/federal/budget/page.tsx:307
+#: src/app/[lang]/(main)/federal/budget/page.tsx:309
 msgid "All government budget data is sourced from official databases, but due to the complexity of these systems, occasional errors may occur despite our best efforts. This page is also based on government memos and leaks, so it is not an official release of the Fall 2025 Budget. We aim to make this information more accessible and accurate, and we welcome feedback. If you notice any issues, please let us know <0>here</0> — we appreciate it and will work to address them promptly."
 msgstr "All government budget data is sourced from official databases, but due to the complexity of these systems, occasional errors may occur despite our best efforts. This page is also based on government memos and leaks, so it is not an official release of the Fall 2025 Budget. We aim to make this information more accessible and accurate, and we welcome feedback. If you notice any issues, please let us know <0>here</0> — we appreciate it and will work to address them promptly."
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:278
+#: src/app/[lang]/(main)/federal/spending/page.tsx:279
 #: src/app/[lang]/(main)/spending/page.tsx:269
 #: src/components/JurisdictionPageContent.tsx:507
 msgid "All government spending data is sourced from official databases, but due to the complexity of these systems, occasional errors may occur despite our best efforts. We aim to make this information more accessible and accurate, and we welcome feedback. If you notice any issues, please let us know <0>here</0> — we appreciate it and will work to address them promptly."
@@ -349,12 +349,12 @@ msgstr "All revenue collected during the fiscal year, including transfers, own-s
 msgid "All the information comes from public databases and reports by the Government of Canada. We show our sources, so you know exactly where it comes from."
 msgstr "All the information comes from public databases and reports by the Government of Canada. We show our sources, so you know exactly where it comes from."
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:580
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:621
 msgid "All the taxes that apply to your income"
 msgstr "All the taxes that apply to your income"
 
 #: src/app/[lang]/(main)/budget/page.tsx:62
-#: src/app/[lang]/(main)/federal/budget/page.tsx:62
+#: src/app/[lang]/(main)/federal/budget/page.tsx:63
 msgid "Amount/Change"
 msgstr "Amount/Change"
 
@@ -376,7 +376,7 @@ msgstr "Annual interest payments on outstanding debt. This represents the cost o
 msgid "Annual municipal spending per {0} resident"
 msgstr "Annual municipal spending per {0} resident"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:185
+#: src/app/[lang]/(main)/federal/spending/page.tsx:186
 #: src/app/[lang]/(main)/spending/page.tsx:176
 msgid "Annual payroll"
 msgstr "Annual payroll"
@@ -386,7 +386,7 @@ msgid "Application ID"
 msgstr "Application ID"
 
 #. placeholder {0}: formatAmount(provincialTax)
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:475
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:488
 msgid "Applied to provincial tax of {0}"
 msgstr "Applied to provincial tax of {0}"
 
@@ -423,7 +423,7 @@ msgstr "As of fiscal year end {fiscalYear}"
 msgid "Assets, liabilities, and net financial position as of the end of fiscal year {fiscalYear}."
 msgstr "Assets, liabilities, and net financial position as of the end of fiscal year {fiscalYear}."
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:178
+#: src/app/[lang]/(main)/federal/spending/page.tsx:179
 #: src/app/[lang]/(main)/spending/page.tsx:169
 msgid "Average annual compensation"
 msgstr "Average annual compensation"
@@ -454,7 +454,7 @@ msgid "Based on Data"
 msgstr "Based on Data"
 
 #. placeholder {0}: formatAmount(income)
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:528
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:541
 msgid "Based on income of {0}"
 msgstr "Based on income of {0}"
 
@@ -490,12 +490,12 @@ msgid "Budget"
 msgstr "Budget"
 
 #: src/app/[lang]/(main)/budget/page.tsx:59
-#: src/app/[lang]/(main)/federal/budget/page.tsx:59
+#: src/app/[lang]/(main)/federal/budget/page.tsx:60
 msgid "Budget Impact"
 msgstr "Budget Impact"
 
 #: src/app/[lang]/(main)/budget/page.tsx:169
-#: src/app/[lang]/(main)/federal/budget/page.tsx:206
+#: src/app/[lang]/(main)/federal/budget/page.tsx:208
 msgid "Budget Statistics (Projected FY 2025)"
 msgstr "Budget Statistics (Projected FY 2025)"
 
@@ -519,20 +519,20 @@ msgstr "Canada Community-Building Fund"
 msgid "Canada Emergency Wage Subsidy"
 msgstr "Canada Emergency Wage Subsidy"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/MiniSankey.tsx:19
 msgid "Canada health transfer"
 msgstr "Canada health transfer"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:38
 msgid "Canada Revenue Agency"
 msgstr "Canada Revenue Agency"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:34
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:34
 msgid "Canada Revenue Agency | Canada Spends"
 msgstr "Canada Revenue Agency | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/MiniSankey.tsx:23
 msgid "Canada social transfer"
 msgstr "Canada social transfer"
 
@@ -569,7 +569,7 @@ msgstr "Canada Spends provides a secure way for sources to submit tips and docum
 msgid "Canada Spends, as a project of Build Canada, is funded through donations from our builder network. Donate"
 msgstr "Canada Spends, as a project of Build Canada, is funded through donations from our builder network. Donate"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:211
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:211
 msgid "Canada Student Loans Program: providing financial aid for post-secondary students."
 msgstr "Canada Student Loans Program: providing financial aid for post-secondary students."
 
@@ -582,7 +582,7 @@ msgid "Canada, you need the facts."
 msgstr "Canada, you need the facts."
 
 #: src/app/[lang]/(main)/budget/page.tsx:204
-#: src/app/[lang]/(main)/federal/budget/page.tsx:241
+#: src/app/[lang]/(main)/federal/budget/page.tsx:243
 msgid "Capital Investments"
 msgstr "Capital Investments"
 
@@ -674,7 +674,7 @@ msgstr "Compare your total tax burden across all Canadian provinces and territor
 msgid "Compensation"
 msgstr "Compensation"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:176
+#: src/app/[lang]/(main)/federal/spending/page.tsx:177
 #: src/app/[lang]/(main)/spending/page.tsx:167
 msgid "Compensation per Employee"
 msgstr "Compensation per Employee"
@@ -733,19 +733,19 @@ msgstr "Countries"
 msgid "COVID-19 Income Support"
 msgstr "COVID-19 Income Support"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:187
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:187
 msgid "CRA spending is divided across tax administration, compliance enforcement, benefit program delivery, and intergovernmental agreements with provinces and territories. The largest expenditures in FY 2024 included personal income tax processing, corporate tax audits, and benefit administration."
 msgstr "CRA spending is divided across tax administration, compliance enforcement, benefit program delivery, and intergovernmental agreements with provinces and territories. The largest expenditures in FY 2024 included personal income tax processing, corporate tax audits, and benefit administration."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:197
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:197
 msgid "CRA spending isolated to FY 2024"
 msgstr "CRA spending isolated to FY 2024"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:141
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:141
 msgid "CRA's share of federal spending in FY 2024 was higher than in FY 1995"
 msgstr "CRA's share of federal spending in FY 2024 was higher than in FY 1995"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:121
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:121
 msgid "CRA's spending grew more than overall spending, meaning its share of the federal budget increased. In 2024, the agency accounted for 3.2% of all federal spending, 1.85 percentage points higher than in 1995."
 msgstr "CRA's spending grew more than overall spending, meaning its share of the federal budget increased. In 2024, the agency accounted for 3.2% of all federal spending, 1.85 percentage points higher than in 1995."
 
@@ -770,23 +770,23 @@ msgstr "Customs Duties"
 msgid "Customs Import Duties"
 msgstr "Customs Import Duties"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:68
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:68
 msgid "Data updated March 20, 2025"
 msgstr "Data updated March 20, 2025"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:69
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:70
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:76
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:74
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:76
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:63
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:81
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:64
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:71
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:68
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:66
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:64
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:66
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:69
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:70
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:76
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:74
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:76
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:63
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:81
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:64
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:71
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:68
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:66
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:64
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:66
 msgid "Data updated March 21, 2025"
 msgstr "Data updated March 21, 2025"
 
@@ -807,7 +807,7 @@ msgid "Defence Team"
 msgstr "Defence Team"
 
 #: src/app/[lang]/(main)/budget/page.tsx:215
-#: src/app/[lang]/(main)/federal/budget/page.tsx:252
+#: src/app/[lang]/(main)/federal/budget/page.tsx:254
 msgid "Deficit"
 msgstr "Deficit"
 
@@ -816,19 +816,19 @@ msgstr "Deficit"
 msgid "Department"
 msgstr "Department"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/MiniSankey.tsx:16
 msgid "Department of Finance"
 msgstr "Department of Finance"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:35
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:35
 msgid "Department of Finance | Canada Spends"
 msgstr "Department of Finance | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:188
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:188
 msgid "Department of Finance, Spending by Entity, FY 2024 (in millions)"
 msgstr "Department of Finance, Spending by Entity, FY 2024 (in millions)"
 
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:16
 msgid "Department of National Defence"
 msgstr "Department of National Defence"
 
@@ -841,12 +841,12 @@ msgstr "Department Spending"
 msgid "Department Spending Reductions"
 msgstr "Department Spending Reductions"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:230
+#: src/app/[lang]/(main)/federal/spending/page.tsx:231
 #: src/app/[lang]/(main)/spending/page.tsx:221
 msgid "Departments + Agencies"
 msgstr "Departments + Agencies"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:125
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:125
 msgid "Despite these increases, significant challenges remain in areas such as housing, healthcare access, and infrastructure in remote Indigenous communities."
 msgstr "Despite these increases, significant challenges remain in areas such as housing, healthcare access, and infrastructure in remote Indigenous communities."
 
@@ -854,7 +854,7 @@ msgstr "Despite these increases, significant challenges remain in areas such as 
 msgid "Development, Peace + Security Programming"
 msgstr "Development, Peace + Security Programming"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:177
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:177
 msgid "Development, Peace and Security Programming: $5.37B"
 msgstr "Development, Peace and Security Programming: $5.37B"
 
@@ -862,7 +862,7 @@ msgstr "Development, Peace and Security Programming: $5.37B"
 msgid "Direct program expenses"
 msgstr "Direct program expenses"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:160
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:160
 msgid "Direct spending refers to money allocated to government programs, employee salaries, and administrative expenses. Indirect spending includes federal transfers to individuals and provinces."
 msgstr "Direct spending refers to money allocated to government programs, employee salaries, and administrative expenses. Indirect spending includes federal transfers to individuals and provinces."
 
@@ -874,7 +874,7 @@ msgstr "Disaster Relief"
 msgid "Discipline"
 msgstr "Discipline"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:134
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:134
 msgid "DND's spending grew less than overall spending, meaning its share of the federal budget decreased. In 2024, the department accounted for 6.7% of all federal spending, 0.6 percentage points lower than in 1995."
 msgstr "DND's spending grew less than overall spending, meaning its share of the federal budget decreased. In 2024, the department accounted for 6.7% of all federal spending, 0.6 percentage points lower than in 1995."
 
@@ -942,7 +942,7 @@ msgstr "Employment + Training"
 msgid "Employment and Social Development Canada"
 msgstr "Employment and Social Development Canada"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:36
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:36
 msgid "Employment and Social Development Canada | Canada Spends"
 msgstr "Employment and Social Development Canada | Canada Spends"
 
@@ -964,7 +964,7 @@ msgstr "End Date"
 msgid "Energy Taxes"
 msgstr "Energy Taxes"
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:714
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:755
 msgid "Enter your income to see a personalized breakdown of how much you contribute to different government services and programs."
 msgstr "Enter your income to see a personalized breakdown of how much you contribute to different government services and programs."
 
@@ -977,46 +977,46 @@ msgstr "Environment and Climate Change"
 msgid "Equalization Payments to Provinces"
 msgstr "Equalization Payments to Provinces"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:16
 msgid "ESDC"
 msgstr "ESDC"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:95
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:95
 msgid "ESDC accounted for 18.4% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024."
 msgstr "ESDC accounted for 18.4% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:88
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:88
 msgid "ESDC spent $94.48 billion in fiscal year (FY) 2024. This was 18.4% of the $513.9 billion in overall federal spending, making it one of the highest-spending federal departments."
 msgstr "ESDC spent $94.48 billion in fiscal year (FY) 2024. This was 18.4% of the $513.9 billion in overall federal spending, making it one of the highest-spending federal departments."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:197
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:197
 msgid "ESDC, Spending by Entity, FY 2024"
 msgstr "ESDC, Spending by Entity, FY 2024"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:179
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:179
 msgid "ESDC's share of federal spending in FY 2024"
 msgstr "ESDC's share of federal spending in FY 2024"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:141
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:141
 msgid "ESDC's share of federal spending in FY 2024 was lower than FY 1995"
 msgstr "ESDC's share of federal spending in FY 2024 was lower than FY 1995"
 
 #: src/app/[lang]/(main)/budget/page.tsx:217
-#: src/app/[lang]/(main)/federal/budget/page.tsx:254
+#: src/app/[lang]/(main)/federal/budget/page.tsx:256
 msgid "Est. projected budget deficit"
 msgstr "Est. projected budget deficit"
 
 #: src/app/[lang]/(main)/budget/page.tsx:177
-#: src/app/[lang]/(main)/federal/budget/page.tsx:214
+#: src/app/[lang]/(main)/federal/budget/page.tsx:216
 msgid "Est. projected government budget"
 msgstr "Est. projected government budget"
 
 #: src/app/[lang]/(main)/budget/page.tsx:186
-#: src/app/[lang]/(main)/federal/budget/page.tsx:223
+#: src/app/[lang]/(main)/federal/budget/page.tsx:225
 msgid "Est. projected government revenue"
 msgstr "Est. projected government revenue"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:57
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:57
 msgid "Established in 2005, ESDC is a federal department responsible for supporting Canadians through social programs and workforce development. It administers key programs such as Employment Insurance (EI), the Canada Pension Plan (CPP), Old Age Security (OAS), and skills training initiatives. ESDC also oversees Service Canada, which delivers government services directly to the public."
 msgstr "Established in 2005, ESDC is a federal department responsible for supporting Canadians through social programs and workforce development. It administers key programs such as Employment Insurance (EI), the Canada Pension Plan (CPP), Old Age Security (OAS), and skills training initiatives. ESDC also oversees Service Canada, which delivers government services directly to the public."
 
@@ -1076,12 +1076,12 @@ msgstr "Expenses"
 msgid "Explore Canada's federal budget with interactive visualizations and detailed analysis of government revenue and expenditures."
 msgstr "Explore Canada's federal budget with interactive visualizations and detailed analysis of government revenue and expenditures."
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:250
+#: src/app/[lang]/(main)/federal/spending/page.tsx:251
 #: src/app/[lang]/(main)/spending/page.tsx:241
 msgid "Explore federal employee salary distribution by year and demographic group"
 msgstr "Explore federal employee salary distribution by year and demographic group"
 
-#: src/components/HeroButtons.tsx:34
+#: src/components/HeroButtons.tsx:37
 msgid "Explore Federal Spending"
 msgstr "Explore Federal Spending"
 
@@ -1097,7 +1097,7 @@ msgstr "Explore financial data from First Nations across Canada. Data is extract
 msgid "Explore financial data from First Nations across Canada. View statements of operations, financial positions, and remuneration from annual reports published under the First Nations Financial Transparency Act (FNFTA)."
 msgstr "Explore financial data from First Nations across Canada. View statements of operations, financial positions, and remuneration from annual reports published under the First Nations Financial Transparency Act (FNFTA)."
 
-#: src/components/HeroButtons.tsx:107
+#: src/components/HeroButtons.tsx:110
 msgid "Explore First Nations Spending"
 msgstr "Explore First Nations Spending"
 
@@ -1109,32 +1109,32 @@ msgstr "Explore how the Canadian federal government spends your tax dollars acro
 msgid "Explore in-depth articles about Canadian government spending, budget analysis, and public finance. Stay informed about how your tax dollars are used through Canada Spends."
 msgstr "Explore in-depth articles about Canadian government spending, budget analysis, and public finance. Stay informed about how your tax dollars are used through Canada Spends."
 
-#: src/components/HeroButtons.tsx:70
+#: src/components/HeroButtons.tsx:73
 msgid "Explore Municipal Spending"
 msgstr "Explore Municipal Spending"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:239
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:230
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:258
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:277
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:199
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:210
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:194
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:227
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:194
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:241
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:191
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:201
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:199
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:199
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:239
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:230
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:258
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:277
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:199
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:210
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:194
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:227
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:194
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:241
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:191
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:201
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:199
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:199
 msgid "Explore other Federal Departments"
 msgstr "Explore other Federal Departments"
 
-#: src/components/HeroButtons.tsx:43
+#: src/components/HeroButtons.tsx:46
 msgid "Explore Provincial Spending"
 msgstr "Explore Provincial Spending"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:134
+#: src/app/[lang]/(main)/federal/spending/page.tsx:135
 #: src/app/[lang]/(main)/spending/page.tsx:125
 msgid "Explore revenue and spending categories or filter by agency for deeper insights."
 msgstr "Explore revenue and spending categories or filter by agency for deeper insights."
@@ -1143,16 +1143,16 @@ msgstr "Explore revenue and spending categories or filter by agency for deeper i
 msgid "External ID"
 msgstr "External ID"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:67
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:67
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:67
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:67
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:67
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:67
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:67
 msgid "External Revenues"
 msgstr "External Revenues"
 
@@ -1175,48 +1175,48 @@ msgstr "Federal"
 msgid "Federal Budget 2025 | Canada Spends"
 msgstr "Federal Budget 2025 | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:178
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:178
 msgid "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, Department of Finance entities with the highest expenditures were the Office of the Superintendent of Financial Institutions, Office of the Auditor General, and the Financial Transactions and Reports Analysis Centre of Canada."
 msgstr "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, Department of Finance entities with the highest expenditures were the Office of the Superintendent of Financial Institutions, Office of the Auditor General, and the Financial Transactions and Reports Analysis Centre of Canada."
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:158
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:158
 msgid "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, HICC entities with the highest expenditures were Office of Infrastructure Canada, the Canada Mortgage and Housing Corporation and the Windsor-Detroit Bridge Authority."
 msgstr "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, HICC entities with the highest expenditures were Office of Infrastructure Canada, the Canada Mortgage and Housing Corporation and the Windsor-Detroit Bridge Authority."
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:151
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:151
 msgid "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, IRCC reported total expenditures of $6.2 billion, broken out as follows:"
 msgstr "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, IRCC reported total expenditures of $6.2 billion, broken out as follows:"
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:153
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:153
 msgid "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, ISED's budget was split across the following entities:"
 msgstr "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, ISED's budget was split across the following entities:"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:159
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:159
 msgid "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, PSPC's budget was split across the following entities:"
 msgstr "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, PSPC's budget was split across the following entities:"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:152
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:152
 msgid "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, Transport Canada reported total expenditures of $5.1 billion across the following entities:"
 msgstr "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, Transport Canada reported total expenditures of $5.1 billion across the following entities:"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:152
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:152
 msgid "Federal departments often contain other entities including offices, crown corporations and agencies. The Health Canada entities with the biggest expenditures in FY 2024 were"
 msgstr "Federal departments often contain other entities including offices, crown corporations and agencies. The Health Canada entities with the biggest expenditures in FY 2024 were"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:208
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:208
 msgid "Federal departments often contain other entities. In FY 2024, Global Affairs Canada's entities with the highest expenditures were:"
 msgstr "Federal departments often contain other entities. In FY 2024, Global Affairs Canada's entities with the highest expenditures were:"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:194
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:194
 msgid "Federal departments often include additional agencies, commands, and operational divisions. In FY 2024, the largest spending entities within DND were the Canadian Army, the Royal Canadian Navy, and the Royal Canadian Air Force, accounting for the bulk of military expenditures."
 msgstr "Federal departments often include additional agencies, commands, and operational divisions. In FY 2024, the largest spending entities within DND were the Canadian Army, the Royal Canadian Navy, and the Royal Canadian Air Force, accounting for the bulk of military expenditures."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:190
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:190
 msgid "Federal departments often include multiple agencies and service delivery arms. In FY 2024, ESDC's highest-expenditure entities included:"
 msgstr "Federal departments often include multiple agencies and service delivery arms. In FY 2024, ESDC's highest-expenditure entities included:"
 
 #: src/app/[lang]/(main)/budget/page.tsx:156
-#: src/app/[lang]/(main)/federal/budget/page.tsx:183
+#: src/app/[lang]/(main)/federal/budget/page.tsx:185
 msgid "Federal Fall 2025 Government Budget"
 msgstr "Federal Fall 2025 Government Budget"
 
@@ -1224,78 +1224,78 @@ msgstr "Federal Fall 2025 Government Budget"
 msgid "Federal Government Spending | Canada Spends"
 msgstr "Federal Government Spending | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:170
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:197
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:173
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:170
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:197
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:173
 msgid "Federal government spending in FY 2024"
 msgstr "Federal government spending in FY 2024"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:140
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:142
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:148
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:141
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:144
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:140
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:142
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:148
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:141
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:144
 msgid "Federal government spending isolated to FY 2024"
 msgstr "Federal government spending isolated to FY 2024"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:232
+#: src/app/[lang]/(main)/federal/spending/page.tsx:233
 #: src/app/[lang]/(main)/spending/page.tsx:223
 msgid "Federal organizations"
 msgstr "Federal organizations"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:120
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:120
 msgid "Federal spending may shift over time due to changing global circumstances, diplomatic priorities, and Canada's economic relationships. Since 1995, overall federal spending has increased by 74.9%, while Global Affairs Canada's budget has grown by 166.5%, reflecting an expansion in international engagement."
 msgstr "Federal spending may shift over time due to changing global circumstances, diplomatic priorities, and Canada's economic relationships. Since 1995, overall federal spending has increased by 74.9%, while Global Affairs Canada's budget has grown by 166.5%, reflecting an expansion in international engagement."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:113
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:113
 msgid "Federal spending may shift over time due to economic fluctuations, changes in tax policy, and the expansion of benefit programs. Since 1995, overall federal spending has risen 74.9%, while Canada Revenue Agency spending has increased 302%"
 msgstr "Federal spending may shift over time due to economic fluctuations, changes in tax policy, and the expansion of benefit programs. Since 1995, overall federal spending has risen 74.9%, while Canada Revenue Agency spending has increased 302%"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:126
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:126
 msgid "Federal spending may shift over time due to geopolitical tensions, defence modernization needs, and emerging threats such as cyber warfare. Since 1995, overall federal spending has risen 74.9%, while Department of National Defence spending has increased 59.9%."
 msgstr "Federal spending may shift over time due to geopolitical tensions, defence modernization needs, and emerging threats such as cyber warfare. Since 1995, overall federal spending has risen 74.9%, while Department of National Defence spending has increased 59.9%."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:105
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:105
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging challenges. Since 2005, when ESDC was first established, overall federal spending has risen 62.9%, while ESDC spending has increased 1,485%."
 msgstr "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging challenges. Since 2005, when ESDC was first established, overall federal spending has risen 62.9%, while ESDC spending has increased 1,485%."
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:115
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:115
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging challenges. Since FY 1995, overall federal spending has risen 74.9%, while Health Canada spending has decreased 19.9% when adjusted for inflation."
 msgstr "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging challenges. Since FY 1995, overall federal spending has risen 74.9%, while Health Canada spending has decreased 19.9% when adjusted for inflation."
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:117
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:117
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address."
 msgstr "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:112
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:112
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 74.9%, while Department of Finance spending has increased 41.4%."
 msgstr "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 74.9%, while Department of Finance spending has increased 41.4%."
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:101
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:101
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 74.9%, while IRCC spending has increased 428% (adjusted for inflation)."
 msgstr "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 74.9%, while IRCC spending has increased 428% (adjusted for inflation)."
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:103
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:103
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 74.9%, while ISED spending has increased 90.3%."
 msgstr "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 74.9%, while ISED spending has increased 90.3%."
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:104
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:104
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 74.9%, while PSPC spending has increased by 7.1% when adjusted for inflation."
 msgstr "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 74.9%, while PSPC spending has increased by 7.1% when adjusted for inflation."
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:104
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:104
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 74.9%, while Transport spending has remained relatively flat."
 msgstr "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 74.9%, while Transport spending has remained relatively flat."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:105
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:105
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 77%, while VAC spending has increased 51%."
 msgstr "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 77%, while VAC spending has increased 51%."
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:114
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:114
 msgid "Federal spending on Indigenous priorities may fluctuate over time due to population growth, policy shifts, and emerging challenges such as climate change and infrastructure deficits. Since 1995, total federal spending has risen by 74.9%, while spending on Indigenous priorities has increased by 592%, reflecting expanded program commitments and new governance agreements and claim settlements."
 msgstr "Federal spending on Indigenous priorities may fluctuate over time due to population growth, policy shifts, and emerging challenges such as climate change and infrastructure deficits. Since 1995, total federal spending has risen by 74.9%, while spending on Indigenous priorities has increased by 592%, reflecting expanded program commitments and new governance agreements and claim settlements."
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:113
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:113
 msgid "Federal spending on public safety fluctuates based on evolving security threats, emergency events, and changes in government policy. Since 2005 shortly after it was established, Public Safety Canada's expenditures have increased by 69.6%, reflecting heightened investments in counterterrorism, cyber defence, and disaster response capabilities. The department's share of the federal budget has remained relatively flat from 2.6% in 2005 to 2.7% in 2024."
 msgstr "Federal spending on public safety fluctuates based on evolving security threats, emergency events, and changes in government policy. Since 2005 shortly after it was established, Public Safety Canada's expenditures have increased by 69.6%, reflecting heightened investments in counterterrorism, cyber defence, and disaster response capabilities. The department's share of the federal budget has remained relatively flat from 2.6% in 2005 to 2.7% in 2024."
 
@@ -1303,7 +1303,7 @@ msgstr "Federal spending on public safety fluctuates based on evolving security 
 msgid "Federal Tax"
 msgstr "Federal Tax"
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:315
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:321
 #: src/components/TaxBreakdownAccordion.tsx:105
 msgid "Federal Taxes"
 msgstr "Federal Taxes"
@@ -1353,7 +1353,8 @@ msgstr "Financial Position {0}"
 msgid "Financial Summary FY {fiscalYear}"
 msgstr "Financial Summary FY {fiscalYear}"
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:386
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:392
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:562
 msgid "First"
 msgstr "First"
 
@@ -1398,7 +1399,7 @@ msgstr "First Nations Remuneration Overview"
 msgid "First Nations Remuneration Overview | Canada Spends"
 msgstr "First Nations Remuneration Overview | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/MiniSankey.tsx:27
 msgid "Fiscal arrangements"
 msgstr "Fiscal arrangements"
 
@@ -1420,11 +1421,11 @@ msgstr "Fisheries + Aquatic Ecosystems"
 msgid "Food Safety"
 msgstr "Food Safety"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:130
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:130
 msgid "For example, during the COVID-19 pandemic, federal support programs led to a temporary surge in spending. ESDC expenditures increased from $63.3 billion in 2019 to $169.2 billion in 2021 before stabilizing in recent years."
 msgstr "For example, during the COVID-19 pandemic, federal support programs led to a temporary surge in spending. ESDC expenditures increased from $63.3 billion in 2019 to $169.2 billion in 2021 before stabilizing in recent years."
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:788
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:829
 msgid "For further breakdowns of spending, see <0>Federal</0> and <1>Provincial</1> spending pages."
 msgstr "For further breakdowns of spending, see <0>Federal</0> and <1>Provincial</1> spending pages."
 
@@ -1452,16 +1453,16 @@ msgstr "Future Force Design"
 msgid "FY"
 msgstr "FY"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:131
+#: src/app/[lang]/(main)/federal/spending/page.tsx:132
 #: src/app/[lang]/(main)/spending/page.tsx:122
 msgid "FY 2024 Government Revenue and Spending"
 msgstr "FY 2024 Government Revenue and Spending"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:103
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:103
 msgid "GAC accounted for 3.7% of all federal spending in FY 2024."
 msgstr "GAC accounted for 3.7% of all federal spending in FY 2024."
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:165
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:165
 msgid "GAC's expenditures are divided across five primary categories:"
 msgstr "GAC's expenditures are divided across five primary categories:"
 
@@ -1469,7 +1470,7 @@ msgstr "GAC's expenditures are divided across five primary categories:"
 msgid "Gender Equality"
 msgstr "Gender Equality"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:123
+#: src/app/[lang]/(main)/federal/spending/page.tsx:124
 #: src/app/[lang]/(main)/spending/page.tsx:114
 msgid "Get data-driven insights into how governmental revenue and spending affect Canadian lives and programs."
 msgstr "Get data-driven insights into how governmental revenue and spending affect Canadian lives and programs."
@@ -1486,7 +1487,7 @@ msgid "Get Involved"
 msgstr "Get Involved"
 
 #: src/app/[lang]/(main)/page.tsx:47
-#: src/app/[lang]/layout.tsx:22
+#: src/app/[lang]/layout.tsx:21
 msgid "Get The Facts About Government Spending"
 msgstr "Get The Facts About Government Spending"
 
@@ -1494,28 +1495,28 @@ msgstr "Get The Facts About Government Spending"
 msgid "Get weekly recaps of current events and updates from our team."
 msgstr "Get weekly recaps of current events and updates from our team."
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:32
 msgid "Global Affairs Canada"
 msgstr "Global Affairs Canada"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:55
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:55
 msgid "Global Affairs Canada (GAC) is the federal department responsible for managing Canada's diplomatic relations, international trade, and development assistance. Established in 1909 as the Department of External Affairs, GAC has evolved to oversee Canada's engagement in global affairs, promoting national interests abroad and ensuring the protection of Canadian citizens overseas. The department negotiates international agreements, administers trade policies, and provides humanitarian aid. Additionally, it supports Canadian businesses in expanding internationally and strengthens diplomatic ties through multilateral organizations like the United Nations, the World Trade Organization (WTO), and NATO. GAC also plays a critical role in crisis response, assisting Canadians abroad during emergencies, and fostering global security and stability."
 msgstr "Global Affairs Canada (GAC) is the federal department responsible for managing Canada's diplomatic relations, international trade, and development assistance. Established in 1909 as the Department of External Affairs, GAC has evolved to oversee Canada's engagement in global affairs, promoting national interests abroad and ensuring the protection of Canadian citizens overseas. The department negotiates international agreements, administers trade policies, and provides humanitarian aid. Additionally, it supports Canadian businesses in expanding internationally and strengthens diplomatic ties through multilateral organizations like the United Nations, the World Trade Organization (WTO), and NATO. GAC also plays a critical role in crisis response, assisting Canadians abroad during emergencies, and fostering global security and stability."
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:36
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:36
 msgid "Global Affairs Canada | Canada Spends"
 msgstr "Global Affairs Canada | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:227
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:227
 msgid "Global Affairs Canada is led by two ministers appointed by the Prime Minister and formally sworn into office at Rideau Hall. The department's leadership includes:"
 msgstr "Global Affairs Canada is led by two ministers appointed by the Prime Minister and formally sworn into office at Rideau Hall. The department's leadership includes:"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:94
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:94
 msgid "Global Affairs Canada spent $19.2 billion in fiscal year (FY) 2024, representing 3.7% of the $513.9 billion in overall federal spending. This placed GAC among the mid-sized federal departments in terms of total expenditures."
 msgstr "Global Affairs Canada spent $19.2 billion in fiscal year (FY) 2024, representing 3.7% of the $513.9 billion in overall federal spending. This placed GAC among the mid-sized federal departments in terms of total expenditures."
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:216
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:216
 msgid "Global Affairs Canada, Spending by Entity, FY 2024"
 msgstr "Global Affairs Canada, Spending by Entity, FY 2024"
 
@@ -1532,13 +1533,13 @@ msgstr "Goods and Services Tax"
 msgid "Gottfriedson Band Class Settlement"
 msgstr "Gottfriedson Band Class Settlement"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:269
+#: src/app/[lang]/(main)/federal/spending/page.tsx:270
 #: src/app/[lang]/(main)/spending/page.tsx:260
 msgid "Government Departments explained"
 msgstr "Government Departments explained"
 
 #: src/app/[lang]/(main)/budget/page.tsx:261
-#: src/app/[lang]/(main)/federal/budget/page.tsx:298
+#: src/app/[lang]/(main)/federal/budget/page.tsx:300
 msgid "Government Departments Explained"
 msgstr "Government Departments Explained"
 
@@ -1550,12 +1551,12 @@ msgstr "Government IT Operations"
 msgid "Government organizations"
 msgstr "Government organizations"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:120
+#: src/app/[lang]/(main)/federal/spending/page.tsx:121
 #: src/app/[lang]/(main)/spending/page.tsx:111
 msgid "Government Spending"
 msgstr "Government Spending"
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:785
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:826
 msgid "Government spending is based on 2023-2024 fiscal spending. Attempts have been made to merge similar categories across federal and provincial spending."
 msgstr "Government spending is based on 2023-2024 fiscal spending. Attempts have been made to merge similar categories across federal and provincial spending."
 
@@ -1564,11 +1565,11 @@ msgstr "Government spending is based on 2023-2024 fiscal spending. Attempts have
 msgid "facts-1"
 msgstr "Government spending shouldn’t be a black box. Every year, the federal government spends hundreds of billions of dollars but most Canadians have no clue where it all goes. The data is available, but it’s buried on obscure websites and impossible to navigate."
 
-#: src/app/[lang]/layout.tsx:23
+#: src/app/[lang]/layout.tsx:22
 msgid "Government spending shouldn't be a black box. We turn complex data into clear, non-partisan insights so every Canadian knows where their money goes."
 msgstr "Government spending shouldn't be a black box. We turn complex data into clear, non-partisan insights so every Canadian knows where their money goes."
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:165
+#: src/app/[lang]/(main)/federal/spending/page.tsx:166
 #: src/app/[lang]/(main)/spending/page.tsx:156
 msgid "Government Workforce"
 msgstr "Government Workforce"
@@ -1593,7 +1594,7 @@ msgstr "Group"
 msgid "Have questions or feedback? Email us at hi@canadaspends.com or connect with us on X @canada_spends - we'd love to hear from you!"
 msgstr "Have questions or feedback? Email us at hi@canadaspends.com or connect with us on X @canada_spends - we'd love to hear from you!"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:169
+#: src/app/[lang]/(main)/federal/spending/page.tsx:170
 #: src/app/[lang]/(main)/spending/page.tsx:160
 msgid "Headcount"
 msgstr "Headcount"
@@ -1606,28 +1607,28 @@ msgstr "Health"
 msgid "Health agreements with provinces and territories"
 msgstr "Health agreements with provinces and territories"
 
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:56
 msgid "Health Canada"
 msgstr "Health Canada"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:33
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:33
 msgid "Health Canada | Canada Spends"
 msgstr "Health Canada | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:101
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:101
 msgid "Health Canada accounted for 2.7% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 msgstr "Health Canada accounted for 2.7% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:170
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:170
 msgid "Health Canada is led by the <0>Minister of Health</0>, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 msgstr "Health Canada is led by the <0>Minister of Health</0>, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:51
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:51
 msgid "Health Canada is the federal department responsible for protecting and improving the health of Canadians. It develops health policies, regulates pharmaceuticals and medical devices, enforces food safety standards, and funds public health programs. The department works with provinces and territories to support the healthcare system while ensuring safety standards for drugs, consumer products, and nutrition guidelines."
 msgstr "Health Canada is the federal department responsible for protecting and improving the health of Canadians. It develops health policies, regulates pharmaceuticals and medical devices, enforces food safety standards, and funds public health programs. The department works with provinces and territories to support the healthcare system while ensuring safety standards for drugs, consumer products, and nutrition guidelines."
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:92
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:92
 msgid "Health Canada spent $13.7 billion in fiscal year (FY) 2024. This was 2.7% of the $513.9 billion in overall federal spending. The department ranked tenth among federal departments in total spending."
 msgstr "Health Canada spent $13.7 billion in fiscal year (FY) 2024. This was 2.7% of the $513.9 billion in overall federal spending. The department ranked tenth among federal departments in total spending."
 
@@ -1644,23 +1645,23 @@ msgstr "Health Research"
 msgid "Health Transfer to Provinces"
 msgstr "Health Transfer to Provinces"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:180
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:180
 msgid "Help for Canadians Abroad: $85.98M"
 msgstr "Help for Canadians Abroad: $85.98M"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:16
 msgid "HICC"
 msgstr "HICC"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:102
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:102
 msgid "HICC accounted for 2.8% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024."
 msgstr "HICC accounted for 2.8% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024."
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:62
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:62
 msgid "HICC administers the National Housing Strategy, which funds the construction, repair, and preservation of affordable housing. It also oversees the Canada Mortgage and Housing Corporation (CMHC), which provides mortgage insurance and financing programs. The department supports public transit, clean energy, and community infrastructure through programs like the Canada Infrastructure Bank (CIB)."
 msgstr "HICC administers the National Housing Strategy, which funds the construction, repair, and preservation of affordable housing. It also oversees the Canada Mortgage and Housing Corporation (CMHC), which provides mortgage insurance and financing programs. The department supports public transit, clean energy, and community infrastructure through programs like the Canada Infrastructure Bank (CIB)."
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:94
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:94
 msgid "HICC spent $14.5 billion in fiscal year (FY) 2024. This was 2.8% of the $513.9 billion in overall federal spending. The department ranked eighth among federal departments in total spending."
 msgstr "HICC spent $14.5 billion in fiscal year (FY) 2024. This was 2.8% of the $513.9 billion in overall federal spending. The department ranked eighth among federal departments in total spending."
 
@@ -1681,15 +1682,15 @@ msgstr "Housing Assistance"
 msgid "Housing, Infrastructure and Communities Canada"
 msgstr "Housing, Infrastructure and Communities Canada"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:180
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:180
 msgid "Housing, Infrastructure and Communities Canada (HICC) is led by the <0>Minister of Housing, Infrastructure and Communities</0>, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 msgstr "Housing, Infrastructure and Communities Canada (HICC) is led by the <0>Minister of Housing, Infrastructure and Communities</0>, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:52
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:52
 msgid "Housing, Infrastructure and Communities Canada (HICC) is responsible for federal policies and programs that support public infrastructure, affordable housing, and community development. It works with provinces, territories, and municipalities to fund major infrastructure projects and improve housing affordability across Canada."
 msgstr "Housing, Infrastructure and Communities Canada (HICC) is responsible for federal policies and programs that support public infrastructure, affordable housing, and community development. It works with provinces, territories, and municipalities to fund major infrastructure projects and improve housing affordability across Canada."
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:34
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:34
 msgid "Housing, Infrastructure and Communities Canada | Canada Spends"
 msgstr "Housing, Infrastructure and Communities Canada | Canada Spends"
 
@@ -1701,59 +1702,59 @@ msgstr "How can I show my support?"
 msgid "How can I stay up to date on your work?"
 msgstr "How can I stay up to date on your work?"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:170
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:170
 msgid "How did ESDC spend its budget in 2024?"
 msgstr "How did ESDC spend its budget in 2024?"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:160
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:160
 msgid "How did Global Affairs Canada spend its budget in 2024?"
 msgstr "How did Global Affairs Canada spend its budget in 2024?"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:155
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:155
 msgid "How did HICC spend its budget in FY24?"
 msgstr "How did HICC spend its budget in FY24?"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:137
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:137
 msgid "How did IRCC spend its budget in FY24?"
 msgstr "How did IRCC spend its budget in FY24?"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:170
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:170
 msgid "How did ISC and CIRNAC spend their budgets in 2024?"
 msgstr "How did ISC and CIRNAC spend their budgets in 2024?"
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:139
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:139
 msgid "How did ISED spend its budget in FY 24?"
 msgstr "How did ISED spend its budget in FY 24?"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:145
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:145
 msgid "How did PSPC spend its budget in FY24?"
 msgstr "How did PSPC spend its budget in FY24?"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:141
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:141
 msgid "How did Public Safety Canada spend its budget in 2024?"
 msgstr "How did Public Safety Canada spend its budget in 2024?"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:182
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:182
 msgid "How did the Canada Revenue Agency spend its budget in 2024?"
 msgstr "How did the Canada Revenue Agency spend its budget in 2024?"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:165
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:165
 msgid "How did the Department of Finance spend its budget in 2024?"
 msgstr "How did the Department of Finance spend its budget in 2024?"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:168
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:168
 msgid "How did the Department of National Defence spend its budget in 2024?"
 msgstr "How did the Department of National Defence spend its budget in 2024?"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:138
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:138
 msgid "How did Transport Canada spend its budget in FY24?"
 msgstr "How did Transport Canada spend its budget in FY24?"
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:141
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:141
 msgid "How did VAC spend its budget in FY24?"
 msgstr "How did VAC spend its budget in FY24?"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:110
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:110
 msgid "How has Public Safety Canada's spending changed?"
 msgstr "How has Public Safety Canada's spending changed?"
 
@@ -1765,16 +1766,16 @@ msgstr "How to Submit a Tip"
 msgid "Immigration + Border Security"
 msgstr "Immigration + Border Security"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:74
 msgid "Immigration, Refugees and Citizenship"
 msgstr "Immigration, Refugees and Citizenship"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:170
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:170
 msgid "Immigration, Refugees and Citizenship Canada (IRCC) is led by the Minister of Immigration, Refugees and Citizenship, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 msgstr "Immigration, Refugees and Citizenship Canada (IRCC) is led by the Minister of Immigration, Refugees and Citizenship, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:32
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:32
 msgid "Immigration, Refugees and Citizenship Canada | Canada Spends"
 msgstr "Immigration, Refugees and Citizenship Canada | Canada Spends"
 
@@ -1797,66 +1798,66 @@ msgstr "In {0}, you pay <0>{1}</0> in total tax ({2}% effective rate)"
 msgid "In Financial Year {0},"
 msgstr "In Financial Year {0},"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:99
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:99
 msgid "In fiscal year (FY) 2024, ISC and CIRNAC collectively spent <0>$63 billion</0>, accounting for <1>12.3% of the total federal budget</1>. The departments play a critical role in addressing socio-economic disparities, facilitating self-governance agreements, and improving service delivery for Indigenous communities across Canada."
 msgstr "In fiscal year (FY) 2024, ISC and CIRNAC collectively spent <0>$63 billion</0>, accounting for <1>12.3% of the total federal budget</1>. The departments play a critical role in addressing socio-economic disparities, facilitating self-governance agreements, and improving service delivery for Indigenous communities across Canada."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:73
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:78
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:72
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:77
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:74
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:79
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:80
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:85
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:78
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:83
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:80
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:85
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:67
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:72
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:85
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:90
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:68
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:73
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:75
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:82
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:72
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:77
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:70
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:75
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:68
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:73
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:70
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:75
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:73
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:78
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:72
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:77
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:74
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:79
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:80
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:85
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:78
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:83
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:80
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:85
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:67
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:72
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:85
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:90
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:68
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:73
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:75
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:82
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:72
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:77
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:70
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:75
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:68
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:73
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:70
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:75
 msgid "In FY 2024,"
 msgstr "In FY 2024,"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:173
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:173
 msgid "In FY 2024, 55.2% of CRA net spending was allocated to salaries, benefits, and pensions."
 msgstr "In FY 2024, 55.2% of CRA net spending was allocated to salaries, benefits, and pensions."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:173
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:173
 msgid "In FY 2024, ESDC transferred 63% of its total spending to individuals and provinces."
 msgstr "In FY 2024, ESDC transferred 63% of its total spending to individuals and provinces."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:155
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:155
 msgid "In FY 2024, Finance Canada transferred 66.2% of its total spending to provinces and territories. The chart below outlines all departmental spending in 2024."
 msgstr "In FY 2024, Finance Canada transferred 66.2% of its total spending to provinces and territories. The chart below outlines all departmental spending in 2024."
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:162
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:162
 msgid "In FY 2024, ISC and CIRNAC transferred 93.1% of total spending directly to indigenous communities."
 msgstr "In FY 2024, ISC and CIRNAC transferred 93.1% of total spending directly to indigenous communities."
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:146
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:146
 msgid "In FY 2024, Public Safety's budget was allocated across several key areas, including:"
 msgstr "In FY 2024, Public Safety's budget was allocated across several key areas, including:"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:112
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:112
 msgid "In FY 2024, Transport Canada accounted for 1% of all federal spending, 0.74% percentage points lower than in 1995."
 msgstr "In FY 2024, Transport Canada accounted for 1% of all federal spending, 0.74% percentage points lower than in 1995."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:155
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:155
 msgid "In FY 2024, VAC reported total expenditures of $6.07 billion across two entities:"
 msgstr "In FY 2024, VAC reported total expenditures of $6.07 billion across two entities:"
 
@@ -1876,11 +1877,11 @@ msgstr "Indeterminate"
 msgid "Indigenous Priorities"
 msgstr "Indigenous Priorities"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:35
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:35
 msgid "Indigenous Services and Northern Affairs Canada | Canada Spends"
 msgstr "Indigenous Services and Northern Affairs Canada | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:55
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:55
 msgid "Indigenous Services Canada (ISC) and Crown-Indigenous Relations and Northern Affairs Canada (CIRNAC) are two distinct federal departments tasked with advancing Indigenous priorities in Canada. Established in 2017 following the dissolution of Indigenous and Northern Affairs Canada (INAC), these departments manage different aspects of Indigenous policy, service delivery, and governance."
 msgstr "Indigenous Services Canada (ISC) and Crown-Indigenous Relations and Northern Affairs Canada (CIRNAC) are two distinct federal departments tasked with advancing Indigenous priorities in Canada. Established in 2017 following the dissolution of Indigenous and Northern Affairs Canada (INAC), these departments manage different aspects of Indigenous policy, service delivery, and governance."
 
@@ -1900,19 +1901,19 @@ msgstr "Individual Income Tax"
 msgid "Individual Income Taxes"
 msgstr "Individual Income Taxes"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:27
 msgid "Information"
 msgstr "Information"
 
@@ -1924,16 +1925,16 @@ msgstr "Infrastructure Investments"
 msgid "Innovation + Research"
 msgstr "Innovation + Research"
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:62
 msgid "Innovation, Science and Industry"
 msgstr "Innovation, Science and Industry"
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:171
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:171
 msgid "Innovation, Science and Industry Canada (ISED) is led by the Minister of Innovation, Science and Industry, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 msgstr "Innovation, Science and Industry Canada (ISED) is led by the Minister of Innovation, Science and Industry, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:32
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:32
 msgid "Innovation, Science and Industry Canada | Canada Spends"
 msgstr "Innovation, Science and Industry Canada | Canada Spends"
 
@@ -1958,21 +1959,21 @@ msgstr "Interest on Debt"
 msgid "Interim Housing Assistance"
 msgstr "Interim Housing Assistance"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:71
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:67
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:71
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:67
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:71
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:71
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:71
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:71
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:71
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:71
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:71
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:71
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:71
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:71
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:71
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:71
 msgid "Internal Revenues"
 msgstr "Internal Revenues"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:171
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:171
 msgid "International Advocacy and Diplomacy: $1B"
 msgstr "International Advocacy and Diplomacy: $1B"
 
@@ -1996,11 +1997,11 @@ msgstr "Investment, Growth and Commercialization"
 msgid "Involved First Nations"
 msgstr "Involved First Nations"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:89
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:89
 msgid "IRCC accounted for 1.2% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 msgstr "IRCC accounted for 1.2% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:81
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:81
 msgid "IRCC spent $6.3 billion in fiscal year (FY) 2024. This was 1.2% of the $513.9 billion in overall federal spending. The department ranked thirteenth among federal departments in total spending."
 msgstr "IRCC spent $6.3 billion in fiscal year (FY) 2024. This was 1.2% of the $513.9 billion in overall federal spending. The department ranked thirteenth among federal departments in total spending."
 
@@ -2008,23 +2009,23 @@ msgstr "IRCC spent $6.3 billion in fiscal year (FY) 2024. This was 1.2% of the $
 msgid "Is this a lobby group?"
 msgstr "Is this a lobby group?"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:182
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:182
 msgid "ISC + CIRNAC, Spending by Entity, FY 2024"
 msgstr "ISC + CIRNAC, Spending by Entity, FY 2024"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:135
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:135
 msgid "ISC + CIRNAC's share of federal spending in FY 2024 was 592% higher than in FY 1995"
 msgstr "ISC + CIRNAC's share of federal spending in FY 2024 was 592% higher than in FY 1995"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:16
 msgid "ISC and CIRNAC"
 msgstr "ISC and CIRNAC"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:65
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:65
 msgid "ISC is responsible for providing essential services to First Nations, Inuit, and Métis communities, including healthcare, education, housing, and child and family services. It also works to transfer control of these services to Indigenous-led organizations. CIRNAC focuses on treaty negotiations, self-government agreements, land claims, and Northern affairs, aiming to strengthen nation-to-nation relationships and modernize Indigenous governance structures. Together, ISC and CIRNAC oversee key programs that impact Indigenous communities across Canada."
 msgstr "ISC is responsible for providing essential services to First Nations, Inuit, and Métis communities, including healthcare, education, housing, and child and family services. It also works to transfer control of these services to Indigenous-led organizations. CIRNAC focuses on treaty negotiations, self-government agreements, land claims, and Northern affairs, aiming to strengthen nation-to-nation relationships and modernize Indigenous governance structures. Together, ISC and CIRNAC oversee key programs that impact Indigenous communities across Canada."
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:82
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:82
 msgid "ISED spent $10.2 billion in fiscal year (FY) 2024. This was 2% of the $513.9 billion in overall federal spending. The department ranked eleventh among federal departments in total spending."
 msgstr "ISED spent $10.2 billion in fiscal year (FY) 2024. This was 2% of the $513.9 billion in overall federal spending. The department ranked eleventh among federal departments in total spending."
 
@@ -2050,7 +2051,7 @@ msgstr "Key Dates"
 msgid "Keywords"
 msgstr "Keywords"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:217
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:217
 msgid "Labour Market Development Agreements (LMDAs): federal funding to provinces for job training and employment support."
 msgstr "Labour Market Development Agreements (LMDAs): federal funding to provinces for job training and employment support."
 
@@ -2067,7 +2068,7 @@ msgid "Last Update"
 msgstr "Last Update"
 
 #: src/app/[lang]/(main)/budget/page.tsx:248
-#: src/app/[lang]/(main)/federal/budget/page.tsx:285
+#: src/app/[lang]/(main)/federal/budget/page.tsx:287
 msgid "Latest Budget News & Impact"
 msgstr "Latest Budget News & Impact"
 
@@ -2085,40 +2086,40 @@ msgstr "Location"
 msgid "Look back at what {0}'s government made and spent. {1}"
 msgstr "Look back at what {0}'s government made and spent. {1}"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:148
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:148
 msgid "Major international events, trade agreements, foreign aid commitments, and global crises such as the COVID-19 pandemic have influenced fluctuations in spending. In 2020, GAC's budget surged due to emergency international assistance programs, including vaccine distribution and humanitarian relief efforts."
 msgstr "Major international events, trade agreements, foreign aid commitments, and global crises such as the COVID-19 pandemic have influenced fluctuations in spending. In 2020, GAC's budget surged due to emergency international assistance programs, including vaccine distribution and humanitarian relief efforts."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:124
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:124
 msgid "Major legislation, economic conditions, and external factors can impact ESDC's spending."
 msgstr "Major legislation, economic conditions, and external factors can impact ESDC's spending."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:120
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:120
 msgid "Major legislation, internal or global economic conditions, and acute events like the COVID-19 pandemic can affect spending year to year. For example, the federal expenses fluctuated during the pandemic, rising from $410.2 billion (in 2024 dollars) in 2019 to $420 billion in 2020 and $720.3 billion in 2021"
 msgstr "Major legislation, internal or global economic conditions, and acute events like the COVID-19 pandemic can affect spending year to year. For example, the federal expenses fluctuated during the pandemic, rising from $410.2 billion (in 2024 dollars) in 2019 to $420 billion in 2020 and $720.3 billion in 2021"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:131
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:131
 msgid "Major legislation, internal or global economic conditions, and acute events like the COVID-19 pandemic can significantly influence government spending year to year. For example, during the COVID-19 pandemic, federal support programs led to a temporary surge in spending. Health Canada expenditures increased from $5 billion in FY 2019 to $14.2 billion in FY 2021 before stabilizing in recent years."
 msgstr "Major legislation, internal or global economic conditions, and acute events like the COVID-19 pandemic can significantly influence government spending year to year. For example, during the COVID-19 pandemic, federal support programs led to a temporary surge in spending. Health Canada expenditures increased from $5 billion in FY 2019 to $14.2 billion in FY 2021 before stabilizing in recent years."
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:132
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:117
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:119
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:120
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:118
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:121
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:132
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:117
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:119
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:120
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:118
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:121
 msgid "Major legislation, internal or global economic conditions, and acute events like the COVID-19 pandemic can significantly influence government spending year to year. For instance, during the pandemic, the Government of Canada's total expenses rose from $410.2 billion in 2019 to $420 billion in 2020 and further to $720.3 billion in 2021."
 msgstr "Major legislation, internal or global economic conditions, and acute events like the COVID-19 pandemic can significantly influence government spending year to year. For instance, during the pandemic, the Government of Canada's total expenses rose from $410.2 billion in 2019 to $420 billion in 2020 and further to $720.3 billion in 2021."
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:159
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:159
 msgid "Major legislation, shifts in international security dynamics, and acute events such as Russia's invasion of Ukraine or Arctic sovereignty disputes can influence military spending."
 msgstr "Major legislation, shifts in international security dynamics, and acute events such as Russia's invasion of Ukraine or Arctic sovereignty disputes can influence military spending."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:129
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:129
 msgid "Major legislative changes, compliance trends, and digital tax services have influenced CRA spending patterns. For example, compliance initiatives and fraud investigations recovered an estimated $11.5 billion in lost revenue in 2024 due to tax evasion."
 msgstr "Major legislative changes, compliance trends, and digital tax services have influenced CRA spending patterns. For example, compliance initiatives and fraud investigations recovered an estimated $11.5 billion in lost revenue in 2024 due to tax evasion."
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:125
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:125
 msgid "Major policy shifts, unforeseen events such as natural disasters, and global security concerns can significantly impact the department's annual spending. The COVID-19 pandemic, for example, led to a sharp increase in federal emergency response funding in 2020."
 msgstr "Major policy shifts, unforeseen events such as natural disasters, and global security concerns can significantly impact the department's annual spending. The COVID-19 pandemic, for example, led to a sharp increase in federal emergency response funding in 2020."
 
@@ -2168,18 +2169,18 @@ msgstr "Months"
 msgid "More coming soon..."
 msgstr "More coming soon..."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:167
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:167
 msgid "Most CRA spending is dedicated to personnel and IT infrastructure supporting tax filing, compliance, and benefit administration."
 msgstr "Most CRA spending is dedicated to personnel and IT infrastructure supporting tax filing, compliance, and benefit administration."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:155
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:155
 msgid "Most federal spending can be categorized as direct or indirect."
 msgstr "Most federal spending can be categorized as direct or indirect."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:158
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:146
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:153
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:183
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:158
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:146
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:153
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:183
 msgid "Most federal spending can be categorized as direct or indirect. Direct spending refers to money the federal government spends on budget items such as federal programs, employee salaries, and debt interest. Indirect spending refers to federal transfers to other levels of government."
 msgstr "Most federal spending can be categorized as direct or indirect. Direct spending refers to money the federal government spends on budget items such as federal programs, employee salaries, and debt interest. Indirect spending refers to federal transfers to other levels of government."
 
@@ -2197,19 +2198,19 @@ msgstr "Name"
 msgid "National Defence"
 msgstr "National Defence"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:35
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:35
 msgid "National Defence | Canada Spends"
 msgstr "National Defence | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:107
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:107
 msgid "National Defence accounted for 6.7% of all federal spending in FY 2024"
 msgstr "National Defence accounted for 6.7% of all federal spending in FY 2024"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:203
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:203
 msgid "National Defence, Spending by Entity, FY 2024"
 msgstr "National Defence, Spending by Entity, FY 2024"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:144
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:144
 msgid "National Defence's share of federal spending in FY 2024 was lower than in FY 1995"
 msgstr "National Defence's share of federal spending in FY 2024 was lower than in FY 1995"
 
@@ -2287,7 +2288,7 @@ msgid "Newfoundland and Labrador STP"
 msgstr "Newfoundland and Labrador STP"
 
 #: src/app/[lang]/(main)/budget/page.tsx:56
-#: src/app/[lang]/(main)/federal/budget/page.tsx:56
+#: src/app/[lang]/(main)/federal/budget/page.tsx:57
 msgid "News Source & Date"
 msgstr "News Source & Date"
 
@@ -2430,59 +2431,59 @@ msgstr "of {0} municipal spending was by {1}"
 msgid "of {0} provincial spending was by {1}"
 msgstr "of {0} provincial spending was by {1}"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:92
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:92
 msgid "of federal spending was allocated to Indigenous priorities via these Departments. This does not include additional programs in other departments designed specifically for Indigenous beneficiaries."
 msgstr "of federal spending was allocated to Indigenous priorities via these Departments. This does not include additional programs in other departments designed specifically for Indigenous beneficiaries."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:81
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:81
 msgid "of federal spending was by ESDC"
 msgstr "of federal spending was by ESDC"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:79
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:79
 msgid "of federal spending was by Finance Canada"
 msgstr "of federal spending was by Finance Canada"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:85
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:85
 msgid "of federal spending was by Health Canada"
 msgstr "of federal spending was by Health Canada"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:87
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:87
 msgid "of federal spending was by Housing, Infrastructure and Communities Canada"
 msgstr "of federal spending was by Housing, Infrastructure and Communities Canada"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:77
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:77
 msgid "Of federal spending was by Public Services and Procurement Canada"
 msgstr "Of federal spending was by Public Services and Procurement Canada"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:80
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:80
 msgid "of federal spending was by the Canada Revenue Agency"
 msgstr "of federal spending was by the Canada Revenue Agency"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:85
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:85
 msgid "of federal spending was by the Department of National Defence"
 msgstr "of federal spending was by the Department of National Defence"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:74
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:74
 msgid "Of federal spending was by the Dept. of Immigration, Refugees and Citizenship"
 msgstr "Of federal spending was by the Dept. of Immigration, Refugees and Citizenship"
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:75
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:75
 msgid "Of federal spending was by the Dept. of Innovation, Science and Industry"
 msgstr "Of federal spending was by the Dept. of Innovation, Science and Industry"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:75
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:75
 msgid "Of federal spending was by the Dept. of Transport"
 msgstr "Of federal spending was by the Dept. of Transport"
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:77
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:77
 msgid "Of federal spending was by the Dept. of Veterans Affairs"
 msgstr "Of federal spending was by the Dept. of Veterans Affairs"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:87
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:87
 msgid "of federal spending was by the Global Affairs Canada"
 msgstr "of federal spending was by the Global Affairs Canada"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:79
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:79
 msgid "of federal spending was by the Public Safety Canada"
 msgstr "of federal spending was by the Public Safety Canada"
 
@@ -2494,7 +2495,7 @@ msgstr "Office of the Chief Electoral Officer"
 msgid "Office of the Secretary to the Governor General"
 msgstr "Office of the Secretary to the Governor General"
 
-#: src/app/[lang]/(main)/federal/budget/page.tsx:168
+#: src/app/[lang]/(main)/federal/budget/page.tsx:170
 msgid "Official Fall 2025 Federal Budget Released"
 msgstr "Official Fall 2025 Federal Budget Released"
 
@@ -2532,7 +2533,7 @@ msgid "Open Tor Browser and wait for it to connect."
 msgstr "Open Tor Browser and wait for it to connect."
 
 #: src/app/[lang]/(main)/budget/page.tsx:195
-#: src/app/[lang]/(main)/federal/budget/page.tsx:232
+#: src/app/[lang]/(main)/federal/budget/page.tsx:234
 msgid "Operational Spend"
 msgstr "Operational Spend"
 
@@ -2544,7 +2545,7 @@ msgstr "or subscribe to"
 msgid "Organization"
 msgstr "Organization"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/MiniSankey.tsx:35
 #: src/components/Sankey/index.tsx:319
 msgid "Other"
 msgstr "Other"
@@ -2576,7 +2577,7 @@ msgstr "Other Environment and Climate Change Programs"
 msgid "Other Excise Taxes and Duties"
 msgstr "Other Excise Taxes and Duties"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/MiniSankey.tsx:39
 msgid "Other expenditures"
 msgstr "Other expenditures"
 
@@ -2632,22 +2633,22 @@ msgstr "Other Public Services + Procurement"
 msgid "Other Settlement Agreements"
 msgstr "Other Settlement Agreements"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:63
 msgid "Other subsidies and payments"
 msgstr "Other subsidies and payments"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:55
 msgid "Other Subsidies and Payments"
 msgstr "Other Subsidies and Payments"
 
@@ -2685,7 +2686,7 @@ msgstr "Parliament"
 msgid "Payment Amount"
 msgstr "Payment Amount"
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:348
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:354
 msgid "Payroll Contributions"
 msgstr "Payroll Contributions"
 
@@ -2693,7 +2694,7 @@ msgstr "Payroll Contributions"
 msgid "Payroll Taxes"
 msgstr "Payroll Taxes"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:237
+#: src/app/[lang]/(main)/federal/spending/page.tsx:238
 #: src/app/[lang]/(main)/spending/page.tsx:228
 msgid "PBO"
 msgstr "PBO"
@@ -2707,43 +2708,43 @@ msgstr "Per Capita Spending"
 msgid "per resident"
 msgstr "per resident"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:148
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:148
 msgid "Percentage of federal budget dedicated to Canada Revenue Agency, FYs 1995-2024"
 msgstr "Percentage of federal budget dedicated to Canada Revenue Agency, FYs 1995-2024"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:152
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:152
 msgid "Percentage of federal budget dedicated to Defence, FYs 1995-2024"
 msgstr "Percentage of federal budget dedicated to Defence, FYs 1995-2024"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:146
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:146
 msgid "Percentage of federal budget dedicated to ESDC, FYs 1995-2024 (inflation-adjusted)"
 msgstr "Percentage of federal budget dedicated to ESDC, FYs 1995-2024 (inflation-adjusted)"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:138
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:138
 msgid "Percentage of federal budget dedicated to Finance, FYs 1995-2024"
 msgstr "Percentage of federal budget dedicated to Finance, FYs 1995-2024"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:131
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:131
 msgid "Percentage of federal budget dedicated to Global Affairs Canada, FYs 1995-2024"
 msgstr "Percentage of federal budget dedicated to Global Affairs Canada, FYs 1995-2024"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:141
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:141
 msgid "Percentage of federal budget dedicated to Indigenous Priorities, FYs 1995-2024"
 msgstr "Percentage of federal budget dedicated to Indigenous Priorities, FYs 1995-2024"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:19
 msgid "Personnel"
 msgstr "Personnel"
 
@@ -2798,22 +2799,22 @@ msgstr "Principal Investigator"
 msgid "Privy Council Office"
 msgstr "Privy Council Office"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:31
 msgid "Professional + Special Services"
 msgstr "Professional + Special Services"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:31
 msgid "Professional and Special Services"
 msgstr "Professional and Special Services"
 
@@ -2830,12 +2831,12 @@ msgid "Project Number"
 msgstr "Project Number"
 
 #: src/app/[lang]/(main)/budget/page.tsx:206
-#: src/app/[lang]/(main)/federal/budget/page.tsx:243
+#: src/app/[lang]/(main)/federal/budget/page.tsx:245
 msgid "Projected capital investments"
 msgstr "Projected capital investments"
 
 #: src/app/[lang]/(main)/budget/page.tsx:197
-#: src/app/[lang]/(main)/federal/budget/page.tsx:234
+#: src/app/[lang]/(main)/federal/budget/page.tsx:236
 msgid "Projected operational spending"
 msgstr "Projected operational spending"
 
@@ -2873,11 +2874,11 @@ msgstr "Provincial"
 msgid "Provincial Tax"
 msgstr "Provincial Tax"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:92
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:92
 msgid "PSPC accounted for 1.6% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 msgstr "PSPC accounted for 1.6% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:84
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:84
 msgid "PSPC spent $8.3 billion in fiscal year (FY) 2024. This was 1.6% of the $513.9 billion in overall federal spending. The department ranked twelfth among federal departments in total spending."
 msgstr "PSPC spent $8.3 billion in fiscal year (FY) 2024. This was 1.6% of the $513.9 billion in overall federal spending. The department ranked twelfth among federal departments in total spending."
 
@@ -2887,19 +2888,19 @@ msgstr "PSPC spent $8.3 billion in fiscal year (FY) 2024. This was 1.6% of the $
 msgid "Public Accounts of {0} FY {1}"
 msgstr "Public Accounts of {0} FY {1}"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:59
 msgid "Public debt charges"
 msgstr "Public debt charges"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:59
 #: src/components/Sankey/BudgetSankey.tsx:427
 msgid "Public Debt Charges"
 msgstr "Public Debt Charges"
@@ -2912,20 +2913,20 @@ msgstr "Public Health + Disease Prevention"
 msgid "Public Safety"
 msgstr "Public Safety"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:50
 msgid "Public Safety Canada"
 msgstr "Public Safety Canada"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:34
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:34
 msgid "Public Safety Canada | Canada Spends"
 msgstr "Public Safety Canada | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:86
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:86
 msgid "Public Safety Canada spent $13.9 billion in fiscal year (FY) 2024, accounting for 2.7% of the $513.9 billion in total federal spending. While not among the largest departments by expenditure, Public Safety Canada plays a crucial role in national security and emergency management, working in tandem with multiple agencies to mitigate threats and enhance public safety."
 msgstr "Public Safety Canada spent $13.9 billion in fiscal year (FY) 2024, accounting for 2.7% of the $513.9 billion in total federal spending. While not among the largest departments by expenditure, Public Safety Canada plays a crucial role in national security and emergency management, working in tandem with multiple agencies to mitigate threats and enhance public safety."
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:52
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:52
 msgid "Public Safety, Democratic Institutions and Intergovernmental Affairs Canada (Public Safety Canada) is the federal department responsible for national security, emergency preparedness, and community safety. Established in 2003, it consolidates security, law enforcement, and emergency management functions. It includes the RCMP, CSIS, and CBSA and coordinates federal responses to threats and develops policies on crime prevention, cyber resilience, and disaster preparedness while overseeing intelligence-sharing with domestic and international partners."
 msgstr "Public Safety, Democratic Institutions and Intergovernmental Affairs Canada (Public Safety Canada) is the federal department responsible for national security, emergency preparedness, and community safety. Established in 2003, it consolidates security, law enforcement, and emergency management functions. It includes the RCMP, CSIS, and CBSA and coordinates federal responses to threats and develops policies on crime prevention, cyber resilience, and disaster preparedness while overseeing intelligence-sharing with domestic and international partners."
 
@@ -2933,16 +2934,16 @@ msgstr "Public Safety, Democratic Institutions and Intergovernmental Affairs Can
 msgid "Public Service Employees"
 msgstr "Public Service Employees"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:68
 msgid "Public Services and Procurement Canada"
 msgstr "Public Services and Procurement Canada"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:177
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:177
 msgid "Public Services and Procurement Canada (PSPC) is led by the Minister of Government Transformation, Public Services and Procurement, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 msgstr "Public Services and Procurement Canada (PSPC) is led by the Minister of Government Transformation, Public Services and Procurement, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:32
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:32
 msgid "Public Services and Procurement Canada | Canada Spends"
 msgstr "Public Services and Procurement Canada | Canada Spends"
 
@@ -2950,7 +2951,7 @@ msgstr "Public Services and Procurement Canada | Canada Spends"
 msgid "Public Works + Government Services"
 msgstr "Public Works + Government Services"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/MiniSankey.tsx:31
 msgid "Quebec abatement"
 msgstr "Quebec abatement"
 
@@ -2989,7 +2990,7 @@ msgid "Ready Forces"
 msgstr "Ready Forces"
 
 #: src/app/[lang]/(main)/budget/page.tsx:251
-#: src/app/[lang]/(main)/federal/budget/page.tsx:288
+#: src/app/[lang]/(main)/federal/budget/page.tsx:290
 msgid "Recent developments and their projected impact on the Fall 2025 Budget"
 msgstr "Recent developments and their projected impact on the Fall 2025 Budget"
 
@@ -3015,38 +3016,38 @@ msgstr "Remuneration"
 msgid "Remuneration and Expenses"
 msgstr "Remuneration and Expenses"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:35
 msgid "Rentals"
 msgstr "Rentals"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:39
 msgid "Repair + Maintenance"
 msgstr "Repair + Maintenance"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:39
 msgid "Repair and Maintenance"
 msgstr "Repair and Maintenance"
 
@@ -3077,7 +3078,7 @@ msgid "Return on Investments"
 msgstr "Return on Investments"
 
 #: src/app/[lang]/(main)/budget/page.tsx:184
-#: src/app/[lang]/(main)/federal/budget/page.tsx:221
+#: src/app/[lang]/(main)/federal/budget/page.tsx:223
 #: src/components/Sankey/BudgetSankey.tsx:456
 #: src/components/Sankey/index.tsx:700
 msgid "Revenue"
@@ -3099,7 +3100,7 @@ msgstr "Safety"
 msgid "Salaries, honoraria, travel, and other expenses paid to elected officials and senior employees during fiscal year {fiscalYear}."
 msgstr "Salaries, honoraria, travel, and other expenses paid to elected officials and senior employees during fiscal year {fiscalYear}."
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:247
+#: src/app/[lang]/(main)/federal/spending/page.tsx:248
 #: src/app/[lang]/(main)/spending/page.tsx:238
 msgid "Salary Distribution"
 msgstr "Salary Distribution"
@@ -3152,7 +3153,7 @@ msgstr "Selection Committee"
 msgid "Selection Mechanism"
 msgstr "Selection Mechanism"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:205
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:205
 msgid "Service Canada: responsible for processing EI, CPP, and OAS benefits."
 msgstr "Service Canada: responsible for processing EI, CPP, and OAS benefits."
 
@@ -3185,23 +3186,23 @@ msgstr "Showing {0} of {1} First Nations"
 msgid "Showing {0} of {1} results"
 msgstr "Showing {0} of {1} results"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:142
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:142
 msgid "Similarly, HICC expenditures experienced notable fluctuations during this period, surging from approximately $5.9 billion​ in 2019 (adjusted for inflation) to $14.5B in 2024."
 msgstr "Similarly, HICC expenditures experienced notable fluctuations during this period, surging from approximately $5.9 billion​ in 2019 (adjusted for inflation) to $14.5B in 2024."
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:127
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:127
 msgid "Similarly, IRCC's expenditures experienced notable fluctuations during this period, surging from approximately $3.02 billion​ in 2019 to $6.3 billion in 2024."
 msgstr "Similarly, IRCC's expenditures experienced notable fluctuations during this period, surging from approximately $3.02 billion​ in 2019 to $6.3 billion in 2024."
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:129
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:129
 msgid "Similarly, ISED's expenditures have increased during this period, growing from approximately $6.5 billion​ in 2019 (adjusted for inflation) to $10.2 billion in 2024."
 msgstr "Similarly, ISED's expenditures have increased during this period, growing from approximately $6.5 billion​ in 2019 (adjusted for inflation) to $10.2 billion in 2024."
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:130
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:130
 msgid "Similarly, PSPC's expenditures experienced notable fluctuations during this period, decreasing from approximately $6.8 billion​ in 2019 (adjusted for inflation) to $5.3 billion in 2021 before increasing again in 2024."
 msgstr "Similarly, PSPC's expenditures experienced notable fluctuations during this period, decreasing from approximately $6.8 billion​ in 2019 (adjusted for inflation) to $5.3 billion in 2021 before increasing again in 2024."
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:128
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:128
 msgid "Similarly, Transport Canada's expenditures experienced fluctuations during this period, increasing from approximately $3.2 billion​ in 2019 (adjusted for inflation) to $5.1B in 2024."
 msgstr "Similarly, Transport Canada's expenditures experienced fluctuations during this period, increasing from approximately $3.2 billion​ in 2019 (adjusted for inflation) to $5.1B in 2024."
 
@@ -3224,21 +3225,21 @@ msgstr "Source"
 msgid "Source PDF"
 msgstr "Source PDF"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:260
+#: src/app/[lang]/(main)/federal/spending/page.tsx:261
 #: src/app/[lang]/(main)/spending/page.tsx:251
 msgid "Source:"
 msgstr "Source:"
 
 #: src/app/[lang]/(main)/budget/page.tsx:267
-#: src/app/[lang]/(main)/federal/budget/page.tsx:304
-#: src/app/[lang]/(main)/federal/spending/page.tsx:275
+#: src/app/[lang]/(main)/federal/budget/page.tsx:306
+#: src/app/[lang]/(main)/federal/spending/page.tsx:276
 #: src/app/[lang]/(main)/spending/page.tsx:266
 #: src/components/first-nations/FirstNationsPageContent.tsx:473
 #: src/components/JurisdictionPageContent.tsx:504
 msgid "Sources"
 msgstr "Sources"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:235
+#: src/app/[lang]/(main)/federal/spending/page.tsx:236
 #: src/app/[lang]/(main)/spending/page.tsx:226
 #: src/components/JurisdictionPageContent.tsx:436
 #: src/components/JurisdictionPageContent.tsx:451
@@ -3260,11 +3261,11 @@ msgstr "Speculation does not meet the level of a strong tip."
 msgid "Spending"
 msgstr "Spending"
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:835
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:876
 msgid "Spending Breakdown Coming Soon"
 msgstr "Spending Breakdown Coming Soon"
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:838
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:879
 msgid "Spending data is not yet available for this province and year combination. The income tax calculation above is still accurate based on {year} tax rates."
 msgstr "Spending data is not yet available for this province and year combination. The income tax calculation above is still accurate based on {year} tax rates."
 
@@ -3335,7 +3336,7 @@ msgstr "Subtotal - Remuneration"
 msgid "Summary"
 msgstr "Summary"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:183
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:183
 msgid "Support for Canada's Presence Abroad: $1.23B"
 msgstr "Support for Canada's Presence Abroad: $1.23B"
 
@@ -3376,7 +3377,7 @@ msgstr "Tax"
 msgid "Tax bracket"
 msgstr "Tax bracket"
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:779
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:820
 msgid "Tax calculations are based on {year} federal and provincial tax brackets."
 msgstr "Tax calculations are based on {year} federal and provincial tax brackets."
 
@@ -3386,7 +3387,7 @@ msgid "Tax Comparison Across Provinces at {0} Income"
 msgstr "Tax Comparison Across Provinces at {0} Income"
 
 #. placeholder {0}: config.year
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:575
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:616
 msgid "Tax Details for {provinceName} ({0})"
 msgstr "Tax Details for {provinceName} ({0})"
 
@@ -3412,7 +3413,7 @@ msgstr "Term"
 msgid "Territorial Formula Financing"
 msgstr "Territorial Formula Financing"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:208
+#: src/app/[lang]/(main)/federal/spending/page.tsx:209
 #: src/app/[lang]/(main)/spending/page.tsx:199
 msgid "The average employee is 43.3 years old"
 msgstr "The average employee is 43.3 years old"
@@ -3421,19 +3422,19 @@ msgstr "The average employee is 43.3 years old"
 msgid "The best way to support us is to engage with our content. Like, share, and comment on our posts on social media. Even better, share our work with a friend and encourage them to do the same. Together, we can expand the conversation and reach more people with these important facts."
 msgstr "The best way to support us is to engage with our content. Like, share, and comment on our posts on social media. Even better, share our work with a friend and encourage them to do the same. Together, we can expand the conversation and reach more people with these important facts."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:53
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:53
 msgid "The Canada Revenue Agency (CRA) is the federal institution responsible for administering tax laws, enforcing compliance, and delivering key benefit programs to individuals and businesses across Canada. Established in 1999 under the Canada Revenue Agency Act, the CRA operates with a workforce of approximately 59,155 employees (2024) and oversees tax revenues totaling $379 billion annually—which accounts for over 82% of federal revenues. It also administers over $46 billion in benefits and credits to Canadians, including the Canada Child Benefit and the GST/HST credit."
 msgstr "The Canada Revenue Agency (CRA) is the federal institution responsible for administering tax laws, enforcing compliance, and delivering key benefit programs to individuals and businesses across Canada. Established in 1999 under the Canada Revenue Agency Act, the CRA operates with a workforce of approximately 59,155 employees (2024) and oversees tax revenues totaling $379 billion annually—which accounts for over 82% of federal revenues. It also administers over $46 billion in benefits and credits to Canadians, including the Canada Child Benefit and the GST/HST credit."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:212
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:212
 msgid "The Canada Revenue Agency is overseen by the <0>Minister of National Revenue</0>, who is responsible for ensuring tax fairness and benefit program integrity but does not have direct authority over tax law interpretations."
 msgstr "The Canada Revenue Agency is overseen by the <0>Minister of National Revenue</0>, who is responsible for ensuring tax fairness and benefit program integrity but does not have direct authority over tax law interpretations."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:87
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:87
 msgid "The Canada Revenue Agency spent $16.8 billion in fiscal year (FY) 2024, representing 3.2% of the $513.9 billion in total federal spending. The CRA's expenditures primarily support tax administration, benefit program delivery, compliance enforcement, and IT modernization."
 msgstr "The Canada Revenue Agency spent $16.8 billion in fiscal year (FY) 2024, representing 3.2% of the $513.9 billion in total federal spending. The CRA's expenditures primarily support tax administration, benefit program delivery, compliance enforcement, and IT modernization."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:97
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:97
 msgid "The CRA accounted for 3.2% of all federal spending in FY 2024"
 msgstr "The CRA accounted for 3.2% of all federal spending in FY 2024"
 
@@ -3441,83 +3442,83 @@ msgstr "The CRA accounted for 3.2% of all federal spending in FY 2024"
 msgid "The cumulative surplus accumulated over time from operations."
 msgstr "The cumulative surplus accumulated over time from operations."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:230
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:230
 msgid "The Department is currently led by the <0>Minister of Jobs and Families</0> who is appointed by the Governor General on the advice of the Prime Minister and then formally sworn into office at Rideau Hall. They take the Oath of Office and the Oath of Allegiance and become a member of the King's Privy Council for Canada."
 msgstr "The Department is currently led by the <0>Minister of Jobs and Families</0> who is appointed by the Governor General on the advice of the Prime Minister and then formally sworn into office at Rideau Hall. They take the Oath of Office and the Oath of Allegiance and become a member of the King's Privy Council for Canada."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:202
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:202
 msgid "The Department is led by the <0>Minister of Finance</0>, who is appointed by the Governor General on the advice of the Prime Minister and then formally sworn into office at Rideau Hall. They take the Oath of Office and the Oath of Allegiance and become a member of the King's Privy Council for Canada."
 msgstr "The Department is led by the <0>Minister of Finance</0>, who is appointed by the Governor General on the advice of the Prime Minister and then formally sworn into office at Rideau Hall. They take the Oath of Office and the Oath of Allegiance and become a member of the King's Privy Council for Canada."
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:163
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:163
 msgid "The Department is led by the <0>Minister of Public Safety</0>, who is appointed by the Governor General on the advice of the Prime Minister and then formally sworn into office at Rideau Hall. They take the Oath of Office and the Oath of Allegiance and become a member of the King's Privy Council for Canada."
 msgstr "The Department is led by the <0>Minister of Public Safety</0>, who is appointed by the Governor General on the advice of the Prime Minister and then formally sworn into office at Rideau Hall. They take the Oath of Office and the Oath of Allegiance and become a member of the King's Privy Council for Canada."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:54
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:54
 msgid "The Department of Finance (Finance Canada) is a central federal department responsible for overseeing the nation's economic and fiscal policies, ensuring financial stability, and managing the government's fiscal framework. Established in 1867 as one of the original departments following Confederation, it advises the Prime Minister and Cabinet on economic matters, develops tax and tariff policies, and prepares the annual federal budget."
 msgstr "The Department of Finance (Finance Canada) is a central federal department responsible for overseeing the nation's economic and fiscal policies, ensuring financial stability, and managing the government's fiscal framework. Established in 1867 as one of the original departments following Confederation, it advises the Prime Minister and Cabinet on economic matters, develops tax and tariff policies, and prepares the annual federal budget."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:97
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:97
 msgid "The Department of Finance accounted for 26.4% of all federal spending in FY 2024."
 msgstr "The Department of Finance accounted for 26.4% of all federal spending in FY 2024."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:86
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:86
 msgid "The Department of Finance spent $136.1 billion in fiscal year (FY) 2024. This was 26.4% of the $513.9 billion in overall federal spending. The department ranked first among federal departments in total spending."
 msgstr "The Department of Finance spent $136.1 billion in fiscal year (FY) 2024. This was 26.4% of the $513.9 billion in overall federal spending. The department ranked first among federal departments in total spending."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:132
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:132
 msgid "The Department of Finance's share of federal spending in FY 2024 was lower than FY 1995."
 msgstr "The Department of Finance's share of federal spending in FY 2024 was lower than FY 1995."
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:50
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:50
 msgid "The Department of Immigration, Refugees and Citizenship Canada (IRCC) is the federal department responsible for managing immigration policies, issuing passports, processing visas and permanent residency applications, and supporting newcomers to Canada. It plays a key role in shaping Canada's immigration system, refugee protection policies, and pathways to citizenship."
 msgstr "The Department of Immigration, Refugees and Citizenship Canada (IRCC) is the federal department responsible for managing immigration policies, issuing passports, processing visas and permanent residency applications, and supporting newcomers to Canada. It plays a key role in shaping Canada's immigration system, refugee protection policies, and pathways to citizenship."
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:50
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:50
 msgid "The Department of Innovation, Science and Industry (ISED) is the federal department responsible for fostering economic growth, technological advancement, and scientific research in Canada. It plays a key role in supporting businesses, funding research and development, and shaping policies that aim to enhance innovation, industrial competitiveness, and the prosperity of the Canadian economy."
 msgstr "The Department of Innovation, Science and Industry (ISED) is the federal department responsible for fostering economic growth, technological advancement, and scientific research in Canada. It plays a key role in supporting businesses, funding research and development, and shaping policies that aim to enhance innovation, industrial competitiveness, and the prosperity of the Canadian economy."
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:53
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:53
 msgid "The Department of National Defence (DND) and the Canadian Armed Forces (CAF) are responsible for ensuring Canada's security and defence through military operations, infrastructure management, and personnel support. Established in 1923 under the National Defence Act, DND oversees the defence budget, military procurement, and readiness planning, while the CAF executes domestic and international operations. The department provides strategic defence policy guidance and works with international allies, including NATO and NORAD, to ensure national security. DND also administers military health services, housing programs, and recruitment initiatives to support its personnel."
 msgstr "The Department of National Defence (DND) and the Canadian Armed Forces (CAF) are responsible for ensuring Canada's security and defence through military operations, infrastructure management, and personnel support. Established in 1923 under the National Defence Act, DND oversees the defence budget, military procurement, and readiness planning, while the CAF executes domestic and international operations. The department provides strategic defence policy guidance and works with international allies, including NATO and NORAD, to ensure national security. DND also administers military health services, housing programs, and recruitment initiatives to support its personnel."
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:214
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:214
 msgid "The Department of National Defence is led by the <0>Minister of National Defence</0>, who is appointed by the Governor General on the advice of the Prime Minister. The minister is responsible for overseeing national defense policy, military operations, and procurement."
 msgstr "The Department of National Defence is led by the <0>Minister of National Defence</0>, who is appointed by the Governor General on the advice of the Prime Minister. The minister is responsible for overseeing national defense policy, military operations, and procurement."
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:95
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:95
 msgid "The Department of National Defence spent $34.5 billion in fiscal year (FY) 2024. This represented 6.7% of the $513.9 billion in total federal spending. DND ranked among the top federal departments in expenditures, largely driven by personnel costs, military procurement, and operational readiness efforts."
 msgstr "The Department of National Defence spent $34.5 billion in fiscal year (FY) 2024. This represented 6.7% of the $513.9 billion in total federal spending. DND ranked among the top federal departments in expenditures, largely driven by personnel costs, military procurement, and operational readiness efforts."
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:51
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:51
 msgid "The Department of Transport (Transport Canada) is the federal department responsible for developing and enforcing transportation policies, regulations, and infrastructure projects to ensure safe and efficient movement of people and goods across Canada. It oversees aviation, rail, marine, and road transportation systems, working to enhance national connectivity and economic growth."
 msgstr "The Department of Transport (Transport Canada) is the federal department responsible for developing and enforcing transportation policies, regulations, and infrastructure projects to ensure safe and efficient movement of people and goods across Canada. It oversees aviation, rail, marine, and road transportation systems, working to enhance national connectivity and economic growth."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:51
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:51
 msgid "The Department of Veterans Affairs Canada (VAC) is the federal department responsible for supporting and serving Canadian veterans, active-duty military personnel, and their families. It provides financial assistance, healthcare support, rehabilitation services, and recognition programs to honor the contributions of those who have served in the Canadian Armed Forces. Additionally, the department is responsible for remembrance initiatives that preserve Canada's military history."
 msgstr "The Department of Veterans Affairs Canada (VAC) is the federal department responsible for supporting and serving Canadian veterans, active-duty military personnel, and their families. It provides financial assistance, healthcare support, rehabilitation services, and recognition programs to honor the contributions of those who have served in the Canadian Armed Forces. Additionally, the department is responsible for remembrance initiatives that preserve Canada's military history."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:113
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:113
 msgid "The department's spending grew at a rate significantly higher than overall spending, reflecting shifts in federal priorities. In 2024, ESDC accounted for 18.4% of all federal spending, 16.51 percentage points higher than in 2005."
 msgstr "The department's spending grew at a rate significantly higher than overall spending, reflecting shifts in federal priorities. In 2024, ESDC accounted for 18.4% of all federal spending, 16.51 percentage points higher than in 2005."
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:123
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:123
 msgid "The department's spending grew at a rate significantly lower than overall spending, reflecting shifts in federal priorities. In FY 2024, Health Canada accounted for 2.7% of all federal spending, 3.14 percentage points lower than in 1995."
 msgstr "The department's spending grew at a rate significantly lower than overall spending, reflecting shifts in federal priorities. In FY 2024, Health Canada accounted for 2.7% of all federal spending, 3.14 percentage points lower than in 1995."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:113
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:113
 msgid "The department's spending has grown less than overall spending, which means that the department's share of the federal budget has increased. In FY 2024, VAC accounted for 1.1% of all federal spending, about the same share as in 1995."
 msgstr "The department's spending has grown less than overall spending, which means that the department's share of the federal budget has increased. In FY 2024, VAC accounted for 1.1% of all federal spending, about the same share as in 1995."
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:109
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:109
 msgid "The department's spending has grown more than overall spending, which means that the department's share of the federal budget has increased. In FY 2024, IRCC accounted for 1.2% of all federal spending, 0.8 percentage points higher than in 1995."
 msgstr "The department's spending has grown more than overall spending, which means that the department's share of the federal budget has increased. In FY 2024, IRCC accounted for 1.2% of all federal spending, 0.8 percentage points higher than in 1995."
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:111
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:111
 msgid "The department's spending has grown more than overall spending, which means that the department's share of the federal budget has increased. In FY 2024, ISED accounted for 2% of all federal spending, 0.17 percentage points higher than in 1995."
 msgstr "The department's spending has grown more than overall spending, which means that the department's share of the federal budget has increased. In FY 2024, ISED accounted for 2% of all federal spending, 0.17 percentage points higher than in 1995."
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:112
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:112
 msgid "The department's spending has increased less than overall spending has grown and the department's share of the federal budget has decreased over time. In FY 2024, PSPC accounted for 1.6% of all federal spending, 1 percentage point lower than in 1995."
 msgstr "The department's spending has increased less than overall spending has grown and the department's share of the federal budget has decreased over time. In FY 2024, PSPC accounted for 1.6% of all federal spending, 1 percentage point lower than in 1995."
 
@@ -3529,51 +3530,51 @@ msgstr "The difference between revenue and spending. A surplus indicates revenue
 msgid "The difference between total revenue and total expenses. A surplus indicates revenue exceeded expenses."
 msgstr "The difference between total revenue and total expenses. A surplus indicates revenue exceeded expenses."
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:193
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:193
 msgid "The leadership of ISC and CIRNAC are led by the <0>Minister of Indigenous Services Canada</0> and the <1>Minister of Crown-Indigenous Relations and Northern Affairs Canada</1>, respectively. These Ministers are appointed by the Governor General on the advice of the Prime Minister and then formally sworn into office at Rideau Hall. They take the Oath of Office and the Oath of Allegiance and become a member of the King's Privy Council for Canada."
 msgstr "The leadership of ISC and CIRNAC are led by the <0>Minister of Indigenous Services Canada</0> and the <1>Minister of Crown-Indigenous Relations and Northern Affairs Canada</1>, respectively. These Ministers are appointed by the Governor General on the advice of the Prime Minister and then formally sworn into office at Rideau Hall. They take the Oath of Office and the Oath of Allegiance and become a member of the King's Privy Council for Canada."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:189
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:189
 msgid "The Minister is responsible for overseeing benefits and services for veterans, ensuring their well-being, and leading national remembrance initiatives."
 msgstr "The Minister is responsible for overseeing benefits and services for veterans, ensuring their well-being, and leading national remembrance initiatives."
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:188
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:188
 msgid "The Minister is responsible for overseeing Canada's transportation policies, ensuring safety regulations, investing in infrastructure, and leading climate initiatives related to aviation, rail, marine, and road transportation."
 msgstr "The Minister is responsible for overseeing Canada's transportation policies, ensuring safety regulations, investing in infrastructure, and leading climate initiatives related to aviation, rail, marine, and road transportation."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:214
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:214
 msgid "The Minister of Finance is one of the <0>cabinet members</0> who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister takes office and appoints a new cabinet. Outgoing ministers remain in their roles until their successors are sworn in."
 msgstr "The Minister of Finance is one of the <0>cabinet members</0> who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister takes office and appoints a new cabinet. Outgoing ministers remain in their roles until their successors are sworn in."
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:181
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:181
 msgid "The Minister of Immigration, Refugees and Citizenship is one of the cabinet members who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister appoints a new cabinet. Outgoing ministers continue in their roles until their successors are sworn in."
 msgstr "The Minister of Immigration, Refugees and Citizenship is one of the cabinet members who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister appoints a new cabinet. Outgoing ministers continue in their roles until their successors are sworn in."
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:181
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:181
 msgid "The Minister of Innovation, Science and Industry is one of the cabinet members who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister appoints a new cabinet. Outgoing ministers continue in their roles until their successors are sworn in."
 msgstr "The Minister of Innovation, Science and Industry is one of the cabinet members who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister appoints a new cabinet. Outgoing ministers continue in their roles until their successors are sworn in."
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:188
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:188
 msgid "The Minister of Public Services and Procurement is one of the cabinet members who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister appoints a new cabinet. Outgoing ministers continue in their roles until their successors are sworn in."
 msgstr "The Minister of Public Services and Procurement is one of the cabinet members who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister appoints a new cabinet. Outgoing ministers continue in their roles until their successors are sworn in."
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:179
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:179
 msgid "The Minister of Transport is one of the cabinet members who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister appoints a new cabinet. Outgoing ministers continue in their roles until their successors are sworn in."
 msgstr "The Minister of Transport is one of the cabinet members who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister appoints a new cabinet. Outgoing ministers continue in their roles until their successors are sworn in."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:180
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:180
 msgid "The Minister of Veterans Affairs is one of the cabinet members who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister appoints a new cabinet. Outgoing ministers continue in their roles until their successors are sworn in."
 msgstr "The Minister of Veterans Affairs is one of the cabinet members who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister appoints a new cabinet. Outgoing ministers continue in their roles until their successors are sworn in."
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:254
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:254
 msgid "The ministers work alongside the Deputy Minister of Foreign Affairs and the Deputy Minister of International Trade, who manage the department's operational and policy frameworks."
 msgstr "The ministers work alongside the Deputy Minister of Foreign Affairs and the Deputy Minister of International Trade, who manage the department's operational and policy frameworks."
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:52
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:52
 msgid "The Public Services and Procurement Canada (PSPC) is the federal department responsible for providing centralized procurement, real estate management, pay and pension administration for federal employees, and translation services to the Government of Canada. It ensures that government departments have the goods, services, and infrastructure they need to operate efficiently while maintaining transparency, fairness, and value for taxpayers."
 msgstr "The Public Services and Procurement Canada (PSPC) is the federal department responsible for providing centralized procurement, real estate management, pay and pension administration for federal employees, and translation services to the Government of Canada. It ensures that government departments have the goods, services, and infrastructure they need to operate efficiently while maintaining transparency, fairness, and value for taxpayers."
 
-#: src/app/[lang]/(main)/federal/budget/page.tsx:194
+#: src/app/[lang]/(main)/federal/budget/page.tsx:196
 msgid "The values you see here are based on the FY 2024 Budget with preliminary updates based on government announcements, memos, and leaks, and are meant to provide a rough idea of the budget. Once the official Fall 2025 Budget is released on November 4th, we will update this page to reflect the official budget."
 msgstr "The values you see here are based on the FY 2024 Budget with preliminary updates based on government announcements, memos, and leaks, and are meant to provide a rough idea of the budget. Once the official Fall 2025 Budget is released on November 4th, we will update this page to reflect the official budget."
 
@@ -3581,19 +3582,19 @@ msgstr "The values you see here are based on the FY 2024 Budget with preliminary
 msgid "Theme"
 msgstr "Theme"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:223
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:242
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:261
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:183
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:194
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:211
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:225
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:175
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:223
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:242
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:261
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:183
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:194
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:211
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:225
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:175
 msgid "These Ministers are some of the <0>cabinet members</0> who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister takes office and appoints a new cabinet. Outgoing ministers remain in their roles until their successors are sworn in."
 msgstr "These Ministers are some of the <0>cabinet members</0> who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister takes office and appoints a new cabinet. Outgoing ministers remain in their roles until their successors are sworn in."
 
 #: src/app/[lang]/(main)/budget/page.tsx:159
-#: src/app/[lang]/(main)/federal/budget/page.tsx:187
+#: src/app/[lang]/(main)/federal/budget/page.tsx:189
 msgid "This page presents the official Fall 2025 Federal Budget as released by the Government of Canada on November 4th, 2025. All data is sourced directly from official government publications and public accounts from the Government of Canada."
 msgstr "This page presents the official Fall 2025 Federal Budget as released by the Government of Canada on November 4th, 2025. All data is sourced directly from official government publications and public accounts from the Government of Canada."
 
@@ -3605,11 +3606,11 @@ msgstr "This schedule has been audited."
 msgid "This schedule is unaudited."
 msgstr "This schedule is unaudited."
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:775
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:816
 msgid "This visualization shows how your income tax contributions are allocated across different government programs and services based on current government spending patterns. Amounts under $20 are grouped into \"Other\" for conciseness."
 msgstr "This visualization shows how your income tax contributions are allocated across different government programs and services based on current government spending patterns. Amounts under $20 are grouped into \"Other\" for conciseness."
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:62
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:62
 msgid "Through the Public Health Agency of Canada (PHAC), Health Canada monitors public health risks, manages disease outbreaks, and promotes health initiatives. It also funds medical research via the Canadian Institutes of Health Research (CIHR) and oversees healthcare services for Indigenous communities."
 msgstr "Through the Public Health Agency of Canada (PHAC), Health Canada monitors public health risks, manages disease outbreaks, and promotes health initiatives. It also funds medical research via the Canadian Institutes of Health Research (CIHR) and oversees healthcare services for Indigenous communities."
 
@@ -3622,8 +3623,8 @@ msgid "Tools"
 msgstr "Tools"
 
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:261
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:398
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:509
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:404
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:522
 #: src/components/first-nations/ClaimsTable.tsx:300
 #: src/components/first-nations/RemunerationOverview.tsx:800
 #: src/components/first-nations/RemunerationTable.tsx:139
@@ -3632,7 +3633,7 @@ msgstr "Tools"
 msgid "Total"
 msgstr "Total"
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:542
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:583
 msgid "Total {provinceName} Tax"
 msgstr "Total {provinceName} Tax"
 
@@ -3645,7 +3646,7 @@ msgid "Total assets minus total liabilities. This represents the First Nation's 
 msgstr "Total assets minus total liabilities. This represents the First Nation's overall financial position."
 
 #: src/app/[lang]/(main)/budget/page.tsx:175
-#: src/app/[lang]/(main)/federal/budget/page.tsx:212
+#: src/app/[lang]/(main)/federal/budget/page.tsx:214
 msgid "Total Budget"
 msgstr "Total Budget"
 
@@ -3665,7 +3666,7 @@ msgstr "Total Expenses"
 msgid "Total expenses in FY {fiscalYear}"
 msgstr "Total expenses in FY {fiscalYear}"
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:413
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:419
 msgid "Total Federal Tax"
 msgstr "Total Federal Tax"
 
@@ -3673,7 +3674,7 @@ msgstr "Total Federal Tax"
 msgid "Total Financial Assets"
 msgstr "Total Financial Assets"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:171
+#: src/app/[lang]/(main)/federal/spending/page.tsx:172
 #: src/app/[lang]/(main)/spending/page.tsx:162
 msgid "Total full-time equivalents"
 msgstr "Total full-time equivalents"
@@ -3736,7 +3737,7 @@ msgstr "Total spending in {0}"
 msgid "Total Tax"
 msgstr "Total Tax"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:183
+#: src/app/[lang]/(main)/federal/spending/page.tsx:184
 #: src/app/[lang]/(main)/spending/page.tsx:174
 msgid "Total Wages"
 msgstr "Total Wages"
@@ -3745,23 +3746,23 @@ msgstr "Total Wages"
 msgid "Trade and Investment"
 msgstr "Trade and Investment"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:174
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:174
 msgid "Trade and Investment: $380.3M"
 msgstr "Trade and Investment: $380.3M"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:55
 msgid "Transfer Payments"
 msgstr "Transfer Payments"
 
@@ -3770,24 +3771,24 @@ msgstr "Transfer Payments"
 msgid "Transfers to Provinces"
 msgstr "Transfers to Provinces"
 
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:86
 msgid "Transport Canada"
 msgstr "Transport Canada"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:33
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:33
 msgid "Transport Canada | Canada Spends"
 msgstr "Transport Canada | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:91
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:91
 msgid "Transport Canada accounted for 1% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 msgstr "Transport Canada accounted for 1% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:169
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:169
 msgid "Transport Canada is led by the Minister of Transport, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 msgstr "Transport Canada is led by the Minister of Transport, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:82
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:82
 msgid "Transport Canada spent $5.1 billion in fiscal year (FY) 2024. This was 1% of the $513.9 billion in overall federal spending. The department ranked fourteenth among federal departments in total spending."
 msgstr "Transport Canada spent $5.1 billion in fiscal year (FY) 2024. This was 1% of the $513.9 billion in overall federal spending. The department ranked fourteenth among federal departments in total spending."
 
@@ -3795,27 +3796,27 @@ msgstr "Transport Canada spent $5.1 billion in fiscal year (FY) 2024. This was 1
 msgid "Transportation"
 msgstr "Transportation"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:23
 msgid "Transportation + Communication"
 msgstr "Transportation + Communication"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:23
 msgid "Transportation and Communication"
 msgstr "Transportation and Communication"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:241
-#: src/app/[lang]/(main)/federal/spending/page.tsx:262
+#: src/app/[lang]/(main)/federal/spending/page.tsx:242
+#: src/app/[lang]/(main)/federal/spending/page.tsx:263
 #: src/app/[lang]/(main)/spending/page.tsx:232
 #: src/app/[lang]/(main)/spending/page.tsx:253
 #: src/components/Sankey/index.tsx:346
@@ -3826,12 +3827,12 @@ msgstr "Treasury Board"
 msgid "Tribunal Award"
 msgstr "Tribunal Award"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:191
+#: src/app/[lang]/(main)/federal/spending/page.tsx:192
 #: src/app/[lang]/(main)/spending/page.tsx:182
 msgid "Type of Tenure"
 msgstr "Type of Tenure"
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:772
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:813
 msgid "Understanding Your Tax Contribution"
 msgstr "Understanding Your Tax Contribution"
 
@@ -3839,44 +3840,44 @@ msgstr "Understanding Your Tax Contribution"
 msgid "Use a computer you trust, not one provided by your employer."
 msgstr "Use a computer you trust, not one provided by your employer."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:43
 msgid "Utilities, Materials and Supplies"
 msgstr "Utilities, Materials and Supplies"
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:92
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:92
 msgid "VAC accounted for 1.2% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 msgstr "VAC accounted for 1.2% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:84
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:84
 msgid "VAC spent $6.1 billion in fiscal year (FY) 2024. This was 1.2% of the $513.9 billion in overall federal spending. The department ranked thirteenth among federal departments in total spending."
 msgstr "VAC spent $6.1 billion in fiscal year (FY) 2024. This was 1.2% of the $513.9 billion in overall federal spending. The department ranked thirteenth among federal departments in total spending."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:131
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:131
 msgid "VAC's expenditures also grew slightly during this period, increasing from approximately $5.5B​ in 2019 when adjusted for inflation to $6.3B in 2024."
 msgstr "VAC's expenditures also grew slightly during this period, increasing from approximately $5.5B​ in 2019 when adjusted for inflation to $6.3B in 2024."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:80
 msgid "Veterans Affairs"
 msgstr "Veterans Affairs"
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:170
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:170
 msgid "Veterans Affairs Canada (VAC) is led by the Minister of Veterans Affairs, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 msgstr "Veterans Affairs Canada (VAC) is led by the Minister of Veterans Affairs, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:33
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:33
 msgid "Veterans Affairs Canada | Canada Spends"
 msgstr "Veterans Affairs Canada | Canada Spends"
 
@@ -3885,12 +3886,12 @@ msgstr "Veterans Affairs Canada | Canada Spends"
 msgid "View {year} financial statements for {0}{provinceSuffix}. Includes statement of operations, financial position, and remuneration data from the First Nations Financial Transparency Act annual report."
 msgstr "View {year} financial statements for {0}{provinceSuffix}. Includes statement of operations, financial position, and remuneration data from the First Nations Financial Transparency Act annual report."
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:744
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:785
 #: src/components/TaxBreakdownAccordion.tsx:100
 msgid "View detailed tax breakdown"
 msgstr "View detailed tax breakdown"
 
-#: src/app/[lang]/(main)/federal/budget/page.tsx:174
+#: src/app/[lang]/(main)/federal/budget/page.tsx:176
 msgid "View Federal 2025 Budget Details"
 msgstr "View Federal 2025 Budget Details"
 
@@ -3908,8 +3909,8 @@ msgid "View source data"
 msgstr "View source data"
 
 #: src/app/[lang]/(main)/budget/page.tsx:242
-#: src/app/[lang]/(main)/federal/budget/page.tsx:279
-#: src/app/[lang]/(main)/federal/spending/page.tsx:158
+#: src/app/[lang]/(main)/federal/budget/page.tsx:281
+#: src/app/[lang]/(main)/federal/spending/page.tsx:159
 #: src/app/[lang]/(main)/spending/page.tsx:149
 #: src/components/JurisdictionPageContent.tsx:393
 msgid "View this chart in full screen"
@@ -3934,59 +3935,59 @@ msgstr "Want even more anonymity?"
 msgid "was spent by {0}"
 msgstr "was spent by {0}"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:76
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:76
 msgid "was spent by ESDC"
 msgstr "was spent by ESDC"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:74
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:74
 msgid "was spent by Finance Canada"
 msgstr "was spent by Finance Canada"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:80
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:80
 msgid "was spent by Health Canada"
 msgstr "was spent by Health Canada"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:82
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:82
 msgid "was spent by Housing, Infrastructure and Communities Canada"
 msgstr "was spent by Housing, Infrastructure and Communities Canada"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:87
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:87
 msgid "was spent by ISC and CIRNAC"
 msgstr "was spent by ISC and CIRNAC"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:72
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:72
 msgid "Was spent by Public Services and Procurement Canada"
 msgstr "Was spent by Public Services and Procurement Canada"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:75
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:75
 msgid "was spent by the Canada Revenue Agency"
 msgstr "was spent by the Canada Revenue Agency"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:78
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:78
 msgid "was spent by the Department of National Defence"
 msgstr "was spent by the Department of National Defence"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:69
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:69
 msgid "Was spent by the Dept. of Immigration, Refugees and Citizenship"
 msgstr "Was spent by the Dept. of Immigration, Refugees and Citizenship"
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:70
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:70
 msgid "Was spent by the Dept. of Innovation, Science and Industry"
 msgstr "Was spent by the Dept. of Innovation, Science and Industry"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:70
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:70
 msgid "Was spent by the Dept. of Transport"
 msgstr "Was spent by the Dept. of Transport"
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:72
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:72
 msgid "Was spent by the Dept. of Veterans Affairs"
 msgstr "Was spent by the Dept. of Veterans Affairs"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:82
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:82
 msgid "was spent by the Global Affairs Canada"
 msgstr "was spent by the Global Affairs Canada"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:74
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:74
 msgid "was spent by the Public Safety Canada"
 msgstr "was spent by the Public Safety Canada"
 
@@ -4058,7 +4059,7 @@ msgstr "What is your methodology?"
 msgid "What Makes a Good Tip?"
 msgstr "What Makes a Good Tip?"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:123
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:123
 msgid "When HICC was founded in FY 2005 as the Office of Infrastructure Canada, the department's spending has grown from $250,000 to over $14 billion, a significant increase in overall spending and mandate. In FY 2024, HICC accounted for 2.8% of all federal spending."
 msgstr "When HICC was founded in FY 2005 as the Office of Infrastructure Canada, the department's spending has grown from $250,000 to over $14 billion, a significant increase in overall spending and mandate. In FY 2024, HICC accounted for 2.8% of all federal spending."
 
@@ -4066,16 +4067,16 @@ msgstr "When HICC was founded in FY 2005 as the Office of Infrastructure Canada,
 msgid "Where do you get the data on your website?"
 msgstr "Where do you get the data on your website?"
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:712
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:766
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:753
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:807
 msgid "Where Your Tax Dollars Go"
 msgstr "Where Your Tax Dollars Go"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:140
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:140
 msgid "While GAC's spending has increased in real terms, its share of the federal budget has also increased moderately over the past decades. In 2024, GAC accounted for 3.7% of federal spending, compared to 2% in 1995."
 msgstr "While GAC's spending has increased in real terms, its share of the federal budget has also increased moderately over the past decades. In 2024, GAC accounted for 3.7% of federal spending, compared to 2% in 1995."
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:90
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:90
 msgid "While not in the top 10 departments by spend, ISED accounted for 2% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 msgstr "While not in the top 10 departments by spend, ISED accounted for 2% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 
@@ -4090,59 +4091,59 @@ msgstr "Whistleblowers"
 msgid "Whistleblowers | Secure Anonymous Tips | Canada Spends"
 msgstr "Whistleblowers | Secure Anonymous Tips | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:227
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:227
 msgid "Who leads ESDC?"
 msgstr "Who leads ESDC?"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:224
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:224
 msgid "Who leads Global Affairs Canada?"
 msgstr "Who leads Global Affairs Canada?"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:167
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:167
 msgid "Who leads Health Canada?"
 msgstr "Who leads Health Canada?"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:175
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:175
 msgid "Who leads Housing, Infrastructure and Communities Canada?"
 msgstr "Who leads Housing, Infrastructure and Communities Canada?"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:165
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:165
 msgid "Who Leads Immigration, Refugees and Citizenship Canada (IRCC)?"
 msgstr "Who Leads Immigration, Refugees and Citizenship Canada (IRCC)?"
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:166
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:166
 msgid "Who Leads Innovation, Science and Industry Canada (ISED)?"
 msgstr "Who Leads Innovation, Science and Industry Canada (ISED)?"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:190
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:190
 msgid "Who leads ISC and CIRNAC?"
 msgstr "Who leads ISC and CIRNAC?"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:160
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:160
 msgid "Who leads Public Safety Canada?"
 msgstr "Who leads Public Safety Canada?"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:172
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:172
 msgid "Who Leads Public Services and Procurement Canada (PSPC)?"
 msgstr "Who Leads Public Services and Procurement Canada (PSPC)?"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:209
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:209
 msgid "Who leads the Canada Revenue Agency?"
 msgstr "Who leads the Canada Revenue Agency?"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:199
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:199
 msgid "Who leads the Department of Finance?"
 msgstr "Who leads the Department of Finance?"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:211
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:211
 msgid "Who leads the Department of National Defence?"
 msgstr "Who leads the Department of National Defence?"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:166
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:166
 msgid "Who Leads Transport Canada?"
 msgstr "Who Leads Transport Canada?"
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:167
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:167
 msgid "Who Leads Veterans Affairs Canada (VAC)?"
 msgstr "Who Leads Veterans Affairs Canada (VAC)?"
 
@@ -4167,7 +4168,7 @@ msgstr "You can access our whistleblower platform directly through your web brow
 msgid "You deserve the facts"
 msgstr "You deserve the facts"
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:778
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:819
 msgid "Your tax contributions are approximated based on employment income. Deductions such as basic personal amount are estimated and included. Other sources of income, such as self-employment, investment income, and capital gains, are not included in the calculations. Deductions such as RRSP and FHSA contributions are also not included."
 msgstr "Your tax contributions are approximated based on employment income. Deductions such as basic personal amount are estimated and included. Other sources of income, such as self-employment, investment income, and capital gains, are not included in the calculations. Deductions such as RRSP and FHSA contributions are also not included."
 

--- a/src/locales/fr.po
+++ b/src/locales/fr.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:149
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:149
 msgid " How did Health Canada spend its budget in FY24?"
 msgstr "Comment Santé Canada a-t-il dépensé son budget au cours de l'exercice 2024?"
 
@@ -72,7 +72,7 @@ msgid "{0} is a First Nation{1}."
 msgstr "{0} est une Première Nation{1}."
 
 #. placeholder {0}: formatPercent(federalAbatementConfig.rate)
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:333
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:339
 msgid "{0} of federal income tax"
 msgstr "{0} de l'impôt fédéral sur le revenu"
 
@@ -108,7 +108,7 @@ msgstr "{0}{provinceSuffix} - Aucune donnée financière n'est actuellement disp
 msgid "{paragraph}"
 msgstr "{paragraph}"
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:458
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:471
 #: src/components/TaxBreakdownAccordion.tsx:112
 msgid "{provinceName} Taxes"
 msgstr "Impôts de {provinceName}"
@@ -121,22 +121,22 @@ msgstr "Total de {provinceName}"
 msgid "© 2025 Canada Spends. All rights reserved. A Project of <0>Build Canada</0>."
 msgstr "© 2025 Canada Spends. Tous droits réservés. Un projet de <0>Build Canada</0>."
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:235
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:235
 msgid "<0>Minister of Foreign Affairs</0>: Responsible for diplomacy, international security, international development assistance, and global partnerships."
 msgstr "<0>Ministre des Affaires étrangères</0> : Responsable de la diplomatie, de la sécurité internationale, de l'aide au développement international et des partenariats mondiaux."
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:244
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:244
 msgid "<0>Minister of International Trade</0>: Oversees Canada's trade negotiations, export promotion, and economic policy engagement."
 msgstr "<0>Ministre du Commerce international</0> : Supervise les négociations commerciales du Canada, la promotion des exportations et l'engagement en matière de politique économique."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:103
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:103
 msgid "10 government departments accounted for 73.2% of federal spending in FY 2024"
 msgstr "10 ministères gouvernementaux représentaient 73,2 % des dépenses fédérales pour l'exercice 2024"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:103
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:109
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:115
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:97
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:103
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:109
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:115
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:97
 msgid "10 government departments accounted for 73.2% of federal spending in FY 2024."
 msgstr "10 ministères gouvernementaux représentaient 73,2 % des dépenses fédérales pour l'exercice 2024."
 
@@ -144,68 +144,68 @@ msgstr "10 ministères gouvernementaux représentaient 73,2 % des dépenses féd
 msgid "100,000"
 msgstr "100 000"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:194
+#: src/app/[lang]/(main)/federal/spending/page.tsx:195
 #: src/app/[lang]/(main)/spending/page.tsx:185
 msgid "80% of employees are in permanent roles"
 msgstr "80 % des employés occupent des postes permanents"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:37
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:37
 msgid "A look at how Employment and Social Development Canada spends its budget"
 msgstr "Un aperçu de la façon dont Emploi et Développement social Canada dépense son budget"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:34
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:34
 msgid "A look at how Health Canada spends its budget"
 msgstr "Un aperçu de la façon dont Santé Canada dépense son budget"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:35
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:35
 msgid "A look at how Housing, Infrastructure and Communities Canada spends its budget"
 msgstr "Un aperçu de la façon dont Logement, Infrastructure et Collectivités Canada dépense son budget"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:33
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:33
 msgid "A look at how Immigration, Refugees and Citizenship Canada spends its budget"
 msgstr "Un aperçu de la façon dont Immigration, Réfugiés et Citoyenneté Canada dépense son budget"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:36
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:36
 msgid "A look at how Indigenous Services and Northern Affairs Canada spends its budget"
 msgstr "Un aperçu de la façon dont Services aux Autochtones et Affaires du Nord Canada dépense son budget"
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:33
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:33
 msgid "A look at how Innovation, Science and Industry Canada spends its budget"
 msgstr "Un aperçu de la façon dont Innovation, Sciences et Industrie Canada dépense son budget"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:36
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:36
 msgid "A look at how National Defence spends its budget"
 msgstr "Un aperçu de la façon dont la Défense nationale dépense son budget"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:35
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:35
 msgid "A look at how Public Safety Canada spends its budget"
 msgstr "Un aperçu de la façon dont Sécurité publique Canada dépense son budget"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:33
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:33
 msgid "A look at how Public Services and Procurement Canada spends its budget"
 msgstr "Un aperçu de la façon dont Services publics et Approvisionnement Canada dépense son budget"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:35
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:35
 msgid "A look at how the Canada Revenue Agency spends its budget"
 msgstr "Un aperçu de la façon dont l'Agence du revenu du Canada dépense son budget"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:36
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:36
 msgid "A look at how the Department of Finance spends its budget"
 msgstr "Un aperçu de la façon dont le ministère des Finances dépense son budget"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:37
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:37
 msgid "A look at how the Global Affairs Canada spends its budget"
 msgstr "Un aperçu de la façon dont Affaires mondiales Canada dépense son budget"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:34
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:34
 msgid "A look at how Transport Canada spends its budget"
 msgstr "Un aperçu de la façon dont Transports Canada dépense son budget"
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:34
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:34
 msgid "A look at how Veterans Affairs Canada spends its budget"
 msgstr "Un aperçu de la façon dont Anciens Combattants Canada dépense son budget"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:187
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:187
 msgid "A significant portion of GAC's budget supports Canada's international development assistance, with key programs focused on climate adaptation, gender equality, and health initiatives in developing nations. The department also facilitates economic diplomacy and trade agreements that benefit Canadian businesses and secure investment opportunities abroad."
 msgstr "Une partie importante du budget d'AMC soutient l'aide au développement international du Canada, avec des programmes clés axés sur l'adaptation au climat, l'égalité des genres et les initiatives de santé dans les pays en développement. Le ministère facilite également la diplomatie économique et les accords commerciaux qui profitent aux entreprises canadiennes et sécurisent les opportunités d'investissement à l'étranger."
 
@@ -224,7 +224,7 @@ msgid "About Us"
 msgstr "À propos de nous"
 
 #. placeholder {0}: formatAmount(tier.threshold)
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:496
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:509
 msgid "Above {0}"
 msgstr "Au-dessus de {0}"
 
@@ -236,36 +236,36 @@ msgstr "Comptes créditeurs, dette à long terme et autres obligations envers de
 msgid "Accumulated Surplus"
 msgstr "Excédent accumulé"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:47
 msgid "Acquisition of Land, Buildings and Works"
 msgstr "Acquisition de terrains, de bâtiments et de travaux"
 
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:47
 msgid "Acquisition of Lands, Buildings and Works"
 msgstr "Acquisition de terrains, de bâtiments et de travaux"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:47
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:47
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:51
 msgid "Acquisition of Machinery and Equipment"
 msgstr "Acquisition de machines et d'équipement"
 
@@ -277,7 +277,7 @@ msgstr "Ajuster pour l'inflation (dollars de 2025)"
 msgid "Adjust sliders to see how department spending reductions affect the overall Fall 2025 Budget. The Minister of Finance has asked departments to reduce spending by 7.5% in 2026-27, 10% in 2027-28, and 15% in 2028-29."
 msgstr "Ajustez les curseurs pour voir comment les réductions des dépenses ministérielles affectent le budget global de l'automne 2025. Le ministre des Finances a demandé aux ministères de réduire les dépenses de 7,5 % en 2026-27, de 10 % en 2027-28 et de 15 % en 2028-29."
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:205
+#: src/app/[lang]/(main)/federal/spending/page.tsx:206
 #: src/app/[lang]/(main)/spending/page.tsx:196
 msgid "Age"
 msgstr "Âge"
@@ -319,11 +319,11 @@ msgid "All expenses incurred during the fiscal year including program delivery, 
 msgstr "Toutes les dépenses engagées au cours de l'exercice financier, y compris la prestation de programmes, l'administration et les coûts d'immobilisations."
 
 #: src/app/[lang]/(main)/budget/page.tsx:270
-#: src/app/[lang]/(main)/federal/budget/page.tsx:307
+#: src/app/[lang]/(main)/federal/budget/page.tsx:309
 msgid "All government budget data is sourced from official databases, but due to the complexity of these systems, occasional errors may occur despite our best efforts. This page is also based on government memos and leaks, so it is not an official release of the Fall 2025 Budget. We aim to make this information more accessible and accurate, and we welcome feedback. If you notice any issues, please let us know <0>here</0> — we appreciate it and will work to address them promptly."
 msgstr "Toutes les données budgétaires gouvernementales proviennent de bases de données officielles, mais en raison de la complexité de ces systèmes, des erreurs occasionnelles peuvent survenir malgré nos meilleurs efforts. Cette page est également basée sur des notes et des fuites gouvernementales, ce n'est donc pas une publication officielle du budget de l'automne 2025. Nous visons à rendre cette information plus accessible et précise, et nous accueillons vos commentaires. Si vous remarquez des problèmes, veuillez nous en informer <0>ici</0> — nous l'apprécions et nous travaillerons à les résoudre rapidement."
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:278
+#: src/app/[lang]/(main)/federal/spending/page.tsx:279
 #: src/app/[lang]/(main)/spending/page.tsx:269
 #: src/components/JurisdictionPageContent.tsx:507
 msgid "All government spending data is sourced from official databases, but due to the complexity of these systems, occasional errors may occur despite our best efforts. We aim to make this information more accessible and accurate, and we welcome feedback. If you notice any issues, please let us know <0>here</0> — we appreciate it and will work to address them promptly."
@@ -349,12 +349,12 @@ msgstr "Tous les revenus perçus au cours de l'exercice financier, y compris les
 msgid "All the information comes from public databases and reports by the Government of Canada. We show our sources, so you know exactly where it comes from."
 msgstr "Toutes les informations proviennent des bases de données publiques et des rapports du gouvernement du Canada. Nous indiquons nos sources pour que vous sachiez exactement d'où elles proviennent."
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:580
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:621
 msgid "All the taxes that apply to your income"
 msgstr "Tous les impôts qui s'appliquent à votre revenu"
 
 #: src/app/[lang]/(main)/budget/page.tsx:62
-#: src/app/[lang]/(main)/federal/budget/page.tsx:62
+#: src/app/[lang]/(main)/federal/budget/page.tsx:63
 msgid "Amount/Change"
 msgstr "Montant/Changement"
 
@@ -376,7 +376,7 @@ msgstr "Paiements d'intérêts annuels sur la dette en cours. Cela représente l
 msgid "Annual municipal spending per {0} resident"
 msgstr "Dépenses municipales annuelles par résident de {0}"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:185
+#: src/app/[lang]/(main)/federal/spending/page.tsx:186
 #: src/app/[lang]/(main)/spending/page.tsx:176
 msgid "Annual payroll"
 msgstr "Masse salariale annuelle"
@@ -386,7 +386,7 @@ msgid "Application ID"
 msgstr "ID de la demande"
 
 #. placeholder {0}: formatAmount(provincialTax)
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:475
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:488
 msgid "Applied to provincial tax of {0}"
 msgstr "Appliqué à l'impôt provincial de {0}"
 
@@ -423,7 +423,7 @@ msgstr "À la fin de l'exercice financier {fiscalYear}"
 msgid "Assets, liabilities, and net financial position as of the end of fiscal year {fiscalYear}."
 msgstr "Actifs, passifs et situation financière nette à la fin de l'exercice financier {fiscalYear}."
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:178
+#: src/app/[lang]/(main)/federal/spending/page.tsx:179
 #: src/app/[lang]/(main)/spending/page.tsx:169
 msgid "Average annual compensation"
 msgstr "Rémunération annuelle moyenne"
@@ -454,7 +454,7 @@ msgid "Based on Data"
 msgstr "Basé sur les données"
 
 #. placeholder {0}: formatAmount(income)
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:528
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:541
 msgid "Based on income of {0}"
 msgstr "Basé sur un revenu de {0}"
 
@@ -490,12 +490,12 @@ msgid "Budget"
 msgstr "Budget"
 
 #: src/app/[lang]/(main)/budget/page.tsx:59
-#: src/app/[lang]/(main)/federal/budget/page.tsx:59
+#: src/app/[lang]/(main)/federal/budget/page.tsx:60
 msgid "Budget Impact"
 msgstr "Impact budgétaire"
 
 #: src/app/[lang]/(main)/budget/page.tsx:169
-#: src/app/[lang]/(main)/federal/budget/page.tsx:206
+#: src/app/[lang]/(main)/federal/budget/page.tsx:208
 msgid "Budget Statistics (Projected FY 2025)"
 msgstr "Statistiques budgétaires (exercice 2025 projeté)"
 
@@ -519,20 +519,20 @@ msgstr "Fonds pour la construction communautaire du Canada"
 msgid "Canada Emergency Wage Subsidy"
 msgstr "Subvention salariale d'urgence du Canada"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/MiniSankey.tsx:19
 msgid "Canada health transfer"
 msgstr "Transfert canadien en matière de santé"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:38
 msgid "Canada Revenue Agency"
 msgstr "Agence du revenu du Canada"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:34
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:34
 msgid "Canada Revenue Agency | Canada Spends"
 msgstr "Agence du revenu du Canada | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/MiniSankey.tsx:23
 msgid "Canada social transfer"
 msgstr "Transfert canadien en matière de programmes sociaux"
 
@@ -569,7 +569,7 @@ msgstr "Canada Spends offre un moyen sécurisé aux sources de soumettre des inf
 msgid "Canada Spends, as a project of Build Canada, is funded through donations from our builder network. Donate"
 msgstr "Canada Spends, en tant que projet de Build Canada, est financé par des dons de notre réseau de constructeurs. Faire un don"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:211
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:211
 msgid "Canada Student Loans Program: providing financial aid for post-secondary students."
 msgstr "Programme canadien de prêts aux étudiants : fournir une aide financière aux étudiants de niveau postsecondaire."
 
@@ -582,7 +582,7 @@ msgid "Canada, you need the facts."
 msgstr "Canada, vous avez besoin des faits."
 
 #: src/app/[lang]/(main)/budget/page.tsx:204
-#: src/app/[lang]/(main)/federal/budget/page.tsx:241
+#: src/app/[lang]/(main)/federal/budget/page.tsx:243
 msgid "Capital Investments"
 msgstr "Investissements en capital"
 
@@ -674,7 +674,7 @@ msgstr "Comparez votre fardeau fiscal total dans toutes les provinces et territo
 msgid "Compensation"
 msgstr "Rémunération"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:176
+#: src/app/[lang]/(main)/federal/spending/page.tsx:177
 #: src/app/[lang]/(main)/spending/page.tsx:167
 msgid "Compensation per Employee"
 msgstr "Rémunération par employé"
@@ -733,19 +733,19 @@ msgstr "Pays"
 msgid "COVID-19 Income Support"
 msgstr "Soutien au revenu COVID-19"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:187
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:187
 msgid "CRA spending is divided across tax administration, compliance enforcement, benefit program delivery, and intergovernmental agreements with provinces and territories. The largest expenditures in FY 2024 included personal income tax processing, corporate tax audits, and benefit administration."
 msgstr "Les dépenses de l'ARC sont réparties entre l'administration fiscale, l'application de la conformité, la prestation de programmes de prestations et les accords intergouvernementaux avec les provinces et les territoires. Les plus importantes dépenses au cours de l'exercice 2024 comprenaient le traitement de l'impôt sur le revenu des particuliers, les vérifications de l'impôt des sociétés et l'administration des prestations."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:197
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:197
 msgid "CRA spending isolated to FY 2024"
 msgstr "Dépenses de l'ARC isolées pour l'exercice 2024"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:141
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:141
 msgid "CRA's share of federal spending in FY 2024 was higher than in FY 1995"
 msgstr "La part des dépenses fédérales de l'ARC en 2024 était plus élevée qu'en 1995"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:121
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:121
 msgid "CRA's spending grew more than overall spending, meaning its share of the federal budget increased. In 2024, the agency accounted for 3.2% of all federal spending, 1.85 percentage points higher than in 1995."
 msgstr "Les dépenses de l'ARC ont augmenté plus que les dépenses globales, ce qui signifie que sa part du budget fédéral a augmenté. En 2024, l'agence représentait 3,2 % de toutes les dépenses fédérales, soit 1,85 point de pourcentage de plus qu'en 1995."
 
@@ -770,23 +770,23 @@ msgstr "Droits de douane"
 msgid "Customs Import Duties"
 msgstr "Droits de douane à l'importation"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:68
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:68
 msgid "Data updated March 20, 2025"
 msgstr "Données mises à jour le 20 mars 2025"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:69
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:70
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:76
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:74
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:76
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:63
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:81
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:64
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:71
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:68
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:66
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:64
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:66
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:69
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:70
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:76
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:74
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:76
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:63
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:81
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:64
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:71
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:68
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:66
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:64
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:66
 msgid "Data updated March 21, 2025"
 msgstr "Données mises à jour le 21 mars 2025"
 
@@ -807,7 +807,7 @@ msgid "Defence Team"
 msgstr "Équipe de la défense"
 
 #: src/app/[lang]/(main)/budget/page.tsx:215
-#: src/app/[lang]/(main)/federal/budget/page.tsx:252
+#: src/app/[lang]/(main)/federal/budget/page.tsx:254
 msgid "Deficit"
 msgstr "Déficit"
 
@@ -816,19 +816,19 @@ msgstr "Déficit"
 msgid "Department"
 msgstr "Ministère"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/MiniSankey.tsx:16
 msgid "Department of Finance"
 msgstr "Ministère des Finances"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:35
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:35
 msgid "Department of Finance | Canada Spends"
 msgstr "Ministère des Finances | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:188
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:188
 msgid "Department of Finance, Spending by Entity, FY 2024 (in millions)"
 msgstr "Ministère des Finances, Dépenses par entité, exercice 2024 (en millions)"
 
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:16
 msgid "Department of National Defence"
 msgstr "Ministère de la Défense nationale"
 
@@ -841,12 +841,12 @@ msgstr "Dépenses du ministère"
 msgid "Department Spending Reductions"
 msgstr "Réductions des dépenses ministérielles"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:230
+#: src/app/[lang]/(main)/federal/spending/page.tsx:231
 #: src/app/[lang]/(main)/spending/page.tsx:221
 msgid "Departments + Agencies"
 msgstr "Ministères + Organismes"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:125
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:125
 msgid "Despite these increases, significant challenges remain in areas such as housing, healthcare access, and infrastructure in remote Indigenous communities."
 msgstr "Malgré ces augmentations, des défis importants subsistent dans des domaines tels que le logement, l'accès aux soins de santé et l'infrastructure dans les communautés autochtones éloignées."
 
@@ -854,7 +854,7 @@ msgstr "Malgré ces augmentations, des défis importants subsistent dans des dom
 msgid "Development, Peace + Security Programming"
 msgstr "Programmation du développement, de la paix + de la sécurité"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:177
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:177
 msgid "Development, Peace and Security Programming: $5.37B"
 msgstr "Programmation du développement, de la paix et de la sécurité : 5,37 G$"
 
@@ -862,7 +862,7 @@ msgstr "Programmation du développement, de la paix et de la sécurité : 5,37 G
 msgid "Direct program expenses"
 msgstr "Dépenses directes des programmes"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:160
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:160
 msgid "Direct spending refers to money allocated to government programs, employee salaries, and administrative expenses. Indirect spending includes federal transfers to individuals and provinces."
 msgstr "Les dépenses directes font référence à l'argent alloué aux programmes gouvernementaux, aux salaires des employés et aux dépenses administratives. Les dépenses indirectes comprennent les transferts fédéraux aux particuliers et aux provinces."
 
@@ -874,7 +874,7 @@ msgstr "Secours aux sinistrés"
 msgid "Discipline"
 msgstr "Discipline"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:134
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:134
 msgid "DND's spending grew less than overall spending, meaning its share of the federal budget decreased. In 2024, the department accounted for 6.7% of all federal spending, 0.6 percentage points lower than in 1995."
 msgstr "Les dépenses du MDN ont augmenté moins que les dépenses globales, ce qui signifie que sa part du budget fédéral a diminué. En 2024, le ministère représentait 6,7 % de toutes les dépenses fédérales, soit 0,6 point de pourcentage de moins qu'en 1995."
 
@@ -942,7 +942,7 @@ msgstr "Emploi + Formation"
 msgid "Employment and Social Development Canada"
 msgstr "Emploi et Développement social Canada"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:36
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:36
 msgid "Employment and Social Development Canada | Canada Spends"
 msgstr "Emploi et Développement social Canada | Canada Spends"
 
@@ -964,7 +964,7 @@ msgstr "Date de fin"
 msgid "Energy Taxes"
 msgstr "Taxes sur l'énergie"
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:714
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:755
 msgid "Enter your income to see a personalized breakdown of how much you contribute to different government services and programs."
 msgstr "Entrez votre revenu pour voir une répartition personnalisée de votre contribution aux différents services et programmes gouvernementaux."
 
@@ -977,46 +977,46 @@ msgstr "Environnement et Changement climatique"
 msgid "Equalization Payments to Provinces"
 msgstr "Paiements de péréquation aux provinces"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:16
 msgid "ESDC"
 msgstr "EDSC"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:95
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:95
 msgid "ESDC accounted for 18.4% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024."
 msgstr "EDSC représentait 18,4 % de toutes les dépenses fédérales pour l'exercice 2024. 10 ministères gouvernementaux représentaient 73,2 % des dépenses fédérales pour l'exercice 2024."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:88
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:88
 msgid "ESDC spent $94.48 billion in fiscal year (FY) 2024. This was 18.4% of the $513.9 billion in overall federal spending, making it one of the highest-spending federal departments."
 msgstr "EDSC a dépensé 94,48 milliards de dollars au cours de l'exercice 2024. Cela représentait 18,4 % des 513,9 milliards de dollars de dépenses fédérales totales, ce qui en fait l'un des ministères fédéraux aux dépenses les plus élevées."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:197
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:197
 msgid "ESDC, Spending by Entity, FY 2024"
 msgstr "EDSC, Dépenses par entité, exercice 2024"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:179
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:179
 msgid "ESDC's share of federal spending in FY 2024"
 msgstr "Part des dépenses fédérales d'EDSC pour l'exercice 2024"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:141
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:141
 msgid "ESDC's share of federal spending in FY 2024 was lower than FY 1995"
 msgstr "La part des dépenses fédérales d'EDSC en 2024 était inférieure à celle de 1995"
 
 #: src/app/[lang]/(main)/budget/page.tsx:217
-#: src/app/[lang]/(main)/federal/budget/page.tsx:254
+#: src/app/[lang]/(main)/federal/budget/page.tsx:256
 msgid "Est. projected budget deficit"
 msgstr "Déficit budgétaire projeté estimé"
 
 #: src/app/[lang]/(main)/budget/page.tsx:177
-#: src/app/[lang]/(main)/federal/budget/page.tsx:214
+#: src/app/[lang]/(main)/federal/budget/page.tsx:216
 msgid "Est. projected government budget"
 msgstr "Budget gouvernemental projeté estimé"
 
 #: src/app/[lang]/(main)/budget/page.tsx:186
-#: src/app/[lang]/(main)/federal/budget/page.tsx:223
+#: src/app/[lang]/(main)/federal/budget/page.tsx:225
 msgid "Est. projected government revenue"
 msgstr "Revenus gouvernementaux projetés estimés"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:57
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:57
 msgid "Established in 2005, ESDC is a federal department responsible for supporting Canadians through social programs and workforce development. It administers key programs such as Employment Insurance (EI), the Canada Pension Plan (CPP), Old Age Security (OAS), and skills training initiatives. ESDC also oversees Service Canada, which delivers government services directly to the public."
 msgstr "Établi en 2005, EDSC est un ministère fédéral responsable du soutien aux Canadiens par le biais de programmes sociaux et de développement de la main-d'œuvre. Il administre des programmes clés tels que l'assurance-emploi (AE), le Régime de pensions du Canada (RPC), la Sécurité de la vieillesse (SV) et des initiatives de formation professionnelle. EDSC supervise également Service Canada, qui fournit des services gouvernementaux directement au public."
 
@@ -1076,12 +1076,12 @@ msgstr "Dépenses"
 msgid "Explore Canada's federal budget with interactive visualizations and detailed analysis of government revenue and expenditures."
 msgstr "Explorez le budget fédéral du Canada avec des visualisations interactives et une analyse détaillée des revenus et dépenses gouvernementales."
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:250
+#: src/app/[lang]/(main)/federal/spending/page.tsx:251
 #: src/app/[lang]/(main)/spending/page.tsx:241
 msgid "Explore federal employee salary distribution by year and demographic group"
 msgstr "Explorez la répartition des salaires des employés fédéraux par année et groupe démographique"
 
-#: src/components/HeroButtons.tsx:34
+#: src/components/HeroButtons.tsx:37
 msgid "Explore Federal Spending"
 msgstr "Explorer les dépenses fédérales"
 
@@ -1097,7 +1097,7 @@ msgstr "Explorez les données financières des Premières Nations à travers le 
 msgid "Explore financial data from First Nations across Canada. View statements of operations, financial positions, and remuneration from annual reports published under the First Nations Financial Transparency Act (FNFTA)."
 msgstr "Explorez les données financières des Premières Nations à travers le Canada. Consultez les états des résultats, les situations financières et la rémunération à partir des rapports annuels publiés en vertu de la Loi sur la transparence financière des Premières Nations (LTFPN)."
 
-#: src/components/HeroButtons.tsx:107
+#: src/components/HeroButtons.tsx:110
 msgid "Explore First Nations Spending"
 msgstr "Explorer les dépenses des Premières Nations"
 
@@ -1109,32 +1109,32 @@ msgstr "Découvrez comment le gouvernement fédéral canadien dépense vos impô
 msgid "Explore in-depth articles about Canadian government spending, budget analysis, and public finance. Stay informed about how your tax dollars are used through Canada Spends."
 msgstr "Explorez des articles approfondis sur les dépenses gouvernementales canadiennes, l'analyse budgétaire et les finances publiques. Restez informé de l'utilisation de vos dollars d'impôt grâce à Canada Spends."
 
-#: src/components/HeroButtons.tsx:70
+#: src/components/HeroButtons.tsx:73
 msgid "Explore Municipal Spending"
 msgstr "Explorer les dépenses municipales"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:239
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:230
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:258
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:277
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:199
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:210
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:194
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:227
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:194
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:241
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:191
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:201
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:199
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:199
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:239
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:230
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:258
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:277
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:199
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:210
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:194
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:227
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:194
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:241
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:191
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:201
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:199
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:199
 msgid "Explore other Federal Departments"
 msgstr "Explorer d'autres ministères fédéraux"
 
-#: src/components/HeroButtons.tsx:43
+#: src/components/HeroButtons.tsx:46
 msgid "Explore Provincial Spending"
 msgstr "Explorer les dépenses provinciales"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:134
+#: src/app/[lang]/(main)/federal/spending/page.tsx:135
 #: src/app/[lang]/(main)/spending/page.tsx:125
 msgid "Explore revenue and spending categories or filter by agency for deeper insights."
 msgstr "Explorez les catégories de revenus et de dépenses ou filtrez par organisme pour des analyses plus approfondies."
@@ -1143,16 +1143,16 @@ msgstr "Explorez les catégories de revenus et de dépenses ou filtrez par organ
 msgid "External ID"
 msgstr "ID externe"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:67
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:67
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:67
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:67
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:67
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:67
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:67
 msgid "External Revenues"
 msgstr "Revenus externes"
 
@@ -1175,48 +1175,48 @@ msgstr "Fédéral"
 msgid "Federal Budget 2025 | Canada Spends"
 msgstr "Budget fédéral 2025 | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:178
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:178
 msgid "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, Department of Finance entities with the highest expenditures were the Office of the Superintendent of Financial Institutions, Office of the Auditor General, and the Financial Transactions and Reports Analysis Centre of Canada."
 msgstr "Les ministères fédéraux comprennent souvent d'autres entités, notamment des bureaux, des sociétés d'État et des organismes. Au cours de l'exercice 2024, les entités du ministère des Finances ayant les dépenses les plus élevées étaient le Bureau du surintendant des institutions financières, le Bureau du vérificateur général et le Centre d'analyse des opérations et déclarations financières du Canada."
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:158
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:158
 msgid "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, HICC entities with the highest expenditures were Office of Infrastructure Canada, the Canada Mortgage and Housing Corporation and the Windsor-Detroit Bridge Authority."
 msgstr "Les ministères fédéraux comprennent souvent d'autres entités, notamment des bureaux, des sociétés d'État et des organismes. Au cours de l'exercice 2024, les entités de LICC ayant les dépenses les plus élevées étaient le Bureau d'Infrastructure Canada, la Société canadienne d'hypothèques et de logement et l'Autorité du pont Windsor-Detroit."
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:151
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:151
 msgid "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, IRCC reported total expenditures of $6.2 billion, broken out as follows:"
 msgstr "Les ministères fédéraux comprennent souvent d'autres entités, notamment des bureaux, des sociétés d'État et des organismes. Au cours de l'exercice 2024, IRCC a déclaré des dépenses totales de 6,2 milliards de dollars, réparties comme suit :"
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:153
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:153
 msgid "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, ISED's budget was split across the following entities:"
 msgstr "Les ministères fédéraux comprennent souvent d'autres entités, notamment des bureaux, des sociétés d'État et des organismes. Au cours de l'exercice 2024, le budget d'ISDE était réparti entre les entités suivantes :"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:159
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:159
 msgid "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, PSPC's budget was split across the following entities:"
 msgstr "Les ministères fédéraux comprennent souvent d'autres entités, notamment des bureaux, des sociétés d'État et des organismes. Au cours de l'exercice 2024, le budget de SPAC était réparti entre les entités suivantes :"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:152
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:152
 msgid "Federal departments often contain other entities including offices, crown corporations and agencies. In FY 2024, Transport Canada reported total expenditures of $5.1 billion across the following entities:"
 msgstr "Les ministères fédéraux comprennent souvent d'autres entités, notamment des bureaux, des sociétés d'État et des organismes. Au cours de l'exercice 2024, Transports Canada a déclaré des dépenses totales de 5,1 milliards de dollars réparties entre les entités suivantes :"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:152
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:152
 msgid "Federal departments often contain other entities including offices, crown corporations and agencies. The Health Canada entities with the biggest expenditures in FY 2024 were"
 msgstr "Les ministères fédéraux comprennent souvent d'autres entités, notamment des bureaux, des sociétés d'État et des organismes. Les entités de Santé Canada ayant les dépenses les plus élevées au cours de l'exercice 2024 étaient"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:208
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:208
 msgid "Federal departments often contain other entities. In FY 2024, Global Affairs Canada's entities with the highest expenditures were:"
 msgstr "Les ministères fédéraux comprennent souvent d'autres entités. Au cours de l'exercice 2024, les entités d'Affaires mondiales Canada ayant les dépenses les plus élevées étaient :"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:194
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:194
 msgid "Federal departments often include additional agencies, commands, and operational divisions. In FY 2024, the largest spending entities within DND were the Canadian Army, the Royal Canadian Navy, and the Royal Canadian Air Force, accounting for the bulk of military expenditures."
 msgstr "Les ministères fédéraux comprennent souvent des agences supplémentaires, des commandements et des divisions opérationnelles. Au cours de l'exercice 2024, les entités ayant les dépenses les plus importantes au sein du MDN étaient l'Armée canadienne, la Marine royale canadienne et l'Aviation royale canadienne, représentant la majeure partie des dépenses militaires."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:190
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:190
 msgid "Federal departments often include multiple agencies and service delivery arms. In FY 2024, ESDC's highest-expenditure entities included:"
 msgstr "Les ministères fédéraux comprennent souvent plusieurs agences et organes de prestation de services. Au cours de l'exercice 2024, les entités d'EDSC ayant les dépenses les plus élevées comprenaient :"
 
 #: src/app/[lang]/(main)/budget/page.tsx:156
-#: src/app/[lang]/(main)/federal/budget/page.tsx:183
+#: src/app/[lang]/(main)/federal/budget/page.tsx:185
 msgid "Federal Fall 2025 Government Budget"
 msgstr "Budget gouvernemental fédéral de l'automne 2025"
 
@@ -1224,78 +1224,78 @@ msgstr "Budget gouvernemental fédéral de l'automne 2025"
 msgid "Federal Government Spending | Canada Spends"
 msgstr "Dépenses du gouvernement fédéral | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:170
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:197
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:173
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:170
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:197
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:173
 msgid "Federal government spending in FY 2024"
 msgstr "Dépenses du gouvernement fédéral pour l'exercice 2024"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:140
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:142
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:148
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:141
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:144
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:140
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:142
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:148
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:141
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:144
 msgid "Federal government spending isolated to FY 2024"
 msgstr "Dépenses du gouvernement fédéral isolées pour l'exercice 2024"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:232
+#: src/app/[lang]/(main)/federal/spending/page.tsx:233
 #: src/app/[lang]/(main)/spending/page.tsx:223
 msgid "Federal organizations"
 msgstr "Organisations fédérales"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:120
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:120
 msgid "Federal spending may shift over time due to changing global circumstances, diplomatic priorities, and Canada's economic relationships. Since 1995, overall federal spending has increased by 74.9%, while Global Affairs Canada's budget has grown by 166.5%, reflecting an expansion in international engagement."
 msgstr "Les dépenses fédérales peuvent évoluer au fil du temps en raison de l'évolution des circonstances mondiales, des priorités diplomatiques et des relations économiques du Canada. Depuis 1995, les dépenses fédérales globales ont augmenté de 74,9 %, tandis que le budget d'Affaires mondiales Canada a augmenté de 166,5 %, reflétant une expansion de l'engagement international."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:113
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:113
 msgid "Federal spending may shift over time due to economic fluctuations, changes in tax policy, and the expansion of benefit programs. Since 1995, overall federal spending has risen 74.9%, while Canada Revenue Agency spending has increased 302%"
 msgstr "Les dépenses fédérales peuvent évoluer au fil du temps en raison des fluctuations économiques, des changements dans la politique fiscale et de l'expansion des programmes de prestations. Depuis 1995, les dépenses fédérales globales ont augmenté de 74,9 %, tandis que les dépenses de l'Agence du revenu du Canada ont augmenté de 302 %"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:126
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:126
 msgid "Federal spending may shift over time due to geopolitical tensions, defence modernization needs, and emerging threats such as cyber warfare. Since 1995, overall federal spending has risen 74.9%, while Department of National Defence spending has increased 59.9%."
 msgstr "Les dépenses fédérales peuvent évoluer au fil du temps en raison des tensions géopolitiques, des besoins de modernisation de la défense et des menaces émergentes telles que la cyberguerre. Depuis 1995, les dépenses fédérales globales ont augmenté de 74,9 %, tandis que les dépenses du ministère de la Défense nationale ont augmenté de 59,9 %."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:105
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:105
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging challenges. Since 2005, when ESDC was first established, overall federal spending has risen 62.9%, while ESDC spending has increased 1,485%."
 msgstr "Les dépenses fédérales peuvent évoluer au fil du temps en raison de la croissance démographique, des changements dans les politiques et les programmes, et des défis émergents. Depuis 2005, lorsque EDSC a été créé, les dépenses fédérales globales ont augmenté de 62,9 %, tandis que les dépenses d'EDSC ont augmenté de 1 485 %."
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:115
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:115
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging challenges. Since FY 1995, overall federal spending has risen 74.9%, while Health Canada spending has decreased 19.9% when adjusted for inflation."
 msgstr "Les dépenses fédérales peuvent évoluer au fil du temps en raison de la croissance démographique, des changements dans les politiques et les programmes, et des défis émergents. Depuis l'exercice 1995, les dépenses fédérales globales ont augmenté de 74,9 %, tandis que les dépenses de Santé Canada ont diminué de 19,9 % après ajustement pour l'inflation."
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:117
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:117
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address."
 msgstr "Les dépenses fédérales peuvent évoluer au fil du temps en raison de la croissance démographique, des changements dans les politiques et les programmes, et des problèmes émergents à résoudre."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:112
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:112
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 74.9%, while Department of Finance spending has increased 41.4%."
 msgstr "Les dépenses fédérales peuvent évoluer au fil du temps en raison de la croissance démographique, des changements dans les politiques et les programmes, et des problèmes émergents à résoudre. Depuis 1995, les dépenses fédérales globales ont augmenté de 74,9 %, tandis que les dépenses du ministère des Finances ont augmenté de 41,4 %."
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:101
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:101
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 74.9%, while IRCC spending has increased 428% (adjusted for inflation)."
 msgstr "Les dépenses fédérales peuvent évoluer au fil du temps en raison de la croissance démographique, des changements dans les politiques et les programmes, et des problèmes émergents à résoudre. Depuis 1995, les dépenses fédérales globales ont augmenté de 74,9 %, tandis que les dépenses d'IRCC ont augmenté de 428 % (ajustées pour l'inflation)."
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:103
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:103
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 74.9%, while ISED spending has increased 90.3%."
 msgstr "Les dépenses fédérales peuvent évoluer au fil du temps en raison de la croissance démographique, des changements dans les politiques et les programmes, et des problèmes émergents à résoudre. Depuis 1995, les dépenses fédérales globales ont augmenté de 74,9 %, tandis que les dépenses d'ISDE ont augmenté de 90,3 %."
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:104
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:104
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 74.9%, while PSPC spending has increased by 7.1% when adjusted for inflation."
 msgstr "Les dépenses fédérales peuvent évoluer au fil du temps en raison de la croissance démographique, des changements dans les politiques et les programmes, et des problèmes émergents à résoudre. Depuis 1995, les dépenses fédérales globales ont augmenté de 74,9 %, tandis que les dépenses de SPAC ont augmenté de 7,1 % après ajustement pour l'inflation."
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:104
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:104
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 74.9%, while Transport spending has remained relatively flat."
 msgstr "Les dépenses fédérales peuvent évoluer au fil du temps en raison de la croissance démographique, des changements dans les politiques et les programmes, et des problèmes émergents à résoudre. Depuis 1995, les dépenses fédérales globales ont augmenté de 74,9 %, tandis que les dépenses de Transport sont restées relativement stables."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:105
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:105
 msgid "Federal spending may shift over time due to population growth, changes in policy and programs, and emerging problems to address. Since 1995, overall federal spending has risen 77%, while VAC spending has increased 51%."
 msgstr "Les dépenses fédérales peuvent évoluer au fil du temps en raison de la croissance démographique, des changements dans les politiques et les programmes, et des problèmes émergents à résoudre. Depuis 1995, les dépenses fédérales globales ont augmenté de 77 %, tandis que les dépenses d'ACC ont augmenté de 51 %."
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:114
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:114
 msgid "Federal spending on Indigenous priorities may fluctuate over time due to population growth, policy shifts, and emerging challenges such as climate change and infrastructure deficits. Since 1995, total federal spending has risen by 74.9%, while spending on Indigenous priorities has increased by 592%, reflecting expanded program commitments and new governance agreements and claim settlements."
 msgstr "Les dépenses fédérales consacrées aux priorités autochtones peuvent fluctuer au fil du temps en raison de la croissance démographique, des changements de politique et des défis émergents tels que le changement climatique et les déficits d'infrastructure. Depuis 1995, les dépenses fédérales totales ont augmenté de 74,9 %, tandis que les dépenses consacrées aux priorités autochtones ont augmenté de 592 %, reflétant l'expansion des engagements de programme et de nouveaux accords de gouvernance et règlements de revendications."
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:113
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:113
 msgid "Federal spending on public safety fluctuates based on evolving security threats, emergency events, and changes in government policy. Since 2005 shortly after it was established, Public Safety Canada's expenditures have increased by 69.6%, reflecting heightened investments in counterterrorism, cyber defence, and disaster response capabilities. The department's share of the federal budget has remained relatively flat from 2.6% in 2005 to 2.7% in 2024."
 msgstr "Les dépenses fédérales en matière de sécurité publique fluctuent en fonction de l'évolution des menaces pour la sécurité, des événements d'urgence et des changements dans la politique gouvernementale. Depuis 2005, peu après sa création, les dépenses de Sécurité publique Canada ont augmenté de 69,6 %, reflétant des investissements accrus dans les capacités de lutte contre le terrorisme, de cyberdéfense et d'intervention en cas de catastrophe. La part du ministère dans le budget fédéral est restée relativement stable, passant de 2,6 % en 2005 à 2,7 % en 2024."
 
@@ -1303,7 +1303,7 @@ msgstr "Les dépenses fédérales en matière de sécurité publique fluctuent e
 msgid "Federal Tax"
 msgstr "Impôt fédéral"
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:315
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:321
 #: src/components/TaxBreakdownAccordion.tsx:105
 msgid "Federal Taxes"
 msgstr "Impôts fédéraux"
@@ -1353,7 +1353,8 @@ msgstr "Situation financière {0}"
 msgid "Financial Summary FY {fiscalYear}"
 msgstr "Résumé financier EF {fiscalYear}"
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:386
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:392
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:562
 msgid "First"
 msgstr "Premier"
 
@@ -1398,7 +1399,7 @@ msgstr "Aperçu de la rémunération des Premières Nations"
 msgid "First Nations Remuneration Overview | Canada Spends"
 msgstr "Aperçu de la rémunération des Premières Nations | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/MiniSankey.tsx:27
 msgid "Fiscal arrangements"
 msgstr "Arrangements fiscaux"
 
@@ -1420,11 +1421,11 @@ msgstr "Pêches + Écosystèmes aquatiques"
 msgid "Food Safety"
 msgstr "Sécurité alimentaire"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:130
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:130
 msgid "For example, during the COVID-19 pandemic, federal support programs led to a temporary surge in spending. ESDC expenditures increased from $63.3 billion in 2019 to $169.2 billion in 2021 before stabilizing in recent years."
 msgstr "Par exemple, pendant la pandémie de COVID-19, les programmes de soutien fédéraux ont entraîné une augmentation temporaire des dépenses. Les dépenses d'EDSC sont passées de 63,3 milliards de dollars en 2019 à 169,2 milliards de dollars en 2021 avant de se stabiliser ces dernières années."
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:788
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:829
 msgid "For further breakdowns of spending, see <0>Federal</0> and <1>Provincial</1> spending pages."
 msgstr "Pour des répartitions plus détaillées des dépenses, consultez les pages de dépenses <0>fédérales</0> et <1>provinciales</1>."
 
@@ -1452,16 +1453,16 @@ msgstr "Conception des forces futures"
 msgid "FY"
 msgstr "EF"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:131
+#: src/app/[lang]/(main)/federal/spending/page.tsx:132
 #: src/app/[lang]/(main)/spending/page.tsx:122
 msgid "FY 2024 Government Revenue and Spending"
 msgstr "Revenus et dépenses du gouvernement pour l'exercice 2024"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:103
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:103
 msgid "GAC accounted for 3.7% of all federal spending in FY 2024."
 msgstr "AMC représentait 3,7 % de toutes les dépenses fédérales pour l'exercice 2024."
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:165
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:165
 msgid "GAC's expenditures are divided across five primary categories:"
 msgstr "Les dépenses d'AMC sont réparties en cinq catégories principales :"
 
@@ -1469,7 +1470,7 @@ msgstr "Les dépenses d'AMC sont réparties en cinq catégories principales :"
 msgid "Gender Equality"
 msgstr "Égalité des genres"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:123
+#: src/app/[lang]/(main)/federal/spending/page.tsx:124
 #: src/app/[lang]/(main)/spending/page.tsx:114
 msgid "Get data-driven insights into how governmental revenue and spending affect Canadian lives and programs."
 msgstr "Obtenez des analyses basées sur les données sur la façon dont les revenus et les dépenses gouvernementaux affectent la vie des Canadiens et les programmes."
@@ -1486,7 +1487,7 @@ msgid "Get Involved"
 msgstr "Impliquez-vous"
 
 #: src/app/[lang]/(main)/page.tsx:47
-#: src/app/[lang]/layout.tsx:22
+#: src/app/[lang]/layout.tsx:21
 msgid "Get The Facts About Government Spending"
 msgstr "Découvrez les faits sur les dépenses gouvernementales"
 
@@ -1494,28 +1495,28 @@ msgstr "Découvrez les faits sur les dépenses gouvernementales"
 msgid "Get weekly recaps of current events and updates from our team."
 msgstr "Recevez des résumés hebdomadaires des événements actuels et des mises à jour de notre équipe."
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:32
 msgid "Global Affairs Canada"
 msgstr "Affaires mondiales Canada"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:55
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:55
 msgid "Global Affairs Canada (GAC) is the federal department responsible for managing Canada's diplomatic relations, international trade, and development assistance. Established in 1909 as the Department of External Affairs, GAC has evolved to oversee Canada's engagement in global affairs, promoting national interests abroad and ensuring the protection of Canadian citizens overseas. The department negotiates international agreements, administers trade policies, and provides humanitarian aid. Additionally, it supports Canadian businesses in expanding internationally and strengthens diplomatic ties through multilateral organizations like the United Nations, the World Trade Organization (WTO), and NATO. GAC also plays a critical role in crisis response, assisting Canadians abroad during emergencies, and fostering global security and stability."
 msgstr "Affaires mondiales Canada (AMC) est le ministère fédéral responsable de la gestion des relations diplomatiques du Canada, du commerce international et de l'aide au développement. Établi en 1909 sous le nom de ministère des Affaires extérieures, AMC a évolué pour superviser l'engagement du Canada dans les affaires mondiales, promouvoir les intérêts nationaux à l'étranger et assurer la protection des citoyens canadiens à l'étranger. Le ministère négocie des accords internationaux, administre les politiques commerciales et fournit de l'aide humanitaire. De plus, il soutient les entreprises canadiennes dans leur expansion internationale et renforce les liens diplomatiques par le biais d'organisations multilatérales comme les Nations Unies, l'Organisation mondiale du commerce (OMC) et l'OTAN. AMC joue également un rôle crucial dans la réponse aux crises, aidant les Canadiens à l'étranger lors d'urgences et favorisant la sécurité et la stabilité mondiales."
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:36
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:36
 msgid "Global Affairs Canada | Canada Spends"
 msgstr "Affaires mondiales Canada | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:227
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:227
 msgid "Global Affairs Canada is led by two ministers appointed by the Prime Minister and formally sworn into office at Rideau Hall. The department's leadership includes:"
 msgstr "Affaires mondiales Canada est dirigé par deux ministres nommés par le premier ministre et officiellement assermentés à Rideau Hall. La direction du ministère comprend :"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:94
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:94
 msgid "Global Affairs Canada spent $19.2 billion in fiscal year (FY) 2024, representing 3.7% of the $513.9 billion in overall federal spending. This placed GAC among the mid-sized federal departments in terms of total expenditures."
 msgstr "Affaires mondiales Canada a dépensé 19,2 milliards de dollars au cours de l'exercice 2024, représentant 3,7 % des 513,9 milliards de dollars de dépenses fédérales totales. Cela place AMC parmi les ministères fédéraux de taille moyenne en termes de dépenses totales."
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:216
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:216
 msgid "Global Affairs Canada, Spending by Entity, FY 2024"
 msgstr "Affaires mondiales Canada, Dépenses par entité, exercice 2024"
 
@@ -1532,13 +1533,13 @@ msgstr "Taxe sur les produits et services"
 msgid "Gottfriedson Band Class Settlement"
 msgstr "Règlement du recours collectif de la bande Gottfriedson"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:269
+#: src/app/[lang]/(main)/federal/spending/page.tsx:270
 #: src/app/[lang]/(main)/spending/page.tsx:260
 msgid "Government Departments explained"
 msgstr "Explication des ministères gouvernementaux"
 
 #: src/app/[lang]/(main)/budget/page.tsx:261
-#: src/app/[lang]/(main)/federal/budget/page.tsx:298
+#: src/app/[lang]/(main)/federal/budget/page.tsx:300
 msgid "Government Departments Explained"
 msgstr "Ministères gouvernementaux expliqués"
 
@@ -1550,12 +1551,12 @@ msgstr "Opérations informatiques gouvernementales"
 msgid "Government organizations"
 msgstr "Organisations gouvernementales"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:120
+#: src/app/[lang]/(main)/federal/spending/page.tsx:121
 #: src/app/[lang]/(main)/spending/page.tsx:111
 msgid "Government Spending"
 msgstr "Dépenses gouvernementales"
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:785
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:826
 msgid "Government spending is based on 2023-2024 fiscal spending. Attempts have been made to merge similar categories across federal and provincial spending."
 msgstr "Les dépenses gouvernementales sont basées sur les dépenses fiscales de 2023-2024. Des tentatives ont été faites pour fusionner des catégories similaires entre les dépenses fédérales et provinciales."
 
@@ -1564,11 +1565,11 @@ msgstr "Les dépenses gouvernementales sont basées sur les dépenses fiscales d
 msgid "facts-1"
 msgstr "Les dépenses gouvernementales ne devraient pas être une boîte noire. Chaque année, le gouvernement fédéral dépense des centaines de milliards de dollars, mais la plupart des Canadiens n'ont aucune idée où tout cet argent va. Les données sont disponibles, mais elles sont enfouies sur des sites Web obscurs et impossibles à naviguer."
 
-#: src/app/[lang]/layout.tsx:23
+#: src/app/[lang]/layout.tsx:22
 msgid "Government spending shouldn't be a black box. We turn complex data into clear, non-partisan insights so every Canadian knows where their money goes."
 msgstr "Les dépenses gouvernementales ne devraient pas être une boîte noire. Nous transformons des données complexes en analyses claires et non partisanes pour que chaque Canadien sache où va son argent."
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:165
+#: src/app/[lang]/(main)/federal/spending/page.tsx:166
 #: src/app/[lang]/(main)/spending/page.tsx:156
 msgid "Government Workforce"
 msgstr "Effectif gouvernemental"
@@ -1593,7 +1594,7 @@ msgstr "Groupe"
 msgid "Have questions or feedback? Email us at hi@canadaspends.com or connect with us on X @canada_spends - we'd love to hear from you!"
 msgstr "Vous avez des questions ou des commentaires? Envoyez-nous un courriel à hi@canadaspends.com ou connectez-vous avec nous sur X @canada_spends - nous aimerions avoir de vos nouvelles!"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:169
+#: src/app/[lang]/(main)/federal/spending/page.tsx:170
 #: src/app/[lang]/(main)/spending/page.tsx:160
 msgid "Headcount"
 msgstr "Effectif"
@@ -1606,28 +1607,28 @@ msgstr "Santé"
 msgid "Health agreements with provinces and territories"
 msgstr "Accords de santé avec les provinces et les territoires"
 
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:56
 msgid "Health Canada"
 msgstr "Santé Canada"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:33
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:33
 msgid "Health Canada | Canada Spends"
 msgstr "Santé Canada | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:101
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:101
 msgid "Health Canada accounted for 2.7% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 msgstr "Santé Canada représentait 2,7 % des dépenses fédérales totales pour l'exercice 2024. 10 ministères gouvernementaux représentaient 73,2 % des dépenses fédérales pour l'exercice 2024"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:170
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:170
 msgid "Health Canada is led by the <0>Minister of Health</0>, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 msgstr "Santé Canada est dirigé par le <0>ministre de la Santé</0>, qui est nommé par le gouverneur général sur l'avis du premier ministre et officiellement assermenté à Rideau Hall. Lors de sa nomination, le ministre prête le serment d'office et le serment d'allégeance, devenant membre du Conseil privé du Roi pour le Canada."
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:51
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:51
 msgid "Health Canada is the federal department responsible for protecting and improving the health of Canadians. It develops health policies, regulates pharmaceuticals and medical devices, enforces food safety standards, and funds public health programs. The department works with provinces and territories to support the healthcare system while ensuring safety standards for drugs, consumer products, and nutrition guidelines."
 msgstr "Santé Canada est le ministère fédéral responsable de la protection et de l'amélioration de la santé des Canadiens. Il élabore des politiques de santé, réglemente les produits pharmaceutiques et les dispositifs médicaux, applique les normes de sécurité alimentaire et finance des programmes de santé publique. Le ministère collabore avec les provinces et les territoires pour soutenir le système de santé tout en assurant le respect des normes de sécurité pour les médicaments, les produits de consommation et les directives en matière de nutrition."
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:92
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:92
 msgid "Health Canada spent $13.7 billion in fiscal year (FY) 2024. This was 2.7% of the $513.9 billion in overall federal spending. The department ranked tenth among federal departments in total spending."
 msgstr "Santé Canada a dépensé 13,7 milliards de dollars au cours de l'exercice 2024. Cela représentait 2,7 % des 513,9 milliards de dollars de dépenses fédérales totales. Le ministère s'est classé dixième parmi les ministères fédéraux en termes de dépenses totales."
 
@@ -1644,23 +1645,23 @@ msgstr "Recherche en santé"
 msgid "Health Transfer to Provinces"
 msgstr "Transfert en matière de santé aux provinces"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:180
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:180
 msgid "Help for Canadians Abroad: $85.98M"
 msgstr "Aide aux Canadiens à l'étranger : 85,98 M$"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:16
 msgid "HICC"
 msgstr "LICC"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:102
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:102
 msgid "HICC accounted for 2.8% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024."
 msgstr "LICC représentait 2,8 % des dépenses fédérales totales pour l'exercice 2024. 10 ministères gouvernementaux représentaient 73,2 % des dépenses fédérales pour l'exercice 2024."
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:62
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:62
 msgid "HICC administers the National Housing Strategy, which funds the construction, repair, and preservation of affordable housing. It also oversees the Canada Mortgage and Housing Corporation (CMHC), which provides mortgage insurance and financing programs. The department supports public transit, clean energy, and community infrastructure through programs like the Canada Infrastructure Bank (CIB)."
 msgstr "LICC administre la Stratégie nationale sur le logement, qui finance la construction, la réparation et la préservation de logements abordables. Il supervise également la Société canadienne d'hypothèques et de logement (SCHL), qui offre des programmes d'assurance hypothécaire et de financement. Le ministère soutient le transport en commun, l'énergie propre et les infrastructures communautaires par le biais de programmes comme la Banque de l'infrastructure du Canada (BIC)."
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:94
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:94
 msgid "HICC spent $14.5 billion in fiscal year (FY) 2024. This was 2.8% of the $513.9 billion in overall federal spending. The department ranked eighth among federal departments in total spending."
 msgstr "LICC a dépensé 14,5 milliards de dollars au cours de l'exercice 2024. Cela représentait 2,8 % des 513,9 milliards de dollars de dépenses fédérales totales. Le ministère s'est classé huitième parmi les ministères fédéraux en termes de dépenses totales."
 
@@ -1681,15 +1682,15 @@ msgstr "Aide au logement"
 msgid "Housing, Infrastructure and Communities Canada"
 msgstr "Logement, Infrastructure et Collectivités Canada"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:180
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:180
 msgid "Housing, Infrastructure and Communities Canada (HICC) is led by the <0>Minister of Housing, Infrastructure and Communities</0>, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 msgstr "Logement, Infrastructure et Collectivités Canada (LICC) est dirigé par le <0>ministre du Logement, de l'Infrastructure et des Collectivités</0>, qui est nommé par le gouverneur général sur l'avis du premier ministre et officiellement assermenté à Rideau Hall. Lors de sa nomination, le ministre prête le serment d'office et le serment d'allégeance, devenant membre du Conseil privé du Roi pour le Canada."
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:52
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:52
 msgid "Housing, Infrastructure and Communities Canada (HICC) is responsible for federal policies and programs that support public infrastructure, affordable housing, and community development. It works with provinces, territories, and municipalities to fund major infrastructure projects and improve housing affordability across Canada."
 msgstr "Logement, Infrastructure et Collectivités Canada (LICC) est responsable des politiques et programmes fédéraux qui soutiennent les infrastructures publiques, le logement abordable et le développement communautaire. Il collabore avec les provinces, les territoires et les municipalités pour financer d'importants projets d'infrastructure et améliorer l'abordabilité du logement partout au Canada."
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:34
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:34
 msgid "Housing, Infrastructure and Communities Canada | Canada Spends"
 msgstr "Logement, Infrastructure et Collectivités Canada | Canada Spends"
 
@@ -1701,59 +1702,59 @@ msgstr "Comment puis-je montrer mon soutien?"
 msgid "How can I stay up to date on your work?"
 msgstr "Comment puis-je rester informé de votre travail?"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:170
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:170
 msgid "How did ESDC spend its budget in 2024?"
 msgstr "Comment EDSC a-t-il dépensé son budget en 2024?"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:160
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:160
 msgid "How did Global Affairs Canada spend its budget in 2024?"
 msgstr "Comment Affaires mondiales Canada a-t-il dépensé son budget en 2024?"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:155
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:155
 msgid "How did HICC spend its budget in FY24?"
 msgstr "Comment LICC a-t-il dépensé son budget pour l'exercice 2024?"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:137
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:137
 msgid "How did IRCC spend its budget in FY24?"
 msgstr "Comment IRCC a-t-il dépensé son budget pour l'exercice 2024?"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:170
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:170
 msgid "How did ISC and CIRNAC spend their budgets in 2024?"
 msgstr "Comment SAC et RCAANC ont-ils dépensé leurs budgets en 2024?"
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:139
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:139
 msgid "How did ISED spend its budget in FY 24?"
 msgstr "Comment ISDE a-t-il dépensé son budget pour l'exercice 2024?"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:145
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:145
 msgid "How did PSPC spend its budget in FY24?"
 msgstr "Comment SPAC a-t-il dépensé son budget pour l'exercice 2024?"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:141
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:141
 msgid "How did Public Safety Canada spend its budget in 2024?"
 msgstr "Comment Sécurité publique Canada a-t-il dépensé son budget en 2024?"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:182
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:182
 msgid "How did the Canada Revenue Agency spend its budget in 2024?"
 msgstr "Comment l'Agence du revenu du Canada a-t-elle dépensé son budget en 2024?"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:165
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:165
 msgid "How did the Department of Finance spend its budget in 2024?"
 msgstr "Comment le ministère des Finances a-t-il dépensé son budget en 2024?"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:168
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:168
 msgid "How did the Department of National Defence spend its budget in 2024?"
 msgstr "Comment le ministère de la Défense nationale a-t-il dépensé son budget en 2024?"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:138
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:138
 msgid "How did Transport Canada spend its budget in FY24?"
 msgstr "Comment Transports Canada a-t-il dépensé son budget pour l'exercice 2024?"
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:141
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:141
 msgid "How did VAC spend its budget in FY24?"
 msgstr "Comment ACC a-t-il dépensé son budget pour l'exercice 2024?"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:110
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:110
 msgid "How has Public Safety Canada's spending changed?"
 msgstr "Comment les dépenses de Sécurité publique Canada ont-elles évolué?"
 
@@ -1765,16 +1766,16 @@ msgstr "Comment soumettre une information"
 msgid "Immigration + Border Security"
 msgstr "Immigration + Sécurité frontalière"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:74
 msgid "Immigration, Refugees and Citizenship"
 msgstr "Immigration, Réfugiés et Citoyenneté"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:170
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:170
 msgid "Immigration, Refugees and Citizenship Canada (IRCC) is led by the Minister of Immigration, Refugees and Citizenship, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 msgstr "Immigration, Réfugiés et Citoyenneté Canada (IRCC) est dirigé par le ministre de l'Immigration, des Réfugiés et de la Citoyenneté, qui est nommé par le gouverneur général sur l'avis du premier ministre et officiellement assermenté à Rideau Hall. Lors de sa nomination, le ministre prête le serment d'office et le serment d'allégeance, devenant membre du Conseil privé du Roi pour le Canada."
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:32
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:32
 msgid "Immigration, Refugees and Citizenship Canada | Canada Spends"
 msgstr "Immigration, Réfugiés et Citoyenneté Canada | Canada Spends"
 
@@ -1797,66 +1798,66 @@ msgstr "En {0}, vous payez <0>{1}</0> en impôts totaux (taux effectif de {2}%)"
 msgid "In Financial Year {0},"
 msgstr "Au cours de l'exercice financier {0},"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:99
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:99
 msgid "In fiscal year (FY) 2024, ISC and CIRNAC collectively spent <0>$63 billion</0>, accounting for <1>12.3% of the total federal budget</1>. The departments play a critical role in addressing socio-economic disparities, facilitating self-governance agreements, and improving service delivery for Indigenous communities across Canada."
 msgstr "Au cours de l'exercice 2024, SAC et RCAANC ont collectivement dépensé <0>63 milliards de dollars</0>, représentant <1>12,3 % du budget fédéral total</1>. Les ministères jouent un rôle essentiel dans la réduction des disparités socio-économiques, la facilitation des accords d'autonomie gouvernementale et l'amélioration de la prestation de services aux communautés autochtones à travers le Canada."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:73
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:78
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:72
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:77
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:74
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:79
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:80
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:85
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:78
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:83
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:80
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:85
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:67
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:72
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:85
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:90
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:68
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:73
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:75
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:82
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:72
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:77
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:70
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:75
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:68
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:73
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:70
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:75
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:73
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:78
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:72
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:77
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:74
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:79
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:80
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:85
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:78
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:83
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:80
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:85
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:67
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:72
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:85
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:90
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:68
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:73
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:75
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:82
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:72
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:77
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:70
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:75
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:68
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:73
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:70
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:75
 msgid "In FY 2024,"
 msgstr "Au cours de l'exercice 2024,"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:173
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:173
 msgid "In FY 2024, 55.2% of CRA net spending was allocated to salaries, benefits, and pensions."
 msgstr "Au cours de l'exercice 2024, 55,2 % des dépenses nettes de l'ARC ont été allouées aux salaires, aux avantages sociaux et aux pensions."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:173
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:173
 msgid "In FY 2024, ESDC transferred 63% of its total spending to individuals and provinces."
 msgstr "Au cours de l'exercice 2024, EDSC a transféré 63 % de ses dépenses totales aux particuliers et aux provinces."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:155
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:155
 msgid "In FY 2024, Finance Canada transferred 66.2% of its total spending to provinces and territories. The chart below outlines all departmental spending in 2024."
 msgstr "Au cours de l'exercice 2024, Finances Canada a transféré 66,2 % de ses dépenses totales aux provinces et aux territoires. Le graphique ci-dessous présente toutes les dépenses ministérielles en 2024."
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:162
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:162
 msgid "In FY 2024, ISC and CIRNAC transferred 93.1% of total spending directly to indigenous communities."
 msgstr "Au cours de l'exercice 2024, SAC et RCAANC ont transféré 93,1 % des dépenses totales directement aux communautés autochtones."
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:146
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:146
 msgid "In FY 2024, Public Safety's budget was allocated across several key areas, including:"
 msgstr "Au cours de l'exercice 2024, le budget de la Sécurité publique a été réparti entre plusieurs domaines clés, notamment :"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:112
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:112
 msgid "In FY 2024, Transport Canada accounted for 1% of all federal spending, 0.74% percentage points lower than in 1995."
 msgstr "Au cours de l'exercice 2024, Transports Canada représentait 1 % des dépenses fédérales totales, soit 0,74 point de pourcentage de moins qu'en 1995."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:155
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:155
 msgid "In FY 2024, VAC reported total expenditures of $6.07 billion across two entities:"
 msgstr "Au cours de l'exercice 2024, ACC a déclaré des dépenses totales de 6,07 milliards de dollars réparties entre deux entités :"
 
@@ -1876,11 +1877,11 @@ msgstr "Indéterminé"
 msgid "Indigenous Priorities"
 msgstr "Priorités autochtones"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:35
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:35
 msgid "Indigenous Services and Northern Affairs Canada | Canada Spends"
 msgstr "Services aux Autochtones et Affaires du Nord Canada | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:55
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:55
 msgid "Indigenous Services Canada (ISC) and Crown-Indigenous Relations and Northern Affairs Canada (CIRNAC) are two distinct federal departments tasked with advancing Indigenous priorities in Canada. Established in 2017 following the dissolution of Indigenous and Northern Affairs Canada (INAC), these departments manage different aspects of Indigenous policy, service delivery, and governance."
 msgstr "Services aux Autochtones Canada (SAC) et Relations Couronne-Autochtones et Affaires du Nord Canada (RCAANC) sont deux ministères fédéraux distincts chargés de faire progresser les priorités autochtones au Canada. Créés en 2017 à la suite de la dissolution d'Affaires autochtones et du Nord Canada (AANC), ces ministères gèrent différents aspects de la politique autochtone, de la prestation de services et de la gouvernance."
 
@@ -1900,19 +1901,19 @@ msgstr "Impôt sur le revenu des particuliers"
 msgid "Individual Income Taxes"
 msgstr "Impôts sur le revenu des particuliers"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:27
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:27
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:27
 msgid "Information"
 msgstr "Information"
 
@@ -1924,16 +1925,16 @@ msgstr "Investissements en infrastructure"
 msgid "Innovation + Research"
 msgstr "Innovation + Recherche"
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:62
 msgid "Innovation, Science and Industry"
 msgstr "Innovation, Sciences et Industrie"
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:171
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:171
 msgid "Innovation, Science and Industry Canada (ISED) is led by the Minister of Innovation, Science and Industry, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 msgstr "Innovation, Sciences et Industrie Canada (ISIC) est dirigé par le ministre de l'Innovation, des Sciences et de l'Industrie, qui est nommé par le gouverneur général sur l'avis du premier ministre et officiellement assermenté à Rideau Hall. Lors de sa nomination, le ministre prête le serment d'office et le serment d'allégeance, devenant membre du Conseil privé du Roi pour le Canada."
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:32
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:32
 msgid "Innovation, Science and Industry Canada | Canada Spends"
 msgstr "Innovation, Sciences et Industrie Canada | Canada Spends"
 
@@ -1958,21 +1959,21 @@ msgstr "Intérêts sur la dette"
 msgid "Interim Housing Assistance"
 msgstr "Aide temporaire au logement"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:71
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:67
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:71
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:67
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:71
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:71
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:71
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:71
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:71
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:71
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:71
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:67
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:71
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:71
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:71
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:71
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:71
 msgid "Internal Revenues"
 msgstr "Revenus internes"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:171
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:171
 msgid "International Advocacy and Diplomacy: $1B"
 msgstr "Plaidoyer international et diplomatie : 1 G$"
 
@@ -1996,11 +1997,11 @@ msgstr "Investissement, croissance et commercialisation"
 msgid "Involved First Nations"
 msgstr "Premières Nations impliquées"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:89
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:89
 msgid "IRCC accounted for 1.2% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 msgstr "IRCC représentait 1,2 % de toutes les dépenses fédérales pour l'exercice 2024. 10 ministères gouvernementaux représentaient 73,2 % des dépenses fédérales pour l'exercice 2024"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:81
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:81
 msgid "IRCC spent $6.3 billion in fiscal year (FY) 2024. This was 1.2% of the $513.9 billion in overall federal spending. The department ranked thirteenth among federal departments in total spending."
 msgstr "IRCC a dépensé 6,3 milliards de dollars au cours de l'exercice 2024. Cela représentait 1,2 % des 513,9 milliards de dollars de dépenses fédérales totales. Le ministère s'est classé treizième parmi les ministères fédéraux en termes de dépenses totales."
 
@@ -2008,23 +2009,23 @@ msgstr "IRCC a dépensé 6,3 milliards de dollars au cours de l'exercice 2024. C
 msgid "Is this a lobby group?"
 msgstr "Est-ce un groupe de pression?"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:182
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:182
 msgid "ISC + CIRNAC, Spending by Entity, FY 2024"
 msgstr "SAC + RCAANC, Dépenses par entité, exercice 2024"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:135
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:135
 msgid "ISC + CIRNAC's share of federal spending in FY 2024 was 592% higher than in FY 1995"
 msgstr "La part des dépenses fédérales de SAC + RCAANC pour l'exercice 2024 était 592 % plus élevée qu'en 1995"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:16
 msgid "ISC and CIRNAC"
 msgstr "SAC et RCAANC"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:65
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:65
 msgid "ISC is responsible for providing essential services to First Nations, Inuit, and Métis communities, including healthcare, education, housing, and child and family services. It also works to transfer control of these services to Indigenous-led organizations. CIRNAC focuses on treaty negotiations, self-government agreements, land claims, and Northern affairs, aiming to strengthen nation-to-nation relationships and modernize Indigenous governance structures. Together, ISC and CIRNAC oversee key programs that impact Indigenous communities across Canada."
 msgstr "SAC est responsable de fournir des services essentiels aux communautés des Premières Nations, des Inuits et des Métis, y compris les soins de santé, l'éducation, le logement et les services à l'enfance et à la famille. Il travaille également à transférer le contrôle de ces services aux organisations dirigées par les Autochtones. RCAANC se concentre sur les négociations de traités, les accords d'autonomie gouvernementale, les revendications territoriales et les affaires du Nord, visant à renforcer les relations de nation à nation et à moderniser les structures de gouvernance autochtone. Ensemble, SAC et RCAANC supervisent des programmes clés qui ont un impact sur les communautés autochtones à travers le Canada."
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:82
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:82
 msgid "ISED spent $10.2 billion in fiscal year (FY) 2024. This was 2% of the $513.9 billion in overall federal spending. The department ranked eleventh among federal departments in total spending."
 msgstr "ISDE a dépensé 10,2 milliards de dollars au cours de l'exercice 2024. Cela représentait 2 % des 513,9 milliards de dollars de dépenses fédérales totales. Le ministère s'est classé onzième parmi les ministères fédéraux en termes de dépenses totales."
 
@@ -2050,7 +2051,7 @@ msgstr "Dates clés"
 msgid "Keywords"
 msgstr "Mots-clés"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:217
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:217
 msgid "Labour Market Development Agreements (LMDAs): federal funding to provinces for job training and employment support."
 msgstr "Ententes sur le développement du marché du travail (EDMT) : financement fédéral aux provinces pour la formation professionnelle et le soutien à l'emploi."
 
@@ -2067,7 +2068,7 @@ msgid "Last Update"
 msgstr "Dernière mise à jour"
 
 #: src/app/[lang]/(main)/budget/page.tsx:248
-#: src/app/[lang]/(main)/federal/budget/page.tsx:285
+#: src/app/[lang]/(main)/federal/budget/page.tsx:287
 msgid "Latest Budget News & Impact"
 msgstr "Dernières nouvelles budgétaires et impact"
 
@@ -2085,40 +2086,40 @@ msgstr "Emplacement"
 msgid "Look back at what {0}'s government made and spent. {1}"
 msgstr "Regardez en arrière ce que le gouvernement de {0} a gagné et dépensé. {1}"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:148
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:148
 msgid "Major international events, trade agreements, foreign aid commitments, and global crises such as the COVID-19 pandemic have influenced fluctuations in spending. In 2020, GAC's budget surged due to emergency international assistance programs, including vaccine distribution and humanitarian relief efforts."
 msgstr "Les événements internationaux majeurs, les accords commerciaux, les engagements d'aide étrangère et les crises mondiales comme la pandémie de COVID-19 ont influencé les fluctuations des dépenses. En 2020, le budget d'AMC a augmenté en raison des programmes d'aide internationale d'urgence, y compris la distribution de vaccins et les efforts d'aide humanitaire."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:124
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:124
 msgid "Major legislation, economic conditions, and external factors can impact ESDC's spending."
 msgstr "Les principales lois, les conditions économiques et les facteurs externes peuvent avoir un impact sur les dépenses d'EDSC."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:120
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:120
 msgid "Major legislation, internal or global economic conditions, and acute events like the COVID-19 pandemic can affect spending year to year. For example, the federal expenses fluctuated during the pandemic, rising from $410.2 billion (in 2024 dollars) in 2019 to $420 billion in 2020 and $720.3 billion in 2021"
 msgstr "Les principales lois, les conditions économiques internes ou mondiales et les événements aigus comme la pandémie de COVID-19 peuvent affecter les dépenses d'une année à l'autre. Par exemple, les dépenses fédérales ont fluctué pendant la pandémie, passant de 410,2 milliards de dollars (en dollars de 2024) en 2019 à 420 milliards en 2020 et 720,3 milliards en 2021"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:131
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:131
 msgid "Major legislation, internal or global economic conditions, and acute events like the COVID-19 pandemic can significantly influence government spending year to year. For example, during the COVID-19 pandemic, federal support programs led to a temporary surge in spending. Health Canada expenditures increased from $5 billion in FY 2019 to $14.2 billion in FY 2021 before stabilizing in recent years."
 msgstr "Les principales lois, les conditions économiques internes ou mondiales et les événements aigus comme la pandémie de COVID-19 peuvent influencer significativement les dépenses gouvernementales d'une année à l'autre. Par exemple, pendant la pandémie de COVID-19, les programmes de soutien fédéraux ont entraîné une augmentation temporaire des dépenses. Les dépenses de Santé Canada sont passées de 5 milliards de dollars pour l'exercice 2019 à 14,2 milliards pour l'exercice 2021 avant de se stabiliser ces dernières années."
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:132
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:117
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:119
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:120
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:118
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:121
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:132
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:117
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:119
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:120
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:118
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:121
 msgid "Major legislation, internal or global economic conditions, and acute events like the COVID-19 pandemic can significantly influence government spending year to year. For instance, during the pandemic, the Government of Canada's total expenses rose from $410.2 billion in 2019 to $420 billion in 2020 and further to $720.3 billion in 2021."
 msgstr "Les principales lois, les conditions économiques internes ou mondiales et les événements aigus comme la pandémie de COVID-19 peuvent influencer significativement les dépenses gouvernementales d'une année à l'autre. Par exemple, pendant la pandémie, les dépenses totales du gouvernement du Canada sont passées de 410,2 milliards de dollars en 2019 à 420 milliards en 2020 et à 720,3 milliards en 2021."
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:159
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:159
 msgid "Major legislation, shifts in international security dynamics, and acute events such as Russia's invasion of Ukraine or Arctic sovereignty disputes can influence military spending."
 msgstr "Les principales lois, les changements dans la dynamique de sécurité internationale et les événements aigus tels que l'invasion de l'Ukraine par la Russie ou les différends sur la souveraineté de l'Arctique peuvent influencer les dépenses militaires."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:129
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:129
 msgid "Major legislative changes, compliance trends, and digital tax services have influenced CRA spending patterns. For example, compliance initiatives and fraud investigations recovered an estimated $11.5 billion in lost revenue in 2024 due to tax evasion."
 msgstr "Les changements législatifs majeurs, les tendances en matière de conformité et les services fiscaux numériques ont influencé les modèles de dépenses de l'ARC. Par exemple, les initiatives de conformité et les enquêtes sur la fraude ont permis de récupérer environ 11,5 milliards de dollars de revenus perdus en 2024 en raison de l'évasion fiscale."
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:125
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:125
 msgid "Major policy shifts, unforeseen events such as natural disasters, and global security concerns can significantly impact the department's annual spending. The COVID-19 pandemic, for example, led to a sharp increase in federal emergency response funding in 2020."
 msgstr "Les changements majeurs de politique, les événements imprévus tels que les catastrophes naturelles et les préoccupations de sécurité mondiale peuvent avoir un impact significatif sur les dépenses annuelles du ministère. La pandémie de COVID-19, par exemple, a entraîné une forte augmentation du financement fédéral d'intervention d'urgence en 2020."
 
@@ -2168,18 +2169,18 @@ msgstr "Mois"
 msgid "More coming soon..."
 msgstr "Plus à venir..."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:167
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:167
 msgid "Most CRA spending is dedicated to personnel and IT infrastructure supporting tax filing, compliance, and benefit administration."
 msgstr "La plupart des dépenses de l'ARC sont consacrées au personnel et à l'infrastructure informatique soutenant la production des déclarations, la conformité et l'administration des prestations."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:155
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:155
 msgid "Most federal spending can be categorized as direct or indirect."
 msgstr "La plupart des dépenses fédérales peuvent être classées comme directes ou indirectes."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:158
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:146
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:153
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:183
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:158
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:146
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:153
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:183
 msgid "Most federal spending can be categorized as direct or indirect. Direct spending refers to money the federal government spends on budget items such as federal programs, employee salaries, and debt interest. Indirect spending refers to federal transfers to other levels of government."
 msgstr "La plupart des dépenses fédérales peuvent être classées comme directes ou indirectes. Les dépenses directes font référence à l'argent que le gouvernement fédéral dépense pour des postes budgétaires tels que les programmes fédéraux, les salaires des employés et les intérêts sur la dette. Les dépenses indirectes font référence aux transferts fédéraux vers d'autres niveaux de gouvernement."
 
@@ -2197,19 +2198,19 @@ msgstr "Nom"
 msgid "National Defence"
 msgstr "Défense nationale"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:35
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:35
 msgid "National Defence | Canada Spends"
 msgstr "Défense nationale | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:107
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:107
 msgid "National Defence accounted for 6.7% of all federal spending in FY 2024"
 msgstr "La Défense nationale représentait 6,7 % de toutes les dépenses fédérales pour l'exercice 2024"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:203
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:203
 msgid "National Defence, Spending by Entity, FY 2024"
 msgstr "Défense nationale, Dépenses par entité, exercice 2024"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:144
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:144
 msgid "National Defence's share of federal spending in FY 2024 was lower than in FY 1995"
 msgstr "La part des dépenses fédérales de la Défense nationale en 2024 était inférieure à celle de 1995"
 
@@ -2287,7 +2288,7 @@ msgid "Newfoundland and Labrador STP"
 msgstr "TPS Terre-Neuve-et-Labrador"
 
 #: src/app/[lang]/(main)/budget/page.tsx:56
-#: src/app/[lang]/(main)/federal/budget/page.tsx:56
+#: src/app/[lang]/(main)/federal/budget/page.tsx:57
 msgid "News Source & Date"
 msgstr "Source d'actualité et date"
 
@@ -2430,59 +2431,59 @@ msgstr "des dépenses municipales de {0} ont été effectuées par {1}"
 msgid "of {0} provincial spending was by {1}"
 msgstr "des dépenses provinciales de {0} ont été effectuées par {1}"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:92
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:92
 msgid "of federal spending was allocated to Indigenous priorities via these Departments. This does not include additional programs in other departments designed specifically for Indigenous beneficiaries."
 msgstr "des dépenses fédérales ont été allouées aux priorités autochtones via ces ministères. Cela n'inclut pas les programmes supplémentaires dans d'autres ministères conçus spécifiquement pour les bénéficiaires autochtones."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:81
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:81
 msgid "of federal spending was by ESDC"
 msgstr "des dépenses fédérales ont été effectuées par EDSC"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:79
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:79
 msgid "of federal spending was by Finance Canada"
 msgstr "des dépenses fédérales ont été effectuées par Finances Canada"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:85
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:85
 msgid "of federal spending was by Health Canada"
 msgstr "des dépenses fédérales ont été effectuées par Santé Canada"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:87
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:87
 msgid "of federal spending was by Housing, Infrastructure and Communities Canada"
 msgstr "des dépenses fédérales ont été effectuées par Logement, Infrastructure et Collectivités Canada"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:77
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:77
 msgid "Of federal spending was by Public Services and Procurement Canada"
 msgstr "des dépenses fédérales ont été effectuées par Services publics et Approvisionnement Canada"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:80
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:80
 msgid "of federal spending was by the Canada Revenue Agency"
 msgstr "des dépenses fédérales ont été effectuées par l'Agence du revenu du Canada"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:85
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:85
 msgid "of federal spending was by the Department of National Defence"
 msgstr "des dépenses fédérales étaient du ministère de la Défense nationale"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:74
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:74
 msgid "Of federal spending was by the Dept. of Immigration, Refugees and Citizenship"
 msgstr "des dépenses fédérales ont été effectuées par le ministère de l'Immigration, des Réfugiés et de la Citoyenneté"
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:75
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:75
 msgid "Of federal spending was by the Dept. of Innovation, Science and Industry"
 msgstr "des dépenses fédérales ont été effectuées par le ministère de l'Innovation, des Sciences et de l'Industrie"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:75
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:75
 msgid "Of federal spending was by the Dept. of Transport"
 msgstr "des dépenses fédérales ont été effectuées par le ministère des Transports"
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:77
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:77
 msgid "Of federal spending was by the Dept. of Veterans Affairs"
 msgstr "des dépenses fédérales ont été effectuées par le ministère des Anciens Combattants"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:87
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:87
 msgid "of federal spending was by the Global Affairs Canada"
 msgstr "des dépenses fédérales ont été effectuées par Affaires mondiales Canada"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:79
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:79
 msgid "of federal spending was by the Public Safety Canada"
 msgstr "des dépenses fédérales ont été effectuées par Sécurité publique Canada"
 
@@ -2494,7 +2495,7 @@ msgstr "Bureau du directeur général des élections"
 msgid "Office of the Secretary to the Governor General"
 msgstr "Bureau du secrétaire du gouverneur général"
 
-#: src/app/[lang]/(main)/federal/budget/page.tsx:168
+#: src/app/[lang]/(main)/federal/budget/page.tsx:170
 msgid "Official Fall 2025 Federal Budget Released"
 msgstr "Publication du budget fédéral officiel de l'automne 2025"
 
@@ -2532,7 +2533,7 @@ msgid "Open Tor Browser and wait for it to connect."
 msgstr "Ouvrez le navigateur Tor et attendez qu'il se connecte."
 
 #: src/app/[lang]/(main)/budget/page.tsx:195
-#: src/app/[lang]/(main)/federal/budget/page.tsx:232
+#: src/app/[lang]/(main)/federal/budget/page.tsx:234
 msgid "Operational Spend"
 msgstr "Dépenses opérationnelles"
 
@@ -2544,7 +2545,7 @@ msgstr "ou abonnez-vous à"
 msgid "Organization"
 msgstr "Organisation"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/MiniSankey.tsx:35
 #: src/components/Sankey/index.tsx:319
 msgid "Other"
 msgstr "Autre"
@@ -2576,7 +2577,7 @@ msgstr "Autres programmes environnementaux et de changement climatique"
 msgid "Other Excise Taxes and Duties"
 msgstr "Autres taxes et droits d'accise"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/MiniSankey.tsx:39
 msgid "Other expenditures"
 msgstr "Autres dépenses"
 
@@ -2632,22 +2633,22 @@ msgstr "Autres services publics + Approvisionnement"
 msgid "Other Settlement Agreements"
 msgstr "Autres accords de règlement"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:63
 msgid "Other subsidies and payments"
 msgstr "Autres subventions et paiements"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:55
 msgid "Other Subsidies and Payments"
 msgstr "Autres subventions et paiements"
 
@@ -2685,7 +2686,7 @@ msgstr "Parlement"
 msgid "Payment Amount"
 msgstr "Montant du paiement"
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:348
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:354
 msgid "Payroll Contributions"
 msgstr "Cotisations salariales"
 
@@ -2693,7 +2694,7 @@ msgstr "Cotisations salariales"
 msgid "Payroll Taxes"
 msgstr "Charges sociales"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:237
+#: src/app/[lang]/(main)/federal/spending/page.tsx:238
 #: src/app/[lang]/(main)/spending/page.tsx:228
 msgid "PBO"
 msgstr "DPB"
@@ -2707,43 +2708,43 @@ msgstr "Dépenses par habitant"
 msgid "per resident"
 msgstr "par résident"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:148
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:148
 msgid "Percentage of federal budget dedicated to Canada Revenue Agency, FYs 1995-2024"
 msgstr "Pourcentage du budget fédéral consacré à l'Agence du revenu du Canada, exercices 1995-2024"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:152
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:152
 msgid "Percentage of federal budget dedicated to Defence, FYs 1995-2024"
 msgstr "Pourcentage du budget fédéral consacré à la Défense, exercices 1995-2024"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:146
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:146
 msgid "Percentage of federal budget dedicated to ESDC, FYs 1995-2024 (inflation-adjusted)"
 msgstr "Pourcentage du budget fédéral consacré à EDSC, exercices 1995-2024 (ajusté à l'inflation)"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:138
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:138
 msgid "Percentage of federal budget dedicated to Finance, FYs 1995-2024"
 msgstr "Pourcentage du budget fédéral consacré à Finances, exercices 1995-2024"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:131
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:131
 msgid "Percentage of federal budget dedicated to Global Affairs Canada, FYs 1995-2024"
 msgstr "Pourcentage du budget fédéral consacré à Affaires mondiales Canada, exercices 1995-2024"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:141
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:141
 msgid "Percentage of federal budget dedicated to Indigenous Priorities, FYs 1995-2024"
 msgstr "Pourcentage du budget fédéral consacré aux priorités autochtones, exercices 1995-2024"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:19
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:19
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:19
 msgid "Personnel"
 msgstr "Personnel"
 
@@ -2798,22 +2799,22 @@ msgstr "Chercheur principal"
 msgid "Privy Council Office"
 msgstr "Bureau du Conseil privé"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:31
 msgid "Professional + Special Services"
 msgstr "Services professionnels + spéciaux"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:31
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:31
 msgid "Professional and Special Services"
 msgstr "Services professionnels et spéciaux"
 
@@ -2830,12 +2831,12 @@ msgid "Project Number"
 msgstr "Numéro de projet"
 
 #: src/app/[lang]/(main)/budget/page.tsx:206
-#: src/app/[lang]/(main)/federal/budget/page.tsx:243
+#: src/app/[lang]/(main)/federal/budget/page.tsx:245
 msgid "Projected capital investments"
 msgstr "Investissements en capital projetés"
 
 #: src/app/[lang]/(main)/budget/page.tsx:197
-#: src/app/[lang]/(main)/federal/budget/page.tsx:234
+#: src/app/[lang]/(main)/federal/budget/page.tsx:236
 msgid "Projected operational spending"
 msgstr "Dépenses opérationnelles projetées"
 
@@ -2873,11 +2874,11 @@ msgstr "Provincial"
 msgid "Provincial Tax"
 msgstr "Impôt provincial"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:92
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:92
 msgid "PSPC accounted for 1.6% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 msgstr "SPAC représentait 1,6 % de toutes les dépenses fédérales pour l'exercice 2024. 10 ministères gouvernementaux représentaient 73,2 % des dépenses fédérales pour l'exercice 2024"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:84
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:84
 msgid "PSPC spent $8.3 billion in fiscal year (FY) 2024. This was 1.6% of the $513.9 billion in overall federal spending. The department ranked twelfth among federal departments in total spending."
 msgstr "SPAC a dépensé 8,3 milliards de dollars au cours de l'exercice 2024. Cela représentait 1,6 % des 513,9 milliards de dollars de dépenses fédérales totales. Le ministère s'est classé douzième parmi les ministères fédéraux en termes de dépenses totales."
 
@@ -2887,19 +2888,19 @@ msgstr "SPAC a dépensé 8,3 milliards de dollars au cours de l'exercice 2024. C
 msgid "Public Accounts of {0} FY {1}"
 msgstr "Comptes publics de {0} exercice {1}"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:59
 msgid "Public debt charges"
 msgstr "Frais de la dette publique"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:63
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:59
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:63
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:59
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:59
 #: src/components/Sankey/BudgetSankey.tsx:427
 msgid "Public Debt Charges"
 msgstr "Frais de la dette publique"
@@ -2912,20 +2913,20 @@ msgstr "Santé publique + Prévention des maladies"
 msgid "Public Safety"
 msgstr "Sécurité publique"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:50
 msgid "Public Safety Canada"
 msgstr "Sécurité publique Canada"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:34
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:34
 msgid "Public Safety Canada | Canada Spends"
 msgstr "Sécurité publique Canada | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:86
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:86
 msgid "Public Safety Canada spent $13.9 billion in fiscal year (FY) 2024, accounting for 2.7% of the $513.9 billion in total federal spending. While not among the largest departments by expenditure, Public Safety Canada plays a crucial role in national security and emergency management, working in tandem with multiple agencies to mitigate threats and enhance public safety."
 msgstr "Sécurité publique Canada a dépensé 13,9 milliards de dollars au cours de l'exercice 2024, soit 2,7 % des 513,9 milliards de dollars de dépenses fédérales totales. Bien qu'il ne figure pas parmi les plus grands ministères en termes de dépenses, Sécurité publique Canada joue un rôle crucial dans la sécurité nationale et la gestion des urgences, travaillant en tandem avec plusieurs organismes pour atténuer les menaces et améliorer la sécurité publique."
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:52
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:52
 msgid "Public Safety, Democratic Institutions and Intergovernmental Affairs Canada (Public Safety Canada) is the federal department responsible for national security, emergency preparedness, and community safety. Established in 2003, it consolidates security, law enforcement, and emergency management functions. It includes the RCMP, CSIS, and CBSA and coordinates federal responses to threats and develops policies on crime prevention, cyber resilience, and disaster preparedness while overseeing intelligence-sharing with domestic and international partners."
 msgstr "Sécurité publique, Institutions démocratiques et Affaires intergouvernementales Canada (Sécurité publique Canada) est le ministère fédéral responsable de la sécurité nationale, de la préparation aux urgences et de la sécurité communautaire. Établi en 2003, il regroupe les fonctions de sécurité, d'application de la loi et de gestion des urgences. Il comprend la GRC, le SCRS et l'ASFC et coordonne les réponses fédérales aux menaces et élabore des politiques sur la prévention du crime, la cyber-résilience et la préparation aux catastrophes tout en supervisant le partage de renseignements avec les partenaires nationaux et internationaux."
 
@@ -2933,16 +2934,16 @@ msgstr "Sécurité publique, Institutions démocratiques et Affaires intergouver
 msgid "Public Service Employees"
 msgstr "Employés de la fonction publique"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:68
 msgid "Public Services and Procurement Canada"
 msgstr "Services publics et Approvisionnement Canada"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:177
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:177
 msgid "Public Services and Procurement Canada (PSPC) is led by the Minister of Government Transformation, Public Services and Procurement, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 msgstr "Services publics et Approvisionnement Canada (SPAC) est dirigé par le ministre de la Transformation gouvernementale, des Services publics et de l'Approvisionnement, qui est nommé par le gouverneur général sur l'avis du premier ministre et officiellement assermenté à Rideau Hall. Lors de sa nomination, le ministre prête le serment d'office et le serment d'allégeance, devenant membre du Conseil privé du Roi pour le Canada."
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:32
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:32
 msgid "Public Services and Procurement Canada | Canada Spends"
 msgstr "Services publics et Approvisionnement Canada | Canada Spends"
 
@@ -2950,7 +2951,7 @@ msgstr "Services publics et Approvisionnement Canada | Canada Spends"
 msgid "Public Works + Government Services"
 msgstr "Travaux publics + Services gouvernementaux"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/MiniSankey.tsx:31
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/MiniSankey.tsx:31
 msgid "Quebec abatement"
 msgstr "Abattement du Québec"
 
@@ -2989,7 +2990,7 @@ msgid "Ready Forces"
 msgstr "Forces prêtes"
 
 #: src/app/[lang]/(main)/budget/page.tsx:251
-#: src/app/[lang]/(main)/federal/budget/page.tsx:288
+#: src/app/[lang]/(main)/federal/budget/page.tsx:290
 msgid "Recent developments and their projected impact on the Fall 2025 Budget"
 msgstr "Développements récents et leur impact projeté sur le budget de l'automne 2025"
 
@@ -3015,38 +3016,38 @@ msgstr "Rémunération"
 msgid "Remuneration and Expenses"
 msgstr "Rémunération et dépenses"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:35
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:35
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:35
 msgid "Rentals"
 msgstr "Locations"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:39
 msgid "Repair + Maintenance"
 msgstr "Réparation + Entretien"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:39
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:39
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:39
 msgid "Repair and Maintenance"
 msgstr "Réparation et entretien"
 
@@ -3077,7 +3078,7 @@ msgid "Return on Investments"
 msgstr "Rendement des investissements"
 
 #: src/app/[lang]/(main)/budget/page.tsx:184
-#: src/app/[lang]/(main)/federal/budget/page.tsx:221
+#: src/app/[lang]/(main)/federal/budget/page.tsx:223
 #: src/components/Sankey/BudgetSankey.tsx:456
 #: src/components/Sankey/index.tsx:700
 msgid "Revenue"
@@ -3099,7 +3100,7 @@ msgstr "Sécurité"
 msgid "Salaries, honoraria, travel, and other expenses paid to elected officials and senior employees during fiscal year {fiscalYear}."
 msgstr "Salaires, honoraires, déplacements et autres dépenses versés aux élus et aux cadres supérieurs au cours de l'exercice financier {fiscalYear}."
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:247
+#: src/app/[lang]/(main)/federal/spending/page.tsx:248
 #: src/app/[lang]/(main)/spending/page.tsx:238
 msgid "Salary Distribution"
 msgstr "Répartition des salaires"
@@ -3152,7 +3153,7 @@ msgstr "Comité de sélection"
 msgid "Selection Mechanism"
 msgstr "Mécanisme de sélection"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:205
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:205
 msgid "Service Canada: responsible for processing EI, CPP, and OAS benefits."
 msgstr "Service Canada : responsable du traitement des prestations d'AE, du RPC et de la SV."
 
@@ -3185,23 +3186,23 @@ msgstr "Affichage de {0} sur {1} Premières Nations"
 msgid "Showing {0} of {1} results"
 msgstr "Affichage de {0} sur {1} résultats"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:142
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:142
 msgid "Similarly, HICC expenditures experienced notable fluctuations during this period, surging from approximately $5.9 billion​ in 2019 (adjusted for inflation) to $14.5B in 2024."
 msgstr "De même, les dépenses de HICC ont connu des fluctuations notables au cours de cette période, passant d'environ 5,9 milliards de dollars en 2019 (ajusté à l'inflation) à 14,5 milliards de dollars en 2024."
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:127
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:127
 msgid "Similarly, IRCC's expenditures experienced notable fluctuations during this period, surging from approximately $3.02 billion​ in 2019 to $6.3 billion in 2024."
 msgstr "De même, les dépenses d'IRCC ont connu des fluctuations notables au cours de cette période, passant d'environ 3,02 milliards de dollars en 2019 à 6,3 milliards de dollars en 2024."
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:129
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:129
 msgid "Similarly, ISED's expenditures have increased during this period, growing from approximately $6.5 billion​ in 2019 (adjusted for inflation) to $10.2 billion in 2024."
 msgstr "De même, les dépenses d'ISIC ont augmenté au cours de cette période, passant d'environ 6,5 milliards de dollars en 2019 (ajusté à l'inflation) à 10,2 milliards de dollars en 2024."
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:130
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:130
 msgid "Similarly, PSPC's expenditures experienced notable fluctuations during this period, decreasing from approximately $6.8 billion​ in 2019 (adjusted for inflation) to $5.3 billion in 2021 before increasing again in 2024."
 msgstr "De même, les dépenses de SPAC ont connu des fluctuations notables au cours de cette période, diminuant d'environ 6,8 milliards de dollars en 2019 (ajusté à l'inflation) à 5,3 milliards de dollars en 2021 avant d'augmenter à nouveau en 2024."
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:128
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:128
 msgid "Similarly, Transport Canada's expenditures experienced fluctuations during this period, increasing from approximately $3.2 billion​ in 2019 (adjusted for inflation) to $5.1B in 2024."
 msgstr "De même, les dépenses de Transports Canada ont connu des fluctuations au cours de cette période, passant d'environ 3,2 milliards de dollars en 2019 (ajusté à l'inflation) à 5,1 milliards de dollars en 2024."
 
@@ -3224,21 +3225,21 @@ msgstr "Source"
 msgid "Source PDF"
 msgstr "PDF source"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:260
+#: src/app/[lang]/(main)/federal/spending/page.tsx:261
 #: src/app/[lang]/(main)/spending/page.tsx:251
 msgid "Source:"
 msgstr "Source :"
 
 #: src/app/[lang]/(main)/budget/page.tsx:267
-#: src/app/[lang]/(main)/federal/budget/page.tsx:304
-#: src/app/[lang]/(main)/federal/spending/page.tsx:275
+#: src/app/[lang]/(main)/federal/budget/page.tsx:306
+#: src/app/[lang]/(main)/federal/spending/page.tsx:276
 #: src/app/[lang]/(main)/spending/page.tsx:266
 #: src/components/first-nations/FirstNationsPageContent.tsx:473
 #: src/components/JurisdictionPageContent.tsx:504
 msgid "Sources"
 msgstr "Sources"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:235
+#: src/app/[lang]/(main)/federal/spending/page.tsx:236
 #: src/app/[lang]/(main)/spending/page.tsx:226
 #: src/components/JurisdictionPageContent.tsx:436
 #: src/components/JurisdictionPageContent.tsx:451
@@ -3260,11 +3261,11 @@ msgstr "La spéculation n'atteint pas le niveau d'une information solide."
 msgid "Spending"
 msgstr "Dépenses"
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:835
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:876
 msgid "Spending Breakdown Coming Soon"
 msgstr "Répartition des dépenses à venir"
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:838
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:879
 msgid "Spending data is not yet available for this province and year combination. The income tax calculation above is still accurate based on {year} tax rates."
 msgstr "Les données de dépenses ne sont pas encore disponibles pour cette combinaison de province et d'année. Le calcul de l'impôt sur le revenu ci-dessus reste exact selon les taux d'imposition de {year}."
 
@@ -3335,7 +3336,7 @@ msgstr "Sous-total - Rémunération"
 msgid "Summary"
 msgstr "Résumé"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:183
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:183
 msgid "Support for Canada's Presence Abroad: $1.23B"
 msgstr "Soutien à la présence du Canada à l'étranger : 1,23 G$"
 
@@ -3376,7 +3377,7 @@ msgstr "Impôt"
 msgid "Tax bracket"
 msgstr "Tranche d'imposition"
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:779
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:820
 msgid "Tax calculations are based on {year} federal and provincial tax brackets."
 msgstr "Les calculs d'impôt sont basés sur les tranches d'imposition fédérales et provinciales de {year}."
 
@@ -3386,7 +3387,7 @@ msgid "Tax Comparison Across Provinces at {0} Income"
 msgstr "Comparaison des impôts entre les provinces pour un revenu de {0}"
 
 #. placeholder {0}: config.year
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:575
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:616
 msgid "Tax Details for {provinceName} ({0})"
 msgstr "Détails fiscaux pour {provinceName} ({0})"
 
@@ -3412,7 +3413,7 @@ msgstr "Durée déterminée"
 msgid "Territorial Formula Financing"
 msgstr "Financement des territoires par formule"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:208
+#: src/app/[lang]/(main)/federal/spending/page.tsx:209
 #: src/app/[lang]/(main)/spending/page.tsx:199
 msgid "The average employee is 43.3 years old"
 msgstr "L'âge moyen des employés est de 43,3 ans"
@@ -3421,19 +3422,19 @@ msgstr "L'âge moyen des employés est de 43,3 ans"
 msgid "The best way to support us is to engage with our content. Like, share, and comment on our posts on social media. Even better, share our work with a friend and encourage them to do the same. Together, we can expand the conversation and reach more people with these important facts."
 msgstr "La meilleure façon de nous soutenir est d'interagir avec notre contenu. Aimez, partagez et commentez nos publications sur les réseaux sociaux. Mieux encore, partagez notre travail avec un ami et encouragez-le à faire de même. Ensemble, nous pouvons élargir la conversation et atteindre plus de gens avec ces faits importants."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:53
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:53
 msgid "The Canada Revenue Agency (CRA) is the federal institution responsible for administering tax laws, enforcing compliance, and delivering key benefit programs to individuals and businesses across Canada. Established in 1999 under the Canada Revenue Agency Act, the CRA operates with a workforce of approximately 59,155 employees (2024) and oversees tax revenues totaling $379 billion annually—which accounts for over 82% of federal revenues. It also administers over $46 billion in benefits and credits to Canadians, including the Canada Child Benefit and the GST/HST credit."
 msgstr "L'Agence du revenu du Canada (ARC) est l'institution fédérale responsable de l'administration des lois fiscales, de l'application de la conformité et de la prestation de programmes de prestations clés aux particuliers et aux entreprises à travers le Canada. Établie en 1999 en vertu de la Loi sur l'Agence du revenu du Canada, l'ARC fonctionne avec un effectif d'environ 59 155 employés (2024) et supervise des recettes fiscales totalisant 379 milliards de dollars annuellement—ce qui représente plus de 82 % des revenus fédéraux. Elle administre également plus de 46 milliards de dollars en prestations et crédits aux Canadiens, y compris l'Allocation canadienne pour enfants et le crédit pour la TPS/TVH."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:212
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:212
 msgid "The Canada Revenue Agency is overseen by the <0>Minister of National Revenue</0>, who is responsible for ensuring tax fairness and benefit program integrity but does not have direct authority over tax law interpretations."
 msgstr "L'Agence du revenu du Canada est supervisée par le <0>ministre du Revenu national</0>, qui est responsable d'assurer l'équité fiscale et l'intégrité des programmes de prestations, mais n'a pas d'autorité directe sur les interprétations des lois fiscales."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:87
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:87
 msgid "The Canada Revenue Agency spent $16.8 billion in fiscal year (FY) 2024, representing 3.2% of the $513.9 billion in total federal spending. The CRA's expenditures primarily support tax administration, benefit program delivery, compliance enforcement, and IT modernization."
 msgstr "L'Agence du revenu du Canada a dépensé 16,8 milliards de dollars au cours de l'exercice 2024, ce qui représente 3,2 % des 513,9 milliards de dollars de dépenses fédérales totales. Les dépenses de l'ARC soutiennent principalement l'administration fiscale, la prestation de programmes de prestations, l'application de la conformité et la modernisation des TI."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:97
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:97
 msgid "The CRA accounted for 3.2% of all federal spending in FY 2024"
 msgstr "L'ARC représentait 3,2 % de toutes les dépenses fédérales pour l'exercice 2024"
 
@@ -3441,83 +3442,83 @@ msgstr "L'ARC représentait 3,2 % de toutes les dépenses fédérales pour l'exe
 msgid "The cumulative surplus accumulated over time from operations."
 msgstr "L'excédent cumulé accumulé au fil du temps à partir des opérations."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:230
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:230
 msgid "The Department is currently led by the <0>Minister of Jobs and Families</0> who is appointed by the Governor General on the advice of the Prime Minister and then formally sworn into office at Rideau Hall. They take the Oath of Office and the Oath of Allegiance and become a member of the King's Privy Council for Canada."
 msgstr "Le ministère est actuellement dirigé par le <0>ministre des Emplois et des Familles</0> qui est nommé par le gouverneur général sur l'avis du premier ministre et ensuite officiellement assermenté à Rideau Hall. Il prête le serment d'office et le serment d'allégeance et devient membre du Conseil privé du Roi pour le Canada."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:202
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:202
 msgid "The Department is led by the <0>Minister of Finance</0>, who is appointed by the Governor General on the advice of the Prime Minister and then formally sworn into office at Rideau Hall. They take the Oath of Office and the Oath of Allegiance and become a member of the King's Privy Council for Canada."
 msgstr "Le ministère est dirigé par le <0>ministre des Finances</0>, qui est nommé par le gouverneur général sur l'avis du premier ministre et ensuite officiellement assermenté à Rideau Hall. Il prête le serment d'office et le serment d'allégeance et devient membre du Conseil privé du Roi pour le Canada."
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:163
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:163
 msgid "The Department is led by the <0>Minister of Public Safety</0>, who is appointed by the Governor General on the advice of the Prime Minister and then formally sworn into office at Rideau Hall. They take the Oath of Office and the Oath of Allegiance and become a member of the King's Privy Council for Canada."
 msgstr "Le ministère est dirigé par le <0>ministre de la Sécurité publique</0>, qui est nommé par le gouverneur général sur l'avis du premier ministre et ensuite officiellement assermenté à Rideau Hall. Il prête le serment d'office et le serment d'allégeance et devient membre du Conseil privé du Roi pour le Canada."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:54
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:54
 msgid "The Department of Finance (Finance Canada) is a central federal department responsible for overseeing the nation's economic and fiscal policies, ensuring financial stability, and managing the government's fiscal framework. Established in 1867 as one of the original departments following Confederation, it advises the Prime Minister and Cabinet on economic matters, develops tax and tariff policies, and prepares the annual federal budget."
 msgstr "Le ministère des Finances (Finances Canada) est un ministère fédéral central responsable de la supervision des politiques économiques et fiscales du pays, d'assurer la stabilité financière et de gérer le cadre fiscal du gouvernement. Établi en 1867 comme l'un des ministères originaux après la Confédération, il conseille le premier ministre et le Cabinet sur les questions économiques, élabore les politiques fiscales et tarifaires, et prépare le budget fédéral annuel."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:97
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:97
 msgid "The Department of Finance accounted for 26.4% of all federal spending in FY 2024."
 msgstr "Le ministère des Finances représentait 26,4 % de toutes les dépenses fédérales pour l'exercice 2024."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:86
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:86
 msgid "The Department of Finance spent $136.1 billion in fiscal year (FY) 2024. This was 26.4% of the $513.9 billion in overall federal spending. The department ranked first among federal departments in total spending."
 msgstr "Le ministère des Finances a dépensé 136,1 milliards de dollars au cours de l'exercice 2024. Cela représentait 26,4 % des 513,9 milliards de dollars de dépenses fédérales totales. Le ministère s'est classé premier parmi les ministères fédéraux en termes de dépenses totales."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:132
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:132
 msgid "The Department of Finance's share of federal spending in FY 2024 was lower than FY 1995."
 msgstr "La part des dépenses fédérales du ministère des Finances pour l'exercice 2024 était inférieure à celle de l'exercice 1995."
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:50
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:50
 msgid "The Department of Immigration, Refugees and Citizenship Canada (IRCC) is the federal department responsible for managing immigration policies, issuing passports, processing visas and permanent residency applications, and supporting newcomers to Canada. It plays a key role in shaping Canada's immigration system, refugee protection policies, and pathways to citizenship."
 msgstr "Le ministère de l'Immigration, des Réfugiés et de la Citoyenneté Canada (IRCC) est le ministère fédéral responsable de la gestion des politiques d'immigration, de la délivrance des passeports, du traitement des demandes de visa et de résidence permanente, et du soutien aux nouveaux arrivants au Canada. Il joue un rôle clé dans l'élaboration du système d'immigration du Canada, des politiques de protection des réfugiés et des voies d'accès à la citoyenneté."
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:50
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:50
 msgid "The Department of Innovation, Science and Industry (ISED) is the federal department responsible for fostering economic growth, technological advancement, and scientific research in Canada. It plays a key role in supporting businesses, funding research and development, and shaping policies that aim to enhance innovation, industrial competitiveness, and the prosperity of the Canadian economy."
 msgstr "Le ministère de l'Innovation, des Sciences et de l'Industrie (ISIC) est le ministère fédéral responsable de favoriser la croissance économique, l'avancement technologique et la recherche scientifique au Canada. Il joue un rôle clé dans le soutien aux entreprises, le financement de la recherche et du développement, et l'élaboration de politiques visant à améliorer l'innovation, la compétitivité industrielle et la prospérité de l'économie canadienne."
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:53
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:53
 msgid "The Department of National Defence (DND) and the Canadian Armed Forces (CAF) are responsible for ensuring Canada's security and defence through military operations, infrastructure management, and personnel support. Established in 1923 under the National Defence Act, DND oversees the defence budget, military procurement, and readiness planning, while the CAF executes domestic and international operations. The department provides strategic defence policy guidance and works with international allies, including NATO and NORAD, to ensure national security. DND also administers military health services, housing programs, and recruitment initiatives to support its personnel."
 msgstr "Le ministère de la Défense nationale (MDN) et les Forces armées canadiennes (FAC) sont responsables d'assurer la sécurité et la défense du Canada par le biais d'opérations militaires, de gestion des infrastructures et de soutien au personnel. Établi en 1923 en vertu de la Loi sur la défense nationale, le MDN supervise le budget de la défense, l'approvisionnement militaire et la planification de la disponibilité opérationnelle, tandis que les FAC exécutent des opérations nationales et internationales. Le ministère fournit des orientations stratégiques en matière de politique de défense et travaille avec des alliés internationaux, y compris l'OTAN et le NORAD, pour assurer la sécurité nationale. Le MDN administre également les services de santé militaires, les programmes de logement et les initiatives de recrutement pour soutenir son personnel."
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:214
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:214
 msgid "The Department of National Defence is led by the <0>Minister of National Defence</0>, who is appointed by the Governor General on the advice of the Prime Minister. The minister is responsible for overseeing national defense policy, military operations, and procurement."
 msgstr "Le ministère de la Défense nationale est dirigé par le <0>ministre de la Défense nationale</0>, qui est nommé par le gouverneur général sur l'avis du premier ministre. Le ministre est responsable de la supervision de la politique de défense nationale, des opérations militaires et de l'approvisionnement."
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:95
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:95
 msgid "The Department of National Defence spent $34.5 billion in fiscal year (FY) 2024. This represented 6.7% of the $513.9 billion in total federal spending. DND ranked among the top federal departments in expenditures, largely driven by personnel costs, military procurement, and operational readiness efforts."
 msgstr "Le ministère de la Défense nationale a dépensé 34,5 milliards de dollars au cours de l'exercice 2024. Cela représentait 6,7 % des 513,9 milliards de dollars de dépenses fédérales totales. Le MDN s'est classé parmi les principaux ministères fédéraux en termes de dépenses, largement motivées par les coûts de personnel, l'approvisionnement militaire et les efforts de disponibilité opérationnelle."
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:51
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:51
 msgid "The Department of Transport (Transport Canada) is the federal department responsible for developing and enforcing transportation policies, regulations, and infrastructure projects to ensure safe and efficient movement of people and goods across Canada. It oversees aviation, rail, marine, and road transportation systems, working to enhance national connectivity and economic growth."
 msgstr "Le ministère des Transports (Transports Canada) est le ministère fédéral responsable de l'élaboration et de l'application des politiques, des règlements et des projets d'infrastructure en matière de transport pour assurer le déplacement sûr et efficace des personnes et des biens à travers le Canada. Il supervise les systèmes de transport aérien, ferroviaire, maritime et routier, travaillant à améliorer la connectivité nationale et la croissance économique."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:51
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:51
 msgid "The Department of Veterans Affairs Canada (VAC) is the federal department responsible for supporting and serving Canadian veterans, active-duty military personnel, and their families. It provides financial assistance, healthcare support, rehabilitation services, and recognition programs to honor the contributions of those who have served in the Canadian Armed Forces. Additionally, the department is responsible for remembrance initiatives that preserve Canada's military history."
 msgstr "Le ministère des Anciens Combattants Canada (ACC) est le ministère fédéral responsable du soutien et du service aux anciens combattants canadiens, au personnel militaire en service actif et à leurs familles. Il fournit une aide financière, un soutien en matière de soins de santé, des services de réadaptation et des programmes de reconnaissance pour honorer les contributions de ceux qui ont servi dans les Forces armées canadiennes. De plus, le ministère est responsable des initiatives de commémoration qui préservent l'histoire militaire du Canada."
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:113
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:113
 msgid "The department's spending grew at a rate significantly higher than overall spending, reflecting shifts in federal priorities. In 2024, ESDC accounted for 18.4% of all federal spending, 16.51 percentage points higher than in 2005."
 msgstr "Les dépenses du ministère ont augmenté à un rythme significativement plus élevé que les dépenses globales, reflétant les changements dans les priorités fédérales. En 2024, EDSC représentait 18,4 % de toutes les dépenses fédérales, soit 16,51 points de pourcentage de plus qu'en 2005."
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:123
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:123
 msgid "The department's spending grew at a rate significantly lower than overall spending, reflecting shifts in federal priorities. In FY 2024, Health Canada accounted for 2.7% of all federal spending, 3.14 percentage points lower than in 1995."
 msgstr "Les dépenses du ministère ont augmenté à un rythme significativement plus faible que les dépenses globales, reflétant les changements dans les priorités fédérales. Au cours de l'exercice 2024, Santé Canada représentait 2,7 % de toutes les dépenses fédérales, soit 3,14 points de pourcentage de moins qu'en 1995."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:113
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:113
 msgid "The department's spending has grown less than overall spending, which means that the department's share of the federal budget has increased. In FY 2024, VAC accounted for 1.1% of all federal spending, about the same share as in 1995."
 msgstr "Les dépenses du ministère ont augmenté moins que les dépenses globales, ce qui signifie que la part du ministère dans le budget fédéral a augmenté. Au cours de l'exercice 2024, ACC représentait 1,1 % de toutes les dépenses fédérales, soit environ la même part qu'en 1995."
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:109
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:109
 msgid "The department's spending has grown more than overall spending, which means that the department's share of the federal budget has increased. In FY 2024, IRCC accounted for 1.2% of all federal spending, 0.8 percentage points higher than in 1995."
 msgstr "Les dépenses du ministère ont augmenté plus que les dépenses globales, ce qui signifie que la part du ministère dans le budget fédéral a augmenté. Au cours de l'exercice 2024, IRCC représentait 1,2 % de toutes les dépenses fédérales, soit 0,8 point de pourcentage de plus qu'en 1995."
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:111
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:111
 msgid "The department's spending has grown more than overall spending, which means that the department's share of the federal budget has increased. In FY 2024, ISED accounted for 2% of all federal spending, 0.17 percentage points higher than in 1995."
 msgstr "Les dépenses du ministère ont augmenté plus que les dépenses globales, ce qui signifie que la part du ministère dans le budget fédéral a augmenté. Au cours de l'exercice 2024, ISIC représentait 2 % de toutes les dépenses fédérales, soit 0,17 point de pourcentage de plus qu'en 1995."
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:112
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:112
 msgid "The department's spending has increased less than overall spending has grown and the department's share of the federal budget has decreased over time. In FY 2024, PSPC accounted for 1.6% of all federal spending, 1 percentage point lower than in 1995."
 msgstr "Les dépenses du ministère ont augmenté moins que les dépenses globales et la part du ministère dans le budget fédéral a diminué au fil du temps. Au cours de l'exercice 2024, SPAC représentait 1,6 % de toutes les dépenses fédérales, soit 1 point de pourcentage de moins qu'en 1995."
 
@@ -3529,51 +3530,51 @@ msgstr "La différence entre les revenus et les dépenses. Un excédent indique 
 msgid "The difference between total revenue and total expenses. A surplus indicates revenue exceeded expenses."
 msgstr "La différence entre les revenus totaux et les dépenses totales. Un excédent indique que les revenus ont dépassé les dépenses."
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:193
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:193
 msgid "The leadership of ISC and CIRNAC are led by the <0>Minister of Indigenous Services Canada</0> and the <1>Minister of Crown-Indigenous Relations and Northern Affairs Canada</1>, respectively. These Ministers are appointed by the Governor General on the advice of the Prime Minister and then formally sworn into office at Rideau Hall. They take the Oath of Office and the Oath of Allegiance and become a member of the King's Privy Council for Canada."
 msgstr "La direction de SAC et RCAANC est assurée respectivement par le <0>ministre des Services aux Autochtones Canada</0> et le <1>ministre des Relations Couronne-Autochtones et des Affaires du Nord Canada</1>. Ces ministres sont nommés par le gouverneur général sur l'avis du premier ministre et sont ensuite officiellement assermentés à Rideau Hall. Ils prêtent le serment d'office et le serment d'allégeance et deviennent membres du Conseil privé du Roi pour le Canada."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:189
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:189
 msgid "The Minister is responsible for overseeing benefits and services for veterans, ensuring their well-being, and leading national remembrance initiatives."
 msgstr "Le ministre est responsable de la supervision des prestations et des services aux anciens combattants, d'assurer leur bien-être et de diriger les initiatives nationales de commémoration."
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:188
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:188
 msgid "The Minister is responsible for overseeing Canada's transportation policies, ensuring safety regulations, investing in infrastructure, and leading climate initiatives related to aviation, rail, marine, and road transportation."
 msgstr "Le ministre est responsable de la supervision des politiques de transport du Canada, d'assurer les règlements de sécurité, d'investir dans l'infrastructure et de diriger les initiatives climatiques liées au transport aérien, ferroviaire, maritime et routier."
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:214
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:214
 msgid "The Minister of Finance is one of the <0>cabinet members</0> who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister takes office and appoints a new cabinet. Outgoing ministers remain in their roles until their successors are sworn in."
 msgstr "Le ministre des Finances est l'un des <0>membres du cabinet</0> qui servent à la discrétion du premier ministre. Leur mandat se termine généralement lorsqu'ils démissionnent, sont remplacés ou lorsqu'un nouveau premier ministre prend ses fonctions et nomme un nouveau cabinet. Les ministres sortants restent en fonction jusqu'à ce que leurs successeurs soient assermentés."
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:181
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:181
 msgid "The Minister of Immigration, Refugees and Citizenship is one of the cabinet members who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister appoints a new cabinet. Outgoing ministers continue in their roles until their successors are sworn in."
 msgstr "Le ministre de l'Immigration, des Réfugiés et de la Citoyenneté est l'un des membres du cabinet qui servent à la discrétion du premier ministre. Leur mandat se termine généralement lorsqu'ils démissionnent, sont remplacés ou lorsqu'un nouveau premier ministre nomme un nouveau cabinet. Les ministres sortants continuent dans leurs rôles jusqu'à ce que leurs successeurs soient assermentés."
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:181
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:181
 msgid "The Minister of Innovation, Science and Industry is one of the cabinet members who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister appoints a new cabinet. Outgoing ministers continue in their roles until their successors are sworn in."
 msgstr "Le ministre de l'Innovation, des Sciences et de l'Industrie est l'un des membres du cabinet qui servent à la discrétion du premier ministre. Leur mandat se termine généralement lorsqu'ils démissionnent, sont remplacés ou lorsqu'un nouveau premier ministre nomme un nouveau cabinet. Les ministres sortants continuent dans leurs rôles jusqu'à ce que leurs successeurs soient assermentés."
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:188
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:188
 msgid "The Minister of Public Services and Procurement is one of the cabinet members who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister appoints a new cabinet. Outgoing ministers continue in their roles until their successors are sworn in."
 msgstr "Le ministre des Services publics et de l'Approvisionnement est l'un des membres du cabinet qui servent à la discrétion du premier ministre. Leur mandat se termine généralement lorsqu'ils démissionnent, sont remplacés ou lorsqu'un nouveau premier ministre nomme un nouveau cabinet. Les ministres sortants continuent dans leurs rôles jusqu'à ce que leurs successeurs soient assermentés."
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:179
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:179
 msgid "The Minister of Transport is one of the cabinet members who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister appoints a new cabinet. Outgoing ministers continue in their roles until their successors are sworn in."
 msgstr "Le ministre des Transports est l'un des membres du cabinet qui servent à la discrétion du premier ministre. Leur mandat se termine généralement lorsqu'ils démissionnent, sont remplacés ou lorsqu'un nouveau premier ministre nomme un nouveau cabinet. Les ministres sortants continuent dans leurs rôles jusqu'à ce que leurs successeurs soient assermentés."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:180
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:180
 msgid "The Minister of Veterans Affairs is one of the cabinet members who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister appoints a new cabinet. Outgoing ministers continue in their roles until their successors are sworn in."
 msgstr "Le ministre des Anciens Combattants est l'un des membres du cabinet qui servent à la discrétion du premier ministre. Leur mandat se termine généralement lorsqu'ils démissionnent, sont remplacés ou lorsqu'un nouveau premier ministre nomme un nouveau cabinet. Les ministres sortants continuent dans leurs rôles jusqu'à ce que leurs successeurs soient assermentés."
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:254
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:254
 msgid "The ministers work alongside the Deputy Minister of Foreign Affairs and the Deputy Minister of International Trade, who manage the department's operational and policy frameworks."
 msgstr "Les ministres travaillent aux côtés du sous-ministre des Affaires étrangères et du sous-ministre du Commerce international, qui gèrent les cadres opérationnels et politiques du ministère."
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:52
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:52
 msgid "The Public Services and Procurement Canada (PSPC) is the federal department responsible for providing centralized procurement, real estate management, pay and pension administration for federal employees, and translation services to the Government of Canada. It ensures that government departments have the goods, services, and infrastructure they need to operate efficiently while maintaining transparency, fairness, and value for taxpayers."
 msgstr "Services publics et Approvisionnement Canada (SPAC) est le ministère fédéral responsable de l'approvisionnement centralisé, de la gestion immobilière, de l'administration de la paye et des pensions pour les employés fédéraux, et des services de traduction pour le gouvernement du Canada. Il s'assure que les ministères gouvernementaux disposent des biens, des services et de l'infrastructure dont ils ont besoin pour fonctionner efficacement tout en maintenant la transparence, l'équité et la valeur pour les contribuables."
 
-#: src/app/[lang]/(main)/federal/budget/page.tsx:194
+#: src/app/[lang]/(main)/federal/budget/page.tsx:196
 msgid "The values you see here are based on the FY 2024 Budget with preliminary updates based on government announcements, memos, and leaks, and are meant to provide a rough idea of the budget. Once the official Fall 2025 Budget is released on November 4th, we will update this page to reflect the official budget."
 msgstr "Les valeurs que vous voyez ici sont basées sur le budget de l'exercice 2024 avec des mises à jour préliminaires basées sur les annonces gouvernementales, les notes de service et les fuites, et sont destinées à donner une idée générale du budget. Une fois le budget officiel de l'automne 2025 publié le 4 novembre, nous mettrons à jour cette page pour refléter le budget officiel."
 
@@ -3581,19 +3582,19 @@ msgstr "Les valeurs que vous voyez ici sont basées sur le budget de l'exercice 
 msgid "Theme"
 msgstr "Thème"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:223
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:242
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:261
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:183
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:194
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:211
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:225
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:175
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:223
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:242
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:261
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:183
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:194
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:211
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:225
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:175
 msgid "These Ministers are some of the <0>cabinet members</0> who serve at the Prime Minister's discretion. Their tenure typically ends when they resign, are replaced, or when a new Prime Minister takes office and appoints a new cabinet. Outgoing ministers remain in their roles until their successors are sworn in."
 msgstr "Ces ministres sont parmi les <0>membres du cabinet</0> qui servent à la discrétion du premier ministre. Leur mandat se termine généralement lorsqu'ils démissionnent, sont remplacés ou lorsqu'un nouveau premier ministre prend ses fonctions et nomme un nouveau cabinet. Les ministres sortants restent en fonction jusqu'à ce que leurs successeurs soient assermentés."
 
 #: src/app/[lang]/(main)/budget/page.tsx:159
-#: src/app/[lang]/(main)/federal/budget/page.tsx:187
+#: src/app/[lang]/(main)/federal/budget/page.tsx:189
 msgid "This page presents the official Fall 2025 Federal Budget as released by the Government of Canada on November 4th, 2025. All data is sourced directly from official government publications and public accounts from the Government of Canada."
 msgstr "Cette page présente le budget fédéral officiel de l'automne 2025 tel que publié par le gouvernement du Canada le 4 novembre 2025. Toutes les données proviennent directement des publications officielles du gouvernement et des comptes publics du gouvernement du Canada."
 
@@ -3605,11 +3606,11 @@ msgstr "Ce tableau a été vérifié."
 msgid "This schedule is unaudited."
 msgstr "Ce tableau n'a pas été vérifié."
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:775
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:816
 msgid "This visualization shows how your income tax contributions are allocated across different government programs and services based on current government spending patterns. Amounts under $20 are grouped into \"Other\" for conciseness."
 msgstr "Cette visualisation montre comment vos contributions d'impôt sur le revenu sont allouées à différents programmes et services gouvernementaux en fonction des modèles de dépenses gouvernementales actuels. Les montants inférieurs à 20 $ sont regroupés dans \"Autre\" pour plus de concision."
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:62
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:62
 msgid "Through the Public Health Agency of Canada (PHAC), Health Canada monitors public health risks, manages disease outbreaks, and promotes health initiatives. It also funds medical research via the Canadian Institutes of Health Research (CIHR) and oversees healthcare services for Indigenous communities."
 msgstr "Par l'intermédiaire de l'Agence de la santé publique du Canada (ASPC), Santé Canada surveille les risques pour la santé publique, gère les éclosions de maladies et fait la promotion d'initiatives en matière de santé. Il finance également la recherche médicale par l'entremise des Instituts de recherche en santé du Canada (IRSC) et supervise les services de santé pour les communautés autochtones."
 
@@ -3622,8 +3623,8 @@ msgid "Tools"
 msgstr "Outils"
 
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:261
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:398
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:509
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:404
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:522
 #: src/components/first-nations/ClaimsTable.tsx:300
 #: src/components/first-nations/RemunerationOverview.tsx:800
 #: src/components/first-nations/RemunerationTable.tsx:139
@@ -3632,7 +3633,7 @@ msgstr "Outils"
 msgid "Total"
 msgstr "Total"
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:542
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:583
 msgid "Total {provinceName} Tax"
 msgstr "Total impôt {provinceName}"
 
@@ -3645,7 +3646,7 @@ msgid "Total assets minus total liabilities. This represents the First Nation's 
 msgstr "Total des actifs moins total des passifs. Ceci représente la situation financière globale de la Première Nation."
 
 #: src/app/[lang]/(main)/budget/page.tsx:175
-#: src/app/[lang]/(main)/federal/budget/page.tsx:212
+#: src/app/[lang]/(main)/federal/budget/page.tsx:214
 msgid "Total Budget"
 msgstr "Budget total"
 
@@ -3665,7 +3666,7 @@ msgstr "Dépenses totales"
 msgid "Total expenses in FY {fiscalYear}"
 msgstr "Dépenses totales pour l'exercice {fiscalYear}"
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:413
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:419
 msgid "Total Federal Tax"
 msgstr "Total impôt fédéral"
 
@@ -3673,7 +3674,7 @@ msgstr "Total impôt fédéral"
 msgid "Total Financial Assets"
 msgstr "Total des actifs financiers"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:171
+#: src/app/[lang]/(main)/federal/spending/page.tsx:172
 #: src/app/[lang]/(main)/spending/page.tsx:162
 msgid "Total full-time equivalents"
 msgstr "Équivalents temps plein totaux"
@@ -3736,7 +3737,7 @@ msgstr "Dépenses totales en {0}"
 msgid "Total Tax"
 msgstr "Impôt total"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:183
+#: src/app/[lang]/(main)/federal/spending/page.tsx:184
 #: src/app/[lang]/(main)/spending/page.tsx:174
 msgid "Total Wages"
 msgstr "Salaires totaux"
@@ -3745,23 +3746,23 @@ msgstr "Salaires totaux"
 msgid "Trade and Investment"
 msgstr "Commerce et investissement"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:174
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:174
 msgid "Trade and Investment: $380.3M"
 msgstr "Commerce et investissement : 380,3 M$"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:51
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:55
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:51
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:55
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:55
 msgid "Transfer Payments"
 msgstr "Paiements de transfert"
 
@@ -3770,24 +3771,24 @@ msgstr "Paiements de transfert"
 msgid "Transfers to Provinces"
 msgstr "Transferts aux provinces"
 
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:86
 msgid "Transport Canada"
 msgstr "Transports Canada"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:33
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:33
 msgid "Transport Canada | Canada Spends"
 msgstr "Transports Canada | Canada Dépense"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:91
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:91
 msgid "Transport Canada accounted for 1% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 msgstr "Transports Canada représentait 1 % de toutes les dépenses fédérales pour l'exercice 2024. 10 ministères gouvernementaux représentaient 73,2 % des dépenses fédérales pour l'exercice 2024"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:169
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:169
 msgid "Transport Canada is led by the Minister of Transport, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 msgstr "Transports Canada est dirigé par le ministre des Transports, qui est nommé par le gouverneur général sur l'avis du premier ministre et officiellement assermenté à Rideau Hall. Lors de sa nomination, le ministre prête le serment d'office et le serment d'allégeance, devenant membre du Conseil privé du Roi pour le Canada."
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:82
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:82
 msgid "Transport Canada spent $5.1 billion in fiscal year (FY) 2024. This was 1% of the $513.9 billion in overall federal spending. The department ranked fourteenth among federal departments in total spending."
 msgstr "Transports Canada a dépensé 5,1 milliards de dollars au cours de l'exercice 2024. Cela représentait 1 % des 513,9 milliards de dollars de dépenses fédérales totales. Le ministère s'est classé quatorzième parmi les ministères fédéraux en termes de dépenses totales."
 
@@ -3795,27 +3796,27 @@ msgstr "Transports Canada a dépensé 5,1 milliards de dollars au cours de l'exe
 msgid "Transportation"
 msgstr "Transport"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:23
 msgid "Transportation + Communication"
 msgstr "Transport + Communication"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:23
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:23
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:23
 msgid "Transportation and Communication"
 msgstr "Transport et Communication"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:241
-#: src/app/[lang]/(main)/federal/spending/page.tsx:262
+#: src/app/[lang]/(main)/federal/spending/page.tsx:242
+#: src/app/[lang]/(main)/federal/spending/page.tsx:263
 #: src/app/[lang]/(main)/spending/page.tsx:232
 #: src/app/[lang]/(main)/spending/page.tsx:253
 #: src/components/Sankey/index.tsx:346
@@ -3826,12 +3827,12 @@ msgstr "Conseil du Trésor"
 msgid "Tribunal Award"
 msgstr "Décision du tribunal"
 
-#: src/app/[lang]/(main)/federal/spending/page.tsx:191
+#: src/app/[lang]/(main)/federal/spending/page.tsx:192
 #: src/app/[lang]/(main)/spending/page.tsx:182
 msgid "Type of Tenure"
 msgstr "Type d'emploi"
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:772
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:813
 msgid "Understanding Your Tax Contribution"
 msgstr "Comprendre votre contribution fiscale"
 
@@ -3839,44 +3840,44 @@ msgstr "Comprendre votre contribution fiscale"
 msgid "Use a computer you trust, not one provided by your employer."
 msgstr "Utilisez un ordinateur en qui vous avez confiance, pas un ordinateur fourni par votre employeur."
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/global-affairs-canada/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/health-canada/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/national-defence/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/public-safety-canada/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/transport-canada/MiniSankey.tsx:43
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/health-canada/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/national-defence/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/transport-canada/MiniSankey.tsx:43
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:43
 msgid "Utilities, Materials and Supplies"
 msgstr "Services publics, matériel et fournitures"
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:92
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:92
 msgid "VAC accounted for 1.2% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 msgstr "ACC représentait 1,2 % de toutes les dépenses fédérales pour l'exercice 2024. 10 ministères gouvernementaux représentaient 73,2 % des dépenses fédérales pour l'exercice 2024"
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:84
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:84
 msgid "VAC spent $6.1 billion in fiscal year (FY) 2024. This was 1.2% of the $513.9 billion in overall federal spending. The department ranked thirteenth among federal departments in total spending."
 msgstr "ACC a dépensé 6,1 milliards de dollars au cours de l'exercice 2024. Cela représentait 1,2 % des 513,9 milliards de dollars de dépenses fédérales totales. Le ministère s'est classé treizième parmi les ministères fédéraux en termes de dépenses totales."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:131
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:131
 msgid "VAC's expenditures also grew slightly during this period, increasing from approximately $5.5B​ in 2019 when adjusted for inflation to $6.3B in 2024."
 msgstr "Les dépenses d'ACC ont également légèrement augmenté pendant cette période, passant d'environ 5,5 milliards de dollars en 2019, après ajustement pour l'inflation, à 6,3 milliards de dollars en 2024."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/MiniSankey.tsx:16
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/MiniSankey.tsx:16
 #: src/hooks/useDepartments.ts:80
 msgid "Veterans Affairs"
 msgstr "Anciens Combattants"
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:170
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:170
 msgid "Veterans Affairs Canada (VAC) is led by the Minister of Veterans Affairs, who is appointed by the Governor General on the advice of the Prime Minister and formally sworn into office at Rideau Hall. Upon appointment, the Minister takes the Oath of Office and the Oath of Allegiance, becoming a member of the King's Privy Council for Canada."
 msgstr "Anciens Combattants Canada (ACC) est dirigé par le ministre des Anciens Combattants, qui est nommé par le gouverneur général sur l'avis du premier ministre et officiellement assermenté à Rideau Hall. Lors de sa nomination, le ministre prête le serment d'office et le serment d'allégeance, devenant membre du Conseil privé du Roi pour le Canada."
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:33
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:33
 msgid "Veterans Affairs Canada | Canada Spends"
 msgstr "Anciens Combattants Canada | Canada Dépense"
 
@@ -3885,12 +3886,12 @@ msgstr "Anciens Combattants Canada | Canada Dépense"
 msgid "View {year} financial statements for {0}{provinceSuffix}. Includes statement of operations, financial position, and remuneration data from the First Nations Financial Transparency Act annual report."
 msgstr "Consultez les états financiers {year} pour {0}{provinceSuffix}. Comprend l'état des résultats, la situation financière et les données de rémunération du rapport annuel de la Loi sur la transparence financière des Premières Nations."
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:744
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:785
 #: src/components/TaxBreakdownAccordion.tsx:100
 msgid "View detailed tax breakdown"
 msgstr "Voir le détail des impôts"
 
-#: src/app/[lang]/(main)/federal/budget/page.tsx:174
+#: src/app/[lang]/(main)/federal/budget/page.tsx:176
 msgid "View Federal 2025 Budget Details"
 msgstr "Voir les détails du budget fédéral 2025"
 
@@ -3908,8 +3909,8 @@ msgid "View source data"
 msgstr "Voir les données sources"
 
 #: src/app/[lang]/(main)/budget/page.tsx:242
-#: src/app/[lang]/(main)/federal/budget/page.tsx:279
-#: src/app/[lang]/(main)/federal/spending/page.tsx:158
+#: src/app/[lang]/(main)/federal/budget/page.tsx:281
+#: src/app/[lang]/(main)/federal/spending/page.tsx:159
 #: src/app/[lang]/(main)/spending/page.tsx:149
 #: src/components/JurisdictionPageContent.tsx:393
 msgid "View this chart in full screen"
@@ -3934,59 +3935,59 @@ msgstr "Vous voulez encore plus d'anonymat?"
 msgid "was spent by {0}"
 msgstr "a été dépensé par {0}"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:76
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:76
 msgid "was spent by ESDC"
 msgstr "a été dépensé par EDSC"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:74
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:74
 msgid "was spent by Finance Canada"
 msgstr "a été dépensé par Finances Canada"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:80
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:80
 msgid "was spent by Health Canada"
 msgstr "a été dépensé par Santé Canada"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:82
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:82
 msgid "was spent by Housing, Infrastructure and Communities Canada"
 msgstr "a été dépensé par Logement, Infrastructure et Collectivités Canada"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:87
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:87
 msgid "was spent by ISC and CIRNAC"
 msgstr "a été dépensé par SAC et RCAANC"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:72
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:72
 msgid "Was spent by Public Services and Procurement Canada"
 msgstr "A été dépensé par Services publics et Approvisionnement Canada"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:75
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:75
 msgid "was spent by the Canada Revenue Agency"
 msgstr "a été dépensé par l'Agence du revenu du Canada"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:78
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:78
 msgid "was spent by the Department of National Defence"
 msgstr "ont été dépensés par le ministère de la Défense nationale"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:69
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:69
 msgid "Was spent by the Dept. of Immigration, Refugees and Citizenship"
 msgstr "A été dépensé par le ministère de l'Immigration, des Réfugiés et de la Citoyenneté"
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:70
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:70
 msgid "Was spent by the Dept. of Innovation, Science and Industry"
 msgstr "A été dépensé par le ministère de l'Innovation, des Sciences et de l'Industrie"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:70
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:70
 msgid "Was spent by the Dept. of Transport"
 msgstr "A été dépensé par le ministère des Transports"
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:72
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:72
 msgid "Was spent by the Dept. of Veterans Affairs"
 msgstr "A été dépensé par le ministère des Anciens Combattants"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:82
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:82
 msgid "was spent by the Global Affairs Canada"
 msgstr "a été dépensé par Affaires mondiales Canada"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:74
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:74
 msgid "was spent by the Public Safety Canada"
 msgstr "a été dépensé par Sécurité publique Canada"
 
@@ -4058,7 +4059,7 @@ msgstr "Quelle est votre méthodologie?"
 msgid "What Makes a Good Tip?"
 msgstr "Qu'est-ce qui fait une bonne information?"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:123
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:123
 msgid "When HICC was founded in FY 2005 as the Office of Infrastructure Canada, the department's spending has grown from $250,000 to over $14 billion, a significant increase in overall spending and mandate. In FY 2024, HICC accounted for 2.8% of all federal spending."
 msgstr "Lorsque LGIC a été fondé au cours de l'exercice 2005 en tant que Bureau de l'infrastructure du Canada, les dépenses du ministère sont passées de 250 000 $ à plus de 14 milliards de dollars, une augmentation significative des dépenses globales et du mandat. Au cours de l'exercice 2024, LGIC représentait 2,8 % de toutes les dépenses fédérales."
 
@@ -4066,16 +4067,16 @@ msgstr "Lorsque LGIC a été fondé au cours de l'exercice 2005 en tant que Bure
 msgid "Where do you get the data on your website?"
 msgstr "D'où proviennent les données sur votre site web?"
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:712
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:766
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:753
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:807
 msgid "Where Your Tax Dollars Go"
 msgstr "Où vont vos dollars d'impôt"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:140
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:140
 msgid "While GAC's spending has increased in real terms, its share of the federal budget has also increased moderately over the past decades. In 2024, GAC accounted for 3.7% of federal spending, compared to 2% in 1995."
 msgstr "Bien que les dépenses d'AMC aient augmenté en termes réels, sa part du budget fédéral a également augmenté modérément au cours des dernières décennies. En 2024, AMC représentait 3,7 % des dépenses fédérales, contre 2 % en 1995."
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:90
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:90
 msgid "While not in the top 10 departments by spend, ISED accounted for 2% of all federal spending in FY 2024. 10 government departments accounted for 73.2% of federal spending in FY 2024"
 msgstr "Bien que ne figurant pas parmi les 10 premiers ministères en termes de dépenses, ISIC représentait 2 % de toutes les dépenses fédérales pour l'exercice 2024. 10 ministères gouvernementaux représentaient 73,2 % des dépenses fédérales pour l'exercice 2024"
 
@@ -4090,59 +4091,59 @@ msgstr "Lanceurs d'alerte"
 msgid "Whistleblowers | Secure Anonymous Tips | Canada Spends"
 msgstr "Lanceurs d'alerte | Informations anonymes sécurisées | Canada Spends"
 
-#: src/app/[lang]/(main)/spending/employment-and-social-development-canada/page.tsx:227
+#: src/app/[lang]/(main)/federal/spending/employment-and-social-development-canada/page.tsx:227
 msgid "Who leads ESDC?"
 msgstr "Qui dirige EDSC?"
 
-#: src/app/[lang]/(main)/spending/global-affairs-canada/page.tsx:224
+#: src/app/[lang]/(main)/federal/spending/global-affairs-canada/page.tsx:224
 msgid "Who leads Global Affairs Canada?"
 msgstr "Qui dirige Affaires mondiales Canada?"
 
-#: src/app/[lang]/(main)/spending/health-canada/page.tsx:167
+#: src/app/[lang]/(main)/federal/spending/health-canada/page.tsx:167
 msgid "Who leads Health Canada?"
 msgstr "Qui dirige Santé Canada?"
 
-#: src/app/[lang]/(main)/spending/housing-infrastructure-communities/page.tsx:175
+#: src/app/[lang]/(main)/federal/spending/housing-infrastructure-communities/page.tsx:175
 msgid "Who leads Housing, Infrastructure and Communities Canada?"
 msgstr "Qui dirige Logement, Infrastructure et Collectivités Canada?"
 
-#: src/app/[lang]/(main)/spending/immigration-refugees-and-citizenship/page.tsx:165
+#: src/app/[lang]/(main)/federal/spending/immigration-refugees-and-citizenship/page.tsx:165
 msgid "Who Leads Immigration, Refugees and Citizenship Canada (IRCC)?"
 msgstr "Qui dirige Immigration, Réfugiés et Citoyenneté Canada (IRCC)?"
 
-#: src/app/[lang]/(main)/spending/innovation-science-and-industry/page.tsx:166
+#: src/app/[lang]/(main)/federal/spending/innovation-science-and-industry/page.tsx:166
 msgid "Who Leads Innovation, Science and Industry Canada (ISED)?"
 msgstr "Qui dirige Innovation, Sciences et Industrie Canada (ISIC)?"
 
-#: src/app/[lang]/(main)/spending/indigenous-services-and-northern-affairs/page.tsx:190
+#: src/app/[lang]/(main)/federal/spending/indigenous-services-and-northern-affairs/page.tsx:190
 msgid "Who leads ISC and CIRNAC?"
 msgstr "Qui dirige SAC et RCAANC?"
 
-#: src/app/[lang]/(main)/spending/public-safety-canada/page.tsx:160
+#: src/app/[lang]/(main)/federal/spending/public-safety-canada/page.tsx:160
 msgid "Who leads Public Safety Canada?"
 msgstr "Qui dirige Sécurité publique Canada?"
 
-#: src/app/[lang]/(main)/spending/public-services-and-procurement-canada/page.tsx:172
+#: src/app/[lang]/(main)/federal/spending/public-services-and-procurement-canada/page.tsx:172
 msgid "Who Leads Public Services and Procurement Canada (PSPC)?"
 msgstr "Qui dirige Services publics et Approvisionnement Canada (SPAC)?"
 
-#: src/app/[lang]/(main)/spending/canada-revenue-agency/page.tsx:209
+#: src/app/[lang]/(main)/federal/spending/canada-revenue-agency/page.tsx:209
 msgid "Who leads the Canada Revenue Agency?"
 msgstr "Qui dirige l'Agence du revenu du Canada?"
 
-#: src/app/[lang]/(main)/spending/department-of-finance/page.tsx:199
+#: src/app/[lang]/(main)/federal/spending/department-of-finance/page.tsx:199
 msgid "Who leads the Department of Finance?"
 msgstr "Qui dirige le ministère des Finances?"
 
-#: src/app/[lang]/(main)/spending/national-defence/page.tsx:211
+#: src/app/[lang]/(main)/federal/spending/national-defence/page.tsx:211
 msgid "Who leads the Department of National Defence?"
 msgstr "Qui dirige le ministère de la Défense nationale?"
 
-#: src/app/[lang]/(main)/spending/transport-canada/page.tsx:166
+#: src/app/[lang]/(main)/federal/spending/transport-canada/page.tsx:166
 msgid "Who Leads Transport Canada?"
 msgstr "Qui dirige Transports Canada?"
 
-#: src/app/[lang]/(main)/spending/veterans-affairs/page.tsx:167
+#: src/app/[lang]/(main)/federal/spending/veterans-affairs/page.tsx:167
 msgid "Who Leads Veterans Affairs Canada (VAC)?"
 msgstr "Qui dirige Anciens Combattants Canada (ACC)?"
 
@@ -4167,7 +4168,7 @@ msgstr "Vous pouvez accéder à notre plateforme de dénonciation directement vi
 msgid "You deserve the facts"
 msgstr "Vous méritez les faits"
 
-#: src/app/[lang]/(main)/tax-visualizer/page.tsx:778
+#: src/app/[lang]/(main)/tax-visualizer/page.tsx:819
 msgid "Your tax contributions are approximated based on employment income. Deductions such as basic personal amount are estimated and included. Other sources of income, such as self-employment, investment income, and capital gains, are not included in the calculations. Deductions such as RRSP and FHSA contributions are also not included."
 msgstr "Vos contributions fiscales sont estimées en fonction de votre revenu d'emploi. Les déductions telles que le montant personnel de base sont estimées et incluses. Les autres sources de revenus, comme le travail autonome, les revenus de placement et les gains en capital, ne sont pas incluses dans les calculs. Les déductions telles que les cotisations au REER et au CELIAPP ne sont pas non plus incluses."
 


### PR DESCRIPTION
## Summary
This PR adds comprehensive support for Quebec-specific payroll deductions and provincial insurance contributions. Quebec residents now correctly pay QPP (Québec Pension Plan) instead of CPP, a reduced EI rate, and QPIP (Québec Parental Insurance Plan) contributions.

## Key Changes

- **QPP Override**: Quebec residents pay QPP (6.40% rate) instead of federal CPP (5.95%), with province-specific YMPE and exemption amounts
- **QPP2 Support**: Added second additional pension contribution (QPP2) for Quebec, introduced in 2024, with 4% rate on earnings between YMPE and YAMPE
- **Reduced EI Rate**: Quebec residents pay a reduced EI rate (1.27–1.32% depending on year) because the province administers its own parental insurance
- **QPIP Contribution**: Added Quebec Parental Insurance Plan (QPIP) as a new provincial-level contribution (0.455–0.494% depending on year)
- **Year-Specific Configs**: Updated Quebec tax configs for 2023, 2024, 2025, and 2026 with verified rates, YMPEs, and maximum insurable earnings from official sources (Revenu Québec, Retraite Québec, Canada.ca)
- **UI Updates**: Modified tax visualizer to display QPP/QPP2 names and rates, reduced EI rate, and QPIP contributions in both federal and provincial tax cards
- **Calculator Logic**: Updated `calculateWithConfig()` to resolve province-level overrides for pension plans, EI, and parental insurance; added parental insurance contribution to total provincial tax
- **Type System**: Extended `ProvincialTaxConfig` and `DetailedTaxCalculation` types to support pension/EI overrides and parental insurance

## Implementation Details

- All Quebec configuration changes include detailed source citations (Revenu Québec, Retraite Québec, Canada.ca, RQAP)
- Pension and EI overrides are resolved at calculation time, allowing other provinces to define their own overrides in the future
- QPIP is treated as a provincial-level contribution (not federal) and included in provincial tax totals
- Comprehensive test suite (`calculator.quebec.test.ts`) verifies QPP, QPP2, reduced EI, and QPIP calculations for multiple years and income levels
- Non-Quebec provinces (e.g., Ontario) continue to use federal CPP and standard EI rates

https://claude.ai/code/session_015fSy1AfA1RQuBkKThVcjiH