### PR TITLE
Apply Nov 2025 Quebec economic update to 2026 QPIP and QPP rates

### DIFF
--- a/src/lib/tax/configs/2026/quebec.ts
+++ b/src/lib/tax/configs/2026/quebec.ts
@@ -3,18 +3,25 @@ import { ProvincialTaxConfig } from "../../types";
 // Sources (verified):
 // - Income tax brackets & basic personal amount: Revenu Québec — Income Tax Rates
 //   https://www.revenuquebec.ca/en/citizens/income-tax-return/completing-your-income-tax-return/income-tax-rates/
-// - QPP YMPE / YAMPE 2026: Retraite Québec / SAI publications
-//   https://saiinc.ca/en/publications/news/quebec-pension-plan-key-data-2026
-//   2026: rate 6.40%, YMPE $74,600, basic exemption $3,500.
-//   Max employee QPP1 = ($74,600 − $3,500) × 6.40% = $4,550.40.
+// - QPP rate / YMPE / YAMPE 2026: Retraite Québec, plus 0.20-percentage-point
+//   reduction to the base QPP contribution rate announced in the November 25,
+//   2025 Update on Québec's Economic and Financial Situation (combined rate
+//   reduced from 10.8% to 10.6%, employee share 5.3% base + 1.0% first
+//   additional = 6.30%).
+//   https://www.quebec.ca/en/news/actualites/detail/update-on-quebecs-economic-and-financial-situation-protecting-our-purchasing-power-and-our-economy-67246
+//   2026: rate 6.30%, YMPE $74,600, basic exemption $3,500.
+//   Max employee QPP1 = ($74,600 − $3,500) × 6.30% = $4,479.30.
 // - QPP2 (second additional): 2026 rate 4% on earnings between YMPE $74,600 and
 //   YAMPE $85,000 (114% of YMPE). Max employee QPP2 = ($85,000 − $74,600) × 4% = $416.00.
 // - EI (Quebec) 2026: Canada.ca — EI premium rates 2026 (Quebec reduced rate)
 //   https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/payroll/payroll-deductions-contributions/employment-insurance-ei/ei-premium-rates-maximums.html
 //   2026 Quebec EI rate 1.30% on max insurable $68,900 → max $895.70.
-// - QPIP (employee) 2026: Conseil de gestion de l’assurance parentale
-//   https://www.rqap.gouv.qc.ca/en/news/reduction-in-premium-rates-for-the-quebec-parental-insurance-plan-in-2026
-//   2026: employee rate 0.455%, max insurable $103,000 → max $468.65.
+// - QPIP (employee) 2026: Update on Québec's Economic and Financial Situation
+//   (November 25, 2025) — total 13% reduction in QPIP premium rates effective
+//   January 1, 2026 (expanded from the initial 8% reduction announced by RQAP
+//   on September 10, 2025).
+//   https://www.quebec.ca/en/news/actualites/detail/update-on-quebecs-economic-and-financial-situation-protecting-our-purchasing-power-and-our-economy-67246
+//   2026: employee rate 0.430%, max insurable $103,000 → max $442.90.
 
 export const QUEBEC_TAX_CONFIG: ProvincialTaxConfig = {
   incomeTax: {
@@ -37,10 +44,10 @@ export const QUEBEC_TAX_CONFIG: ProvincialTaxConfig = {
     type: "capped",
     name: "Québec Pension Plan",
     shortName: "QPP",
-    rate: 0.064,
+    rate: 0.063,
     exemption: 3500,
     maxEarnings: 74600,
-    maxContribution: 4550.4,
+    maxContribution: 4479.3,
   },
   pensionPlanAdditionalOverride: {
     type: "cpp2",
@@ -64,9 +71,9 @@ export const QUEBEC_TAX_CONFIG: ProvincialTaxConfig = {
     type: "capped",
     name: "Québec Parental Insurance Plan",
     shortName: "QPIP",
-    rate: 0.00455,
+    rate: 0.0043,
     exemption: 0,
     maxEarnings: 103000,
-    maxContribution: 468.65,
+    maxContribution: 442.9,
   },
 };


### PR DESCRIPTION
The Update on Québec's Economic and Financial Situation (November 25, 2025) expanded the previously announced 8% QPIP reduction to 13% and cut the QPP base contribution rate by 0.20 percentage points effective January 1, 2026.

- QPIP employee rate: 0.455% → 0.430% (max $442.90 on $103,000)
- QPP employee rate: 6.40% → 6.30% (max $4,479.30 on YMPE $74,600)