### PR TITLE
Add municipal financial statement pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ pnpm install
 pnpm run dev
 ```
 
+Municipal financial statements are loaded server-side from York Factory. Set
+`YORK_FACTORY_API_URL` to override the default production API base (for example,
+run Rails with `bin/rails server -p 3001`, then set
+`YORK_FACTORY_API_URL=http://localhost:3001/api/v1` when starting Canada Spends).
+
 ## Linting
 
 This project uses ESLint with Next.js configuration. Run linting with:

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
+    "dev:municipal": "YORK_FACTORY_API_URL=http://127.0.0.1:3001/api/v1 next dev --turbopack",
     "dev:ntp": "next dev",
     "build": "pnpm extract && pnpm generate-statics && next build",
     "generate-statics": "tsx scripts/generate-statics.ts",
     "start": "next start",
+    "test": "vitest run",
     "lint": "next lint",
     "lint:fix": "next lint --fix",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,css,md}\"",
@@ -91,7 +93,8 @@
     "simple-git-hooks": "^2.13.1",
     "tailwindcss": "^4.1.12",
     "tsx": "^4.20.4",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "vitest": "3.2.4"
   },
   "packageManager": "pnpm@9.5.0+sha512.140036830124618d624a2187b50d04289d5a087f326c9edfc0ccd733d76c4f52c3a313d4fc148794a2a9d81553016004e6742e8cf850670268a7387fc220c903",
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,6 +234,9 @@ importers:
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.1)(tsx@4.20.4)(yaml@2.8.1)
 
 packages:
 
@@ -449,8 +452,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.25.9':
     resolution: {integrity: sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -461,8 +476,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.25.9':
     resolution: {integrity: sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -473,8 +500,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.25.9':
     resolution: {integrity: sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -485,8 +524,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.25.9':
     resolution: {integrity: sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -497,8 +548,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.25.9':
     resolution: {integrity: sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -509,8 +572,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.25.9':
     resolution: {integrity: sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -521,8 +596,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.25.9':
     resolution: {integrity: sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -533,8 +620,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.9':
     resolution: {integrity: sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -545,8 +644,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.9':
     resolution: {integrity: sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -557,8 +668,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.9':
     resolution: {integrity: sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -569,8 +692,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.25.9':
     resolution: {integrity: sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -581,8 +716,20 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.25.9':
     resolution: {integrity: sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -593,8 +740,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.25.9':
     resolution: {integrity: sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1054,6 +1213,12 @@ packages:
       '@types/react':
         optional: true
 
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [x64]
+    os: [linux]
+
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
@@ -1510,6 +1675,131 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@rollup/rollup-android-arm-eabi@4.63.1':
+    resolution: {integrity: sha512-UZ8sUxPTiHWYX9QNdJedb1kDZSpS1t/VPWBWGSgqHNi9w3Cu6IXvu2mzbhiTiPvtrqgTQJ+zqiAq2iPIPilpaQ==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.63.1':
+    resolution: {integrity: sha512-cQ4nFQABN5cDvDpbvJ7bMStCpnaVxynZrRMfUJYgxcIk9Sh54FIO1vtfkg0B69REjER77ioZ/ov+eAApx/KmLQ==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.63.1':
+    resolution: {integrity: sha512-FQNqd1lRy/0QhDk3xeRIkSBiCpXCiDnZO3YLVdcDKN1UBiKToNftCzcXYNLshmPDUMlu2TdeS8tGcsU6f3YF1Q==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.63.1':
+    resolution: {integrity: sha512-pvD16V939D3CloK0+qikpGaxiPrDUXTe7Y5cWOMkMSy7m1cawa8EGy/kXYi/G/cKAC4HDAbSnzCIk1WmsoOKXg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.63.1':
+    resolution: {integrity: sha512-pcFGeL2345VwdTnJhA6zLbew+YgWB0qBG2+dMtXjCicf6+rm6kO6cOoh5VnTe0ZMrMRgRyuHmCJxZWrIdzYuOw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.63.1':
+    resolution: {integrity: sha512-mRJlqSRulVzcKq/LKA6ICSIc3K/l4fzlVn/gePn2nXIHy8seRi5z/eeRE0d/XMBxcMldiXtQTSpRj0tkkC3g8Q==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.63.1':
+    resolution: {integrity: sha512-YDUNvVM85TI3g/1OpnqKP1h4NeW/j64DfWMf+G3M809xNk1bJSnpFp4sh83NpmVE5DXnkh8ULor4LTVZKoYLHw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.63.1':
+    resolution: {integrity: sha512-7Mcn71p9ZuQFAj+h+dhQXy/yeLePRS2yKRnmW1DijA9thKO5qap0GNOIQK4yQ6iP3SU0Mrb/yWo8h8vgRba8lw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.63.1':
+    resolution: {integrity: sha512-4YiLQTX6U4CSl0L9cluep9A9W6UmTfqBDc2/CH6wlu54pl4E7Jn3cOD8oxzvBDEGk/JMKgJ47C8g+radF7mwvg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.63.1':
+    resolution: {integrity: sha512-2ra8F7w8OquwZN9z2/fKFnli69wa8PLwaVzRMIPGb13ByMJwC28Fbp8YcVGoUhlYMTt7j5j9bNgpysrN2UM+vw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.63.1':
+    resolution: {integrity: sha512-Sy20ncyhjmBP0Ml+UvQbimjlk6VFgjW5uNP+qqwHB00mTE8Bl2C1TuHTlRwK2YoXeZbee5lP2XevBWVkAQAtSQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.63.1':
+    resolution: {integrity: sha512-noITLp8oNjYliPnGWmLyelIHwULGqbHloQHGw1rtxbWhTuWooRpnZarZQJ1y9EUC4szuCusCc+HEpUtxpIwYvA==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.63.1':
+    resolution: {integrity: sha512-hlxxXd+F1mWiAcaFR7Sv9ZQT6m6UfI8+Vy/kFJzztq2pDMU/0wZ9sish0iszNZvsQDo8Gc0i5yuFEOz5dDf6fA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.63.1':
+    resolution: {integrity: sha512-EF7OpqQTQ/BvGqLzUi4rEHuagCV9MugAUXSHemwPW5vxZ75RR+jxO/2j95Ph2dalMpFHSVECjRoioHZgA9zOYA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.63.1':
+    resolution: {integrity: sha512-wQO3JesW9PRkwlabQ27y7sPfVOOTLRG73I4F2UYHG5PXun3J9U3y+b7ezVKSYbsvSKGQ1k1cq8Qlun4C9kLt3w==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.63.1':
+    resolution: {integrity: sha512-ouAGwhO6wHRXdnOVCOsB0tRFkA7nhNB2Nwax6oECXN0YiN8EYUTBAOudADOB1PI+yDL61TeNx/u7MVCzksNbkQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.63.1':
+    resolution: {integrity: sha512-q2R38Sn+1J8RxhfJ+T54wSWmyKXWec+9jgDfqO2AtArEqHO5R2aeayp5H5OYLr5UYDVGsVaZPEFUooMhYCdz5A==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.63.1':
+    resolution: {integrity: sha512-gfI5T24WLLuFfSKw7Go/zDXjAAV0fny0swTaDv+WjK7vqcw4cRhFfdsyKL1n+ukI+ooBxn3bVQnyrn06WpI50w==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.63.1':
+    resolution: {integrity: sha512-4h6XqthmB4Hspji84wvgk+ElodTsGj+dbZqHJHHtKxj4mYq0ANSEEPX9ys3moJueqsRjwpaJYH7874Itwnj2ow==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.63.1':
+    resolution: {integrity: sha512-dlfCOa87o1VAYegLQ9EKilx2JCeRofiyPGhTCmqnuXZ6bMPiycO1rq1+sKoulAp7pGLIsTIw+1x5R+zgh5LhhA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.63.1':
+    resolution: {integrity: sha512-cjkLbOlfcm3QGhMM1J5zaZjsw1GggbN6rw9UTSSRrPrR1KkcXnN7Uq9rPw34xImQ9VOY9GN+6u2Zj80B9ptkcw==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.63.1':
+    resolution: {integrity: sha512-Li1KdUnWGE4N3e1F/B4RTB1ms+nG4WBgjByO46pkeBVX/2UBsY53xf5vK9WygVmnH3RwncIST7lkSdLSY6P9lg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.63.1':
+    resolution: {integrity: sha512-t4ZYOSoLTgwhuFMrmTMLx/+i1DQVK7HYqMc6kY46EApwi8X0nIVphzdNoThU3xt6n+N5urG1/gxBdCaKDLavfg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.63.1':
+    resolution: {integrity: sha512-RgroPfMmKlD1RzSDxvwgcPiy2HNQKoYV7OmwIXDsk73uKW5t6B/V8KIy27SMv/FNXFo/oSBtWc9J0X7t91ezZg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.63.1':
+    resolution: {integrity: sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==}
+    cpu: [x64]
+    os: [win32]
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -1639,6 +1929,9 @@ packages:
   '@tybys/wasm-util@0.10.0':
     resolution: {integrity: sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/d3-array@3.2.1':
     resolution: {integrity: sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==}
 
@@ -1735,6 +2028,9 @@ packages:
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/dom-speech-recognition@0.0.1':
     resolution: {integrity: sha512-udCxb8DvjcDKfk1WTBzDsxFbLgYxmQGKrE/ricoMqHRNjSlSUCcamVTA5lIQqzY10mY5qCY0QDwBfFEwhfoDPw==}
 
@@ -1749,6 +2045,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
@@ -1986,6 +2285,38 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/pretty-format@3.2.7':
+    resolution: {integrity: sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
 
@@ -2161,6 +2492,10 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
@@ -2243,6 +2578,10 @@ packages:
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -2269,6 +2608,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -2288,6 +2631,10 @@ packages:
 
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@3.5.1:
     resolution: {integrity: sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==}
@@ -2580,6 +2927,10 @@ packages:
   decode-named-character-reference@1.2.0:
     resolution: {integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==}
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -2706,6 +3057,11 @@ packages:
 
   esbuild@0.25.9:
     resolution: {integrity: sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2887,6 +3243,10 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
   extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
     engines: {node: '>=0.10.0'}
@@ -2923,6 +3283,15 @@ packages:
 
   fdir@6.4.6:
     resolution: {integrity: sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -3378,6 +3747,9 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
     hasBin: true
@@ -3559,6 +3931,9 @@ packages:
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   lru-cache@11.1.0:
     resolution: {integrity: sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==}
@@ -3944,6 +4319,13 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -3953,6 +4335,10 @@ packages:
 
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  picomatch@4.0.7:
+    resolution: {integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==}
     engines: {node: '>=12'}
 
   pidtree@0.6.0:
@@ -4262,6 +4648,11 @@ packages:
   robust-predicates@3.0.2:
     resolution: {integrity: sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==}
 
+  rollup@4.63.1:
+    resolution: {integrity: sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -4355,6 +4746,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -4412,6 +4806,12 @@ packages:
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -4481,6 +4881,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   style-to-js@1.1.18:
     resolution: {integrity: sha512-JFPn62D4kJaPTnhFUI244MThx+FEGbi+9dw1b9yBBQ+1CZpV7QAT8kUtJ7b7EUNdHajjF/0x8fT+16oLJoojLg==}
@@ -4563,9 +4966,31 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyglobby@0.2.14:
     resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -4744,6 +5169,79 @@ packages:
   victory-vendor@36.9.2:
     resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.6:
+    resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   watchpack@2.4.4:
     resolution: {integrity: sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==}
     engines: {node: '>=10.13.0'}
@@ -4802,6 +5300,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -5154,79 +5657,157 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.9':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.2':
+    optional: true
+
   '@esbuild/android-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.2':
     optional: true
 
   '@esbuild/android-arm@0.25.9':
     optional: true
 
+  '@esbuild/android-arm@0.28.2':
+    optional: true
+
   '@esbuild/android-x64@0.25.9':
+    optional: true
+
+  '@esbuild/android-x64@0.28.2':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.9':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.2':
+    optional: true
+
   '@esbuild/darwin-x64@0.25.9':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.2':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.9':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.2':
+    optional: true
+
   '@esbuild/freebsd-x64@0.25.9':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.2':
     optional: true
 
   '@esbuild/linux-arm64@0.25.9':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.2':
+    optional: true
+
   '@esbuild/linux-arm@0.25.9':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.2':
     optional: true
 
   '@esbuild/linux-ia32@0.25.9':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.2':
+    optional: true
+
   '@esbuild/linux-loong64@0.25.9':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.2':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.9':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.2':
+    optional: true
+
   '@esbuild/linux-ppc64@0.25.9':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.2':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.9':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.2':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.9':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.2':
     optional: true
 
   '@esbuild/linux-x64@0.25.9':
     optional: true
 
+  '@esbuild/linux-x64@0.28.2':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.2':
     optional: true
 
   '@esbuild/netbsd-x64@0.25.9':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.2':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.2':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.9':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.2':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.2':
     optional: true
 
   '@esbuild/sunos-x64@0.25.9':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.2':
+    optional: true
+
   '@esbuild/win32-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.2':
     optional: true
 
   '@esbuild/win32-ia32@0.25.9':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.2':
+    optional: true
+
   '@esbuild/win32-x64@0.25.9':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.2':
     optional: true
 
   '@eslint-community/eslint-utils@4.7.0(eslint@9.33.0(jiti@2.5.1))':
@@ -5717,6 +6298,9 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.10
 
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    optional: true
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.4.5
@@ -6158,6 +6742,81 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@rollup/rollup-android-arm-eabi@4.63.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.63.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.63.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.63.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.63.1':
+    optional: true
+
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.12.0': {}
@@ -6283,6 +6942,11 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/d3-array@3.2.1': {}
 
   '@types/d3-axis@3.0.6':
@@ -6404,6 +7068,8 @@ snapshots:
     dependencies:
       '@types/ms': 2.1.0
 
+  '@types/deep-eql@4.0.2': {}
+
   '@types/dom-speech-recognition@0.0.1': {}
 
   '@types/eslint-scope@3.7.7':
@@ -6421,6 +7087,8 @@ snapshots:
       '@types/estree': 1.0.8
 
   '@types/estree@1.0.8': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/geojson@7946.0.16': {}
 
@@ -6645,6 +7313,52 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.3.6(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.1)(tsx@4.20.4)(yaml@2.8.1))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 7.3.6(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.1)(tsx@4.20.4)(yaml@2.8.1)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/pretty-format@3.2.7':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.17
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:
@@ -6887,6 +7601,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   astring@1.9.0: {}
@@ -6973,6 +7689,8 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -6998,6 +7716,14 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -7012,6 +7738,8 @@ snapshots:
   character-entities@2.0.2: {}
 
   character-reference-invalid@2.0.1: {}
+
+  check-error@2.1.3: {}
 
   chokidar@3.5.1:
     dependencies:
@@ -7317,6 +8045,8 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  deep-eql@5.0.2: {}
+
   deep-is@0.1.4: {}
 
   defaults@1.0.4:
@@ -7538,6 +8268,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.9
       '@esbuild/win32-ia32': 0.25.9
       '@esbuild/win32-x64': 0.25.9
+
+  esbuild@0.28.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
 
   escalade@3.2.0: {}
 
@@ -7794,6 +8553,8 @@ snapshots:
 
   events@3.3.0: {}
 
+  expect-type@1.4.0: {}
+
   extend-shallow@2.0.1:
     dependencies:
       is-extendable: 0.1.1
@@ -7833,6 +8594,14 @@ snapshots:
   fdir@6.4.6(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  fdir@6.5.0(picomatch@4.0.7):
+    optionalDependencies:
+      picomatch: 4.0.7
 
   fflate@0.4.8: {}
 
@@ -8362,6 +9131,8 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@3.14.1:
     dependencies:
       argparse: 1.0.10
@@ -8522,6 +9293,8 @@ snapshots:
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  loupe@3.2.1: {}
 
   lru-cache@11.1.0: {}
 
@@ -9095,11 +9868,17 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
+
+  picomatch@4.0.7: {}
 
   pidtree@0.6.0: {}
 
@@ -9484,6 +10263,38 @@ snapshots:
 
   robust-predicates@3.0.2: {}
 
+  rollup@4.63.1:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@napi-rs/lzma-linux-x64-gnu': 1.5.1
+      '@rollup/rollup-android-arm-eabi': 4.63.1
+      '@rollup/rollup-android-arm64': 4.63.1
+      '@rollup/rollup-darwin-arm64': 4.63.1
+      '@rollup/rollup-darwin-x64': 4.63.1
+      '@rollup/rollup-freebsd-arm64': 4.63.1
+      '@rollup/rollup-freebsd-x64': 4.63.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.63.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.63.1
+      '@rollup/rollup-linux-arm64-gnu': 4.63.1
+      '@rollup/rollup-linux-arm64-musl': 4.63.1
+      '@rollup/rollup-linux-loong64-gnu': 4.63.1
+      '@rollup/rollup-linux-loong64-musl': 4.63.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.63.1
+      '@rollup/rollup-linux-ppc64-musl': 4.63.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.63.1
+      '@rollup/rollup-linux-riscv64-musl': 4.63.1
+      '@rollup/rollup-linux-s390x-gnu': 4.63.1
+      '@rollup/rollup-linux-x64-gnu': 4.63.1
+      '@rollup/rollup-linux-x64-musl': 4.63.1
+      '@rollup/rollup-openbsd-x64': 4.63.1
+      '@rollup/rollup-openharmony-arm64': 4.63.1
+      '@rollup/rollup-win32-arm64-msvc': 4.63.1
+      '@rollup/rollup-win32-ia32-msvc': 4.63.1
+      '@rollup/rollup-win32-x64-gnu': 4.63.1
+      '@rollup/rollup-win32-x64-msvc': 4.63.1
+      fsevents: 2.3.3
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -9636,6 +10447,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -9679,6 +10492,10 @@ snapshots:
   sprintf-js@1.0.3: {}
 
   stable-hash@0.0.5: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -9778,6 +10595,10 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   style-to-js@1.1.18:
     dependencies:
       style-to-object: 1.0.11
@@ -9845,10 +10666,25 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyglobby@0.2.14:
     dependencies:
       fdir: 6.4.6(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.7)
+      picomatch: 4.0.7
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -10093,6 +10929,86 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  vite-node@3.2.4(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.1)(tsx@4.20.4)(yaml@2.8.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.1
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.6(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.1)(tsx@4.20.4)(yaml@2.8.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.6(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.1)(tsx@4.20.4)(yaml@2.8.1):
+    dependencies:
+      esbuild: 0.28.2
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.63.1
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 20.19.10
+      fsevents: 2.3.3
+      jiti: 2.5.1
+      lightningcss: 1.30.1
+      terser: 5.44.1
+      tsx: 4.20.4
+      yaml: 2.8.1
+
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.1)(tsx@4.20.4)(yaml@2.8.1):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.6(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.1)(tsx@4.20.4)(yaml@2.8.1))
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.1
+      expect-type: 1.4.0
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.14
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.6(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.1)(tsx@4.20.4)(yaml@2.8.1)
+      vite-node: 3.2.4(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.1)(tsx@4.20.4)(yaml@2.8.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 20.19.10
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   watchpack@2.4.4:
     dependencies:
       glob-to-regexp: 0.4.1
@@ -10197,6 +11113,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/src/app/[lang]/(main)/municipal/[province]/[municipality]/[year]/page.tsx
+++ b/src/app/[lang]/(main)/municipal/[province]/[municipality]/[year]/page.tsx
@@ -1,15 +1,12 @@
-import { JurisdictionPageContent } from "@/components/JurisdictionPageContent";
-import { initLingui } from "@/initLingui";
+import { MunicipalYearPageContent } from "@/components/municipal/MunicipalYearPageContent";
 import {
-  getExpandedDepartments,
-  getJurisdictionData,
   getMunicipalitiesByProvince,
   getAvailableYearsForJurisdiction,
 } from "@/lib/jurisdictions";
 import { locales } from "@/lib/constants";
-import { notFound } from "next/navigation";
 
-export const dynamicParams = false;
+export const dynamicParams = true;
+export const dynamic = "force-dynamic";
 
 export async function generateStaticParams() {
   const municipalitiesByProvince = getMunicipalitiesByProvince();
@@ -30,45 +27,6 @@ export async function generateStaticParams() {
   );
 
   return all;
-}
-
-type MunicipalYearPageContentProps = {
-  province: string;
-  municipality: string;
-  year: string;
-  lang: string;
-};
-
-export async function MunicipalYearPageContent({
-  province,
-  municipality,
-  year,
-  lang,
-}: MunicipalYearPageContentProps) {
-  initLingui(lang);
-
-  const jurisdictionSlug = `${province}/${municipality}`;
-
-  try {
-    const { jurisdiction, sankey } = getJurisdictionData(
-      jurisdictionSlug,
-      year,
-    );
-    const departments = getExpandedDepartments(jurisdictionSlug, year);
-
-    return (
-      <JurisdictionPageContent
-        jurisdiction={jurisdiction}
-        sankey={sankey}
-        departments={departments}
-        lang={lang}
-        basePath={`/${lang}/municipal/${province}/${municipality}/${year}`}
-        fullScreenPath={`/municipal/${province}/${municipality}/${year}/spending-full-screen`}
-      />
-    );
-  } catch {
-    notFound();
-  }
 }
 
 export default async function MunicipalYearPage({

--- a/src/app/[lang]/(main)/municipal/[province]/[municipality]/page.tsx
+++ b/src/app/[lang]/(main)/municipal/[province]/[municipality]/page.tsx
@@ -1,15 +1,13 @@
-import { MunicipalYearPageContent } from "@/app/[lang]/(main)/municipal/[province]/[municipality]/[year]/page";
-import { BASE_URL } from "@/lib/constants";
-import {
-  getMunicipalitiesByProvince,
-  getAvailableYearsForJurisdiction,
-} from "@/lib/jurisdictions";
+import { getMunicipalitiesByProvince } from "@/lib/jurisdictions";
 import { locales } from "@/lib/constants";
-import { generateHreflangAlternates } from "@/lib/utils";
-import { notFound } from "next/navigation";
-import { Metadata } from "next";
+import {
+  getMunicipalityFinancialStatements,
+  latestMunicipalFinancialYear,
+} from "@/lib/municipal-financial-statements";
+import { notFound, redirect } from "next/navigation";
 
-export const dynamicParams = false;
+export const dynamicParams = true;
+export const dynamic = "force-dynamic";
 
 export async function generateStaticParams() {
   const municipalitiesByProvince = getMunicipalitiesByProvince();
@@ -25,58 +23,20 @@ export async function generateStaticParams() {
   );
 }
 
-export async function generateMetadata({
-  params,
-}: {
-  params: Promise<{ province: string; municipality: string; lang: string }>;
-}): Promise<Metadata> {
-  const { province, municipality, lang } = await params;
-  const jurisdictionSlug = `${province}/${municipality}`;
-  const years = getAvailableYearsForJurisdiction(jurisdictionSlug);
-  const latestYear = years.length > 0 ? years[0] : null;
-
-  if (!latestYear) {
-    return {};
-  }
-
-  // Set canonical URL to the latest year's URL to avoid duplicate content SEO issues
-  const canonical = `${BASE_URL}/${lang}/municipal/${province}/${municipality}/${latestYear}`;
-  return {
-    alternates: {
-      ...generateHreflangAlternates(
-        lang,
-        `/municipal/[province]/[municipality]`,
-        { province, municipality },
-      ),
-      canonical,
-    },
-  };
-}
-
 export default async function MunicipalPage({
   params,
 }: {
   params: Promise<{ province: string; municipality: string; lang: string }>;
 }) {
   const { province, municipality, lang } = await params;
-
-  const jurisdictionSlug = `${province}/${municipality}`;
-
-  // Get the latest year for this municipality
-  const years = getAvailableYearsForJurisdiction(jurisdictionSlug);
-  const latestYear = years.length > 0 ? years[0] : null;
-
-  if (!latestYear) {
-    notFound();
-  }
-
-  // Use the component from the year route
-  return (
-    <MunicipalYearPageContent
-      province={province}
-      municipality={municipality}
-      year={latestYear}
-      lang={lang}
-    />
+  const financialStatements = await getMunicipalityFinancialStatements(
+    province,
+    municipality,
   );
+  const latestYear = latestMunicipalFinancialYear(financialStatements);
+  if (!latestYear) notFound();
+
+  // This target advances whenever a newer statement is reviewed. Keep the
+  // redirect temporary so browsers and CDNs cannot pin the yearless URL.
+  redirect(`/${lang}/municipal/${province}/${municipality}/${latestYear}`);
 }

--- a/src/app/[lang]/(main)/municipal/[province]/[municipality]/page.tsx
+++ b/src/app/[lang]/(main)/municipal/[province]/[municipality]/page.tsx
@@ -1,10 +1,13 @@
 import { getMunicipalitiesByProvince } from "@/lib/jurisdictions";
-import { locales } from "@/lib/constants";
+import { getAvailableYearsForJurisdiction } from "@/lib/jurisdictions";
+import { BASE_URL, locales } from "@/lib/constants";
 import {
   getMunicipalityFinancialStatements,
   latestMunicipalFinancialYear,
 } from "@/lib/municipal-financial-statements";
 import { notFound, redirect } from "next/navigation";
+import type { Metadata } from "next";
+import { generateHreflangAlternates } from "@/lib/utils";
 
 export const dynamicParams = true;
 export const dynamic = "force-dynamic";
@@ -23,17 +26,50 @@ export async function generateStaticParams() {
   );
 }
 
+async function latestYearFor(province: string, municipality: string) {
+  try {
+    const statements = await getMunicipalityFinancialStatements(
+      province,
+      municipality,
+    );
+    return latestMunicipalFinancialYear(statements);
+  } catch {
+    const years = getAvailableYearsForJurisdiction(
+      `${province}/${municipality}`,
+    );
+    return years.length ? Math.max(...years.map(Number)) : null;
+  }
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ province: string; municipality: string; lang: string }>;
+}): Promise<Metadata> {
+  const { province, municipality, lang } = await params;
+  const latestYear = await latestYearFor(province, municipality);
+  if (!latestYear) return {};
+
+  const canonical = `${BASE_URL}/${lang}/municipal/${province}/${municipality}/${latestYear}`;
+  return {
+    alternates: {
+      ...generateHreflangAlternates(
+        lang,
+        "/municipal/[province]/[municipality]",
+        { province, municipality },
+      ),
+      canonical,
+    },
+  };
+}
+
 export default async function MunicipalPage({
   params,
 }: {
   params: Promise<{ province: string; municipality: string; lang: string }>;
 }) {
   const { province, municipality, lang } = await params;
-  const financialStatements = await getMunicipalityFinancialStatements(
-    province,
-    municipality,
-  );
-  const latestYear = latestMunicipalFinancialYear(financialStatements);
+  const latestYear = await latestYearFor(province, municipality);
   if (!latestYear) notFound();
 
   // This target advances whenever a newer statement is reviewed. Keep the

--- a/src/app/[lang]/(main)/municipal/page.tsx
+++ b/src/app/[lang]/(main)/municipal/page.tsx
@@ -1,0 +1,59 @@
+import type { Metadata } from "next";
+import { Trans, useLingui } from "@lingui/react/macro";
+import { H1, Intro, Page, PageContent, Section } from "@/components/Layout";
+import { MunicipalFinancialStatementsSearch } from "@/components/municipal/MunicipalFinancialStatementsSearch";
+import { initLingui } from "@/initLingui";
+import { getMunicipalFinancialStatements } from "@/lib/municipal-financial-statements";
+import { generateHreflangAlternates } from "@/lib/utils";
+
+export const dynamic = "force-dynamic";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ lang: string }>;
+}): Promise<Metadata> {
+  const { lang } = await params;
+  initLingui(lang);
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const { t } = useLingui();
+  return {
+    title: t`Municipal Financial Statements | Canada Spends`,
+    description: t`Explore reviewed financial statement data for municipalities across Canada.`,
+    alternates: generateHreflangAlternates(lang, "/municipal"),
+  };
+}
+
+export default async function MunicipalFinancialStatementsPage({
+  params,
+}: {
+  params: Promise<{ lang: string }>;
+}) {
+  const { lang } = await params;
+  initLingui(lang);
+  const municipalities = await getMunicipalFinancialStatements();
+
+  return (
+    <Page>
+      <PageContent>
+        <Section>
+          <H1>
+            <Trans>Municipal Financial Statements</Trans>
+          </H1>
+          <Intro>
+            <Trans>
+              Explore revenue, expenses, assets, liabilities, and accumulated
+              surplus reported by municipalities across Canada.
+            </Trans>
+          </Intro>
+        </Section>
+        <Section>
+          <MunicipalFinancialStatementsSearch
+            municipalities={municipalities}
+            lang={lang}
+          />
+        </Section>
+      </PageContent>
+    </Page>
+  );
+}

--- a/src/components/FinancialYearSelector.tsx
+++ b/src/components/FinancialYearSelector.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import Link from "next/link";
+import { Trans } from "@lingui/react/macro";
+
+export function FinancialYearSelector({
+  basePath,
+  currentYear,
+  availableYears,
+  formatYear,
+}: {
+  basePath: string;
+  currentYear: string;
+  availableYears: string[];
+  formatYear?: (year: string) => string;
+}) {
+  if (availableYears.length <= 1) return null;
+
+  return (
+    <div className="mt-8 border-t border-gray-200 pt-8">
+      <h3 className="mb-4 text-lg font-medium text-gray-900">
+        <Trans>View Other Fiscal Years</Trans>
+      </h3>
+      <div className="flex flex-wrap gap-2">
+        {availableYears.map((year) => {
+          const current = year === currentYear;
+          return (
+            <Link
+              key={year}
+              href={`${basePath}/${year}`}
+              className={`rounded-md px-4 py-2 text-sm font-medium transition-colors ${
+                current
+                  ? "cursor-default bg-indigo-600 text-white"
+                  : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+              }`}
+              aria-current={current ? "page" : undefined}
+            >
+              {formatYear ? formatYear(year) : <Trans>FY {year}</Trans>}
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/HeroButtons.tsx
+++ b/src/components/HeroButtons.tsx
@@ -79,6 +79,14 @@ export function HeroButtons({
             className="bg-popover text-popover-foreground rounded-md shadow-lg p-1 flex flex-col min-w-50 z-200 max-h-80 overflow-y-auto"
             sideOffset={4}
           >
+            <DropdownMenu.Item asChild>
+              <Link
+                href={`/${i18n.locale}/municipal`}
+                className="px-3 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground rounded cursor-pointer"
+              >
+                <Trans>Browse all financial statements</Trans>
+              </Link>
+            </DropdownMenu.Item>
             {municipalitiesByProvince.map(({ province, municipalities }) => (
               <div key={province}>
                 <div className="px-3 py-2 text-xs font-semibold text-muted-foreground">

--- a/src/components/MainLayout/_components/DesktopNav.tsx
+++ b/src/components/MainLayout/_components/DesktopNav.tsx
@@ -140,6 +140,14 @@ export default function DesktopNav(props: DesktopNavProps) {
                   className="bg-popover rounded-md shadow-lg p-1 flex flex-col min-w-50 z-200"
                   sideOffset={8}
                 >
+                  <DropdownMenu.Item asChild>
+                    <Link
+                      href={`/${i18n.locale}/municipal`}
+                      className="px-3 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground rounded cursor-pointer"
+                    >
+                      <Trans>All financial statements</Trans>
+                    </Link>
+                  </DropdownMenu.Item>
                   {municipalitiesByProvince.map(
                     ({ province, municipalities }) => (
                       <DropdownMenu.Sub key={province}>

--- a/src/components/MainLayout/_components/MobileMenu.tsx
+++ b/src/components/MainLayout/_components/MobileMenu.tsx
@@ -123,6 +123,15 @@ export function MobileMenu(props: MobileMenuProps) {
         <p className="px-3 pl-7 text-sm font-medium text-muted-foreground">
           <Trans>Municipal</Trans>
         </p>
+        <MobileNavLink
+          href={`/${i18n.locale}/municipal`}
+          active={pathname === `/${i18n.locale}/municipal`}
+          onClick={() => setIsMenuOpen(false)}
+        >
+          <span className="pl-8 inline-block">
+            <Trans>All financial statements</Trans>
+          </span>
+        </MobileNavLink>
         {municipalitiesByProvince.map(({ province, municipalities }) => (
           <div key={province}>
             <p className="px-3 pl-11 pt-2 text-xs font-medium text-muted-foreground">

--- a/src/components/Sankey/SankeyChart.tsx
+++ b/src/components/Sankey/SankeyChart.tsx
@@ -301,7 +301,9 @@ export function SankeyChart(props: SankeyChartProps) {
               }
               height={chartHeight}
               amountScalingFactor={amountScalingFactor}
-              onMouseOver={handleMouseOver(flowTotals.revenue)}
+              onMouseOver={handleMouseOver(
+                chartData.revenue || flowTotals.revenue,
+              )}
               onMouseOut={handleMouseOut}
             />
             <SankeyChartSingle
@@ -315,7 +317,9 @@ export function SankeyChart(props: SankeyChartProps) {
               }
               height={chartHeight}
               amountScalingFactor={amountScalingFactor}
-              onMouseOver={handleMouseOver(flowTotals.spending)}
+              onMouseOver={handleMouseOver(
+                chartData.spending || flowTotals.spending,
+              )}
               onMouseOut={handleMouseOut}
             />
           </div>

--- a/src/components/Sankey/SankeyChart.tsx
+++ b/src/components/Sankey/SankeyChart.tsx
@@ -113,6 +113,7 @@ export function SankeyChart(props: SankeyChartProps) {
   );
   const [searchResult, setSearchResult] = useState<Node | null>(null);
   const [hoverNode, setHoverNode] = useState<HoverNodeType | null>(null);
+  const [flowTotals, setFlowTotals] = useState({ revenue: 0, spending: 0 });
   // Mouse position as fallback - ensures tooltip still works if blockRect is missing
   const [mousePosition, setMousePosition] = useState<{
     x: number;
@@ -133,6 +134,7 @@ export function SankeyChart(props: SankeyChartProps) {
     const { nodes, revenueTotal, spendingTotal } = getFlatData(transformedData);
 
     setFlatData(nodes);
+    setFlowTotals({ revenue: revenueTotal, spending: spendingTotal });
     setTotalAmount(Math.max(revenueTotal, spendingTotal));
   }, [props.data]);
 
@@ -299,7 +301,7 @@ export function SankeyChart(props: SankeyChartProps) {
               }
               height={chartHeight}
               amountScalingFactor={amountScalingFactor}
-              onMouseOver={handleMouseOver(chartData.revenue)}
+              onMouseOver={handleMouseOver(flowTotals.revenue)}
               onMouseOut={handleMouseOut}
             />
             <SankeyChartSingle
@@ -313,7 +315,7 @@ export function SankeyChart(props: SankeyChartProps) {
               }
               height={chartHeight}
               amountScalingFactor={amountScalingFactor}
-              onMouseOver={handleMouseOver(chartData.spending)}
+              onMouseOver={handleMouseOver(flowTotals.spending)}
               onMouseOut={handleMouseOut}
             />
           </div>

--- a/src/components/Sankey/utils.ts
+++ b/src/components/Sankey/utils.ts
@@ -1,18 +1,15 @@
 import { SankeyNode } from "./SankeyChartD3";
+import { formatCompactCurrency } from "@/lib/format-compact-currency";
 
 export const formatNumber = (amount: number, scalingFactor = 1e9) => {
-  return Intl.NumberFormat("en-US", {
-    style: "currency",
+  const scaledAmount = Number(amount * scalingFactor);
+
+  return formatCompactCurrency(scaledAmount, {
+    locale: "en-US",
     currency: "USD",
-    notation: "compact",
     maximumFractionDigits:
-      Math.abs(amount * scalingFactor) >= 1e9
-        ? 2
-        : Math.abs(amount * scalingFactor) >= 1e6
-          ? 1
-          : 0,
-    minimumFractionDigits: 0,
-  }).format(Number(amount * scalingFactor));
+      Math.abs(scaledAmount) >= 1e9 ? 2 : Math.abs(scaledAmount) >= 1e6 ? 1 : 0,
+  });
 };
 
 // Generate a unique ID from a name string

--- a/src/components/first-nations/FirstNationsYearSelector.tsx
+++ b/src/components/first-nations/FirstNationsYearSelector.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import Link from "next/link";
-import { Trans } from "@lingui/react/macro";
+import { FinancialYearSelector } from "@/components/FinancialYearSelector";
 
 interface FirstNationsYearSelectorProps {
   bcid: string;
@@ -16,56 +15,23 @@ export function FirstNationsYearSelector({
   availableYears,
   lang,
 }: FirstNationsYearSelectorProps) {
-  if (availableYears.length <= 1) {
-    return null;
-  }
-
   return (
-    <div className="mt-8 pt-8 border-t border-gray-200">
-      <h3 className="text-lg font-medium text-gray-900 mb-4">
-        <Trans>View Other Fiscal Years</Trans>
-      </h3>
-      <div className="flex flex-wrap gap-2">
-        {availableYears.map((year) => {
-          const isCurrentYear = year === currentYear;
-          return (
-            <Link
-              key={year}
-              href={`/${lang}/first-nations/${bcid}/${year}`}
-              className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
-                isCurrentYear
-                  ? "bg-indigo-600 text-white cursor-default"
-                  : "bg-gray-100 text-gray-700 hover:bg-gray-200"
-              }`}
-              aria-current={isCurrentYear ? "page" : undefined}
-            >
-              {formatFiscalYear(year)}
-            </Link>
-          );
-        })}
-      </div>
-    </div>
+    <FinancialYearSelector
+      basePath={`/${lang}/first-nations/${bcid}`}
+      currentYear={currentYear}
+      availableYears={availableYears}
+      formatYear={formatFiscalYear}
+    />
   );
 }
 
 function formatFiscalYear(year: string): string {
-  // If year is in format "2024-03-31", show "FY 2023-24"
-  // If year is just "2024", show "FY 2024"
-  if (year.includes("-")) {
-    const date = new Date(year);
-    const endYear = date.getFullYear();
-    const month = date.getMonth(); // 0-indexed
+  if (!year.includes("-")) return `FY ${year}`;
 
-    // If fiscal year ends in early months (Jan-Mar), it's for the previous calendar year
-    if (month <= 2) {
-      // January = 0, February = 1, March = 2
-      const startYear = endYear - 1;
-      return `FY ${startYear}-${String(endYear).slice(-2)}`;
-    } else {
-      const nextYear = endYear + 1;
-      return `FY ${endYear}-${String(nextYear).slice(-2)}`;
-    }
-  }
-
-  return `FY ${year}`;
+  const date = new Date(`${year}T00:00:00Z`);
+  const endYear = date.getUTCFullYear();
+  const month = date.getUTCMonth();
+  return month <= 2
+    ? `FY ${endYear - 1}-${String(endYear).slice(-2)}`
+    : `FY ${endYear}-${String(endYear + 1).slice(-2)}`;
 }

--- a/src/components/municipal/MunicipalFinancialStatementContent.tsx
+++ b/src/components/municipal/MunicipalFinancialStatementContent.tsx
@@ -1,0 +1,694 @@
+"use client";
+
+import { useState } from "react";
+import { Trans } from "@lingui/react/macro";
+import { FinancialYearSelector } from "@/components/FinancialYearSelector";
+import {
+  H1,
+  H2,
+  Intro,
+  P,
+  Page,
+  PageContent,
+  Section,
+} from "@/components/Layout";
+import { JurisdictionSankey } from "@/components/Sankey/JurisdictionSankey";
+import { Tooltip } from "@/components/Tooltip";
+import {
+  SourceDocumentIcon,
+  SourceDocumentViewer,
+} from "@/components/first-nations/SourceDocumentViewer";
+import type {
+  MunicipalFinancialFact,
+  MunicipalStatement,
+  MunicipalityFinancialDetail,
+} from "@/lib/municipal-financial-statements";
+import { formatCompactCurrency } from "@/lib/format-compact-currency";
+
+function conceptLabel(concept: MunicipalFinancialFact["concept"]) {
+  switch (concept) {
+    case "total_financial_assets":
+      return <Trans>Total financial assets</Trans>;
+    case "total_liabilities":
+      return <Trans>Total liabilities</Trans>;
+    case "net_financial_assets":
+      return <Trans>Net financial assets (debt)</Trans>;
+    case "total_non_financial_assets":
+      return <Trans>Total non-financial assets</Trans>;
+    case "accumulated_surplus":
+      return <Trans>Accumulated surplus</Trans>;
+    case "opening_accumulated_surplus":
+      return <Trans>Opening accumulated surplus</Trans>;
+    case "total_revenue":
+      return <Trans>Total revenue</Trans>;
+    case "total_expenses":
+      return <Trans>Total expenses</Trans>;
+    case "annual_surplus":
+      return <Trans>Annual surplus (deficit)</Trans>;
+  }
+}
+
+function formatCurrency(value: number, lang: string): string {
+  return formatCompactCurrency(value, {
+    locale: lang === "fr" ? "fr-CA" : "en-CA",
+  });
+}
+
+function formatCurrencyExact(value: number, lang: string): string {
+  return new Intl.NumberFormat(lang === "fr" ? "fr-CA" : "en-CA", {
+    style: "currency",
+    currency: "CAD",
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+function formatNumber(value: number, lang: string, maximumFractionDigits = 1) {
+  return new Intl.NumberFormat(lang === "fr" ? "fr-CA" : "en-CA", {
+    maximumFractionDigits,
+  }).format(value);
+}
+
+const HelpIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    className="ml-2 cursor-help text-gray-500"
+  >
+    <circle cx="12" cy="12" r="10" />
+    <path d="M9.1 9a3 3 0 1 1 4.9 2.3c-1 .7-2 1.2-2 2.7" />
+    <path d="M12 17h.01" />
+  </svg>
+);
+
+function SummaryCard({
+  label,
+  value,
+  description,
+  help,
+}: {
+  label: React.ReactNode;
+  value: string;
+  description: React.ReactNode;
+  help: React.ReactNode;
+}) {
+  return (
+    <div className="border-l-4 border-auburn-700 bg-gray-50 p-5">
+      <div className="flex items-center text-sm text-gray-600">
+        {label}
+        <Tooltip text={help}>
+          <HelpIcon />
+        </Tooltip>
+      </div>
+      <div className="my-1 text-3xl font-bold">{value}</div>
+      <div className="text-sm text-gray-600">{description}</div>
+    </div>
+  );
+}
+
+function factFor(
+  statement: MunicipalStatement,
+  concept: MunicipalFinancialFact["concept"],
+): MunicipalFinancialFact | undefined {
+  return statement.facts.find((fact) => fact.concept === concept);
+}
+
+function FactCard({
+  fact,
+  sourceUrl,
+  lang,
+}: {
+  fact: MunicipalFinancialFact;
+  sourceUrl: string | null;
+  lang: string;
+}) {
+  const source = sourceUrl ? `${sourceUrl}#page=${fact.source_page}` : null;
+  return (
+    <div className="border-l-4 border-auburn-700 bg-gray-50 p-5">
+      <div className="text-sm text-gray-600">{conceptLabel(fact.concept)}</div>
+      <div className="my-1 text-3xl font-bold">
+        {formatCurrency(fact.value, lang)}
+      </div>
+      <div className="text-xs text-gray-500">
+        <Trans>Reported as “{fact.raw_label}”</Trans>
+        {source && (
+          <>
+            {" · "}
+            <a
+              href={source}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-auburn-700 underline"
+            >
+              <Trans>page {fact.source_page}</Trans>
+            </a>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function OperationsComparison({
+  statement,
+  lang,
+}: {
+  statement: MunicipalStatement;
+  lang: string;
+}) {
+  const revenue = factFor(statement, "total_revenue");
+  const expenses = factFor(statement, "total_expenses");
+  if (!revenue || !expenses) return null;
+  const maximum = Math.max(
+    Math.abs(revenue.value),
+    Math.abs(expenses.value),
+    1,
+  );
+
+  return (
+    <div className="mt-7 max-w-3xl space-y-4">
+      {[
+        {
+          key: "revenue",
+          label: <Trans>Revenue</Trans>,
+          value: revenue.value,
+          colour: "bg-emerald-700",
+        },
+        {
+          key: "expenses",
+          label: <Trans>Expenses</Trans>,
+          value: expenses.value,
+          colour: "bg-auburn-700",
+        },
+      ].map(({ key, label, value, colour }) => (
+        <div key={key}>
+          <div className="mb-1 flex justify-between gap-4 text-sm font-medium">
+            <span>{label}</span>
+            <span>{formatCurrency(value, lang)}</span>
+          </div>
+          <div className="h-5 bg-gray-100">
+            <div
+              className={`h-full ${colour}`}
+              style={{
+                width: `${(Math.abs(value) / maximum) * 100}%`,
+              }}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function VerificationResults({
+  statement,
+  lang,
+}: {
+  statement: MunicipalStatement;
+  lang: string;
+}) {
+  const { verification } = statement;
+  if (!verification) return null;
+
+  const reviewedAt = new Intl.DateTimeFormat(
+    lang === "fr" ? "fr-CA" : "en-CA",
+    { dateStyle: "long", timeZone: "UTC" },
+  ).format(new Date(verification.reviewed_at));
+
+  return (
+    <div className="mt-6 border border-gray-200 bg-gray-50 p-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <div className="font-semibold">
+            {verification.summary.fail === 0 ? (
+              <Trans>Independent verification completed</Trans>
+            ) : (
+              <Trans>Verification requires attention</Trans>
+            )}
+          </div>
+          <div className="mt-1 text-sm text-gray-600">
+            <Trans>
+              Reviewed by {verification.reviewed_by} on {reviewedAt}
+            </Trans>
+          </div>
+        </div>
+        <div className="flex gap-2 text-xs font-semibold uppercase tracking-wide">
+          <span className="bg-emerald-100 px-2 py-1 text-emerald-800">
+            <Trans>{verification.summary.pass} passed</Trans>
+          </span>
+          {verification.summary.skip > 0 && (
+            <span className="bg-gray-200 px-2 py-1 text-gray-700">
+              <Trans>{verification.summary.skip} skipped</Trans>
+            </span>
+          )}
+          {verification.summary.fail > 0 && (
+            <span className="bg-red-100 px-2 py-1 text-red-800">
+              <Trans>{verification.summary.fail} failed</Trans>
+            </span>
+          )}
+        </div>
+      </div>
+      {verification.review_notes && (
+        <p className="mt-3 text-sm text-gray-700">
+          {verification.review_notes}
+        </p>
+      )}
+      <details className="mt-4 border-t border-gray-200 pt-4">
+        <summary className="cursor-pointer font-medium text-auburn-700">
+          <Trans>
+            View all {verification.summary.total} verification checks
+          </Trans>
+        </summary>
+        <div className="mt-4 overflow-x-auto">
+          <table className="w-full text-left text-sm">
+            <thead>
+              <tr className="border-b border-gray-300 text-gray-600">
+                <th className="px-2 py-2 font-medium">
+                  <Trans>Result</Trans>
+                </th>
+                <th className="px-2 py-2 font-medium">
+                  <Trans>Test</Trans>
+                </th>
+                <th className="px-2 py-2 font-medium">
+                  <Trans>Details</Trans>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {verification.checks.map((check, index) => (
+                <tr
+                  key={`${check.id}-${index}`}
+                  className="border-b border-gray-200 align-top last:border-0"
+                >
+                  <td className="whitespace-nowrap px-2 py-2 font-semibold uppercase">
+                    {check.status === "pass" ? (
+                      <Trans>Pass</Trans>
+                    ) : check.status === "skip" ? (
+                      <Trans>Skipped</Trans>
+                    ) : (
+                      <Trans>Fail</Trans>
+                    )}
+                  </td>
+                  <td className="px-2 py-2 font-mono text-xs">{check.id}</td>
+                  <td className="px-2 py-2 text-gray-700">{check.detail}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </details>
+    </div>
+  );
+}
+
+export function MunicipalFinancialStatementContent({
+  municipality,
+  statement,
+  lang,
+}: {
+  municipality: MunicipalityFinancialDetail;
+  statement: MunicipalStatement;
+  lang: string;
+}) {
+  const [showSource, setShowSource] = useState(false);
+  const sourceUrl = statement.source.download_url || statement.source.page_url;
+  const fiscalYearEnd = new Intl.DateTimeFormat(
+    lang === "fr" ? "fr-CA" : "en-CA",
+    { dateStyle: "long", timeZone: "UTC" },
+  ).format(new Date(`${statement.fiscal_year_end}T00:00:00Z`));
+  const operations = ["annual_surplus", "total_revenue", "total_expenses"]
+    .map((concept) =>
+      factFor(statement, concept as MunicipalFinancialFact["concept"]),
+    )
+    .filter((fact): fact is MunicipalFinancialFact => Boolean(fact));
+  const position = [
+    "total_financial_assets",
+    "total_liabilities",
+    "net_financial_assets",
+    "total_non_financial_assets",
+    "accumulated_surplus",
+  ]
+    .map((concept) =>
+      factFor(statement, concept as MunicipalFinancialFact["concept"]),
+    )
+    .filter((fact): fact is MunicipalFinancialFact => Boolean(fact));
+  const revenue = factFor(statement, "total_revenue");
+  const expenses = factFor(statement, "total_expenses");
+  const surplus = factFor(statement, "annual_surplus");
+  const context = municipality.context;
+  const censusYear = context.census_year;
+
+  return (
+    <Page>
+      <PageContent>
+        <Section>
+          <H1>{municipality.name}</H1>
+          <Intro>
+            <Trans>
+              Reviewed financial statement data for {municipality.name} in{" "}
+              {municipality.province_name}, for the fiscal year ending{" "}
+              {fiscalYearEnd}.
+            </Trans>
+          </Intro>
+          {context.population && censusYear && (
+            <P>
+              <Trans>
+                The municipality serves a {censusYear} Census population of{" "}
+                {formatNumber(context.population, lang, 0)} across{" "}
+                {formatNumber(context.area_sq_km || 0, lang)} square kilometres.
+              </Trans>
+            </P>
+          )}
+        </Section>
+
+        {statement.sankey && (
+          <>
+            <Section>
+              <H2>
+                <span className="inline-flex items-center">
+                  <Trans>Where the money came from and where it went</Trans>
+                  <SourceDocumentIcon
+                    sourceUrl={sourceUrl}
+                    documentType="municipal financial statements"
+                    isOpen={showSource}
+                    onToggle={() => setShowSource(!showSource)}
+                  />
+                </span>
+              </H2>
+              <P>
+                <Trans>
+                  Revenue sources flow in from the left and spending by service
+                  or function flows out on the right. Revenue offsets and losses
+                  are shown as outflows, while expense recoveries are shown as
+                  inflows. Values come from detailed schedules in the audited
+                  financial statements.
+                </Trans>
+              </P>
+              <SourceDocumentViewer
+                sourceUrl={sourceUrl}
+                documentType="Municipal financial statements"
+                isOpen={showSource}
+              />
+            </Section>
+            <div className="sankey-chart-container relative overflow-hidden sm:(mr-0 ml-0) md:(min-h-[776px] min-w-[1280px] w-screen -ml-[50vw] -mr-[50vw] left-1/2 right-1/2)">
+              <JurisdictionSankey
+                data={statement.sankey}
+                amountScalingFactor={1}
+              />
+            </div>
+          </>
+        )}
+
+        {statement.line_items.length > 0 && (
+          <Section>
+            <H2>
+              <Trans>Reported revenue and expense details</Trans>
+            </H2>
+            <P>
+              <Trans>
+                These are the detailed rows extracted from the audited
+                statement. This table preserves every signed amount, including
+                negative and consolidation entries that the Sankey repositions
+                as offsets or recoveries.
+              </Trans>
+            </P>
+            <div className="mt-6 grid gap-8 lg:grid-cols-2">
+              {(["revenue", "expense"] as const).map((flow) => {
+                const items = statement.line_items.filter(
+                  (item) => item.flow === flow,
+                );
+                if (items.length === 0) return null;
+                return (
+                  <div key={flow}>
+                    <h3 className="mb-3 text-lg font-semibold">
+                      {flow === "revenue" ? (
+                        <Trans>Revenue</Trans>
+                      ) : (
+                        <Trans>Expenses</Trans>
+                      )}
+                    </h3>
+                    <div className="overflow-x-auto border border-gray-200">
+                      <table className="w-full text-sm">
+                        <tbody>
+                          {items.map((item, index) => (
+                            <tr
+                              key={`${flow}-${item.position ?? index}-${item.label}`}
+                              className="border-b border-gray-100 last:border-b-0"
+                            >
+                              <td className="px-3 py-2">
+                                <span className="block font-medium">
+                                  {item.label}
+                                </span>
+                                {sourceUrl && (
+                                  <a
+                                    href={`${sourceUrl}#page=${item.source_page}`}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-xs text-auburn-700 underline"
+                                  >
+                                    <Trans>page {item.source_page}</Trans>
+                                  </a>
+                                )}
+                              </td>
+                              <td className="whitespace-nowrap px-3 py-2 text-right font-medium tabular-nums">
+                                {formatCurrencyExact(item.value, lang)}
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </Section>
+        )}
+
+        {operations.length > 0 && (
+          <Section>
+            <H2>
+              <Trans>Financial summary for {statement.fiscal_year}</Trans>
+            </H2>
+            <P>
+              <Trans>
+                How much the municipality reported earning and spending during
+                the fiscal year.
+              </Trans>
+            </P>
+            <div className="mt-6 grid gap-4 md:grid-cols-3">
+              {surplus && (
+                <SummaryCard
+                  label={<Trans>Annual surplus (deficit)</Trans>}
+                  value={formatCurrency(surplus.value, lang)}
+                  description={<Trans>Revenue remaining after expenses</Trans>}
+                  help={
+                    <Trans>
+                      The reported difference between annual revenue and
+                      expenses, including any separately presented adjustments.
+                    </Trans>
+                  }
+                />
+              )}
+              {revenue && (
+                <SummaryCard
+                  label={<Trans>Total revenue</Trans>}
+                  value={formatCurrency(revenue.value, lang)}
+                  description={
+                    statement.per_capita?.total_revenue ? (
+                      <Trans>
+                        {formatCurrency(
+                          statement.per_capita.total_revenue,
+                          lang,
+                        )}{" "}
+                        per resident
+                      </Trans>
+                    ) : (
+                      <Trans>All reported municipal revenue</Trans>
+                    )
+                  }
+                  help={
+                    <Trans>
+                      Taxes, transfers, fees, services, and other reported
+                      income.
+                    </Trans>
+                  }
+                />
+              )}
+              {expenses && (
+                <SummaryCard
+                  label={<Trans>Total expenses</Trans>}
+                  value={formatCurrency(expenses.value, lang)}
+                  description={
+                    statement.per_capita?.total_expenses ? (
+                      <Trans>
+                        {formatCurrency(
+                          statement.per_capita.total_expenses,
+                          lang,
+                        )}{" "}
+                        per resident
+                      </Trans>
+                    ) : (
+                      <Trans>All reported municipal expenses</Trans>
+                    )
+                  }
+                  help={
+                    <Trans>
+                      Program, service, administration, financing, and
+                      amortization expenses.
+                    </Trans>
+                  }
+                />
+              )}
+            </div>
+            <OperationsComparison statement={statement} lang={lang} />
+          </Section>
+        )}
+
+        {context.population && censusYear && (
+          <Section>
+            <H2>
+              <Trans>Community context</Trans>
+            </H2>
+            <P>
+              <Trans>
+                Census context makes municipal totals easier to compare, while
+                recognizing that municipal boundaries and service
+                responsibilities differ.
+              </Trans>
+            </P>
+            <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+              <FactCardSimple
+                label={<Trans>Population</Trans>}
+                value={formatNumber(context.population, lang, 0)}
+                note={<Trans>{censusYear} Census</Trans>}
+              />
+              {context.area_sq_km && (
+                <FactCardSimple
+                  label={<Trans>Land area</Trans>}
+                  value={`${formatNumber(context.area_sq_km, lang)} km²`}
+                  note={<Trans>Municipal census subdivision</Trans>}
+                />
+              )}
+              {context.population_density_per_sq_km && (
+                <FactCardSimple
+                  label={<Trans>Population density</Trans>}
+                  value={formatNumber(
+                    context.population_density_per_sq_km,
+                    lang,
+                  )}
+                  note={<Trans>Residents per km²</Trans>}
+                />
+              )}
+              {statement.per_capita?.total_expenses && (
+                <FactCardSimple
+                  label={<Trans>Expenses per resident</Trans>}
+                  value={formatCurrency(
+                    statement.per_capita.total_expenses,
+                    lang,
+                  )}
+                  note={<Trans>Financial year {statement.fiscal_year}</Trans>}
+                />
+              )}
+            </div>
+          </Section>
+        )}
+
+        {position.length > 0 && (
+          <Section>
+            <H2>
+              <Trans>Financial position</Trans>
+            </H2>
+            <P>
+              <Trans>
+                Assets, liabilities, and accumulated surplus at the end of the
+                fiscal year.
+              </Trans>
+            </P>
+            <div className="mt-6 grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {position.map((fact) => (
+                <FactCard
+                  key={fact.concept}
+                  fact={fact}
+                  sourceUrl={sourceUrl}
+                  lang={lang}
+                />
+              ))}
+            </div>
+          </Section>
+        )}
+
+        <Section>
+          <FinancialYearSelector
+            basePath={`/${lang}/municipal/${municipality.province_slug}/${municipality.slug}`}
+            currentYear={String(statement.fiscal_year)}
+            availableYears={municipality.available_years.map(String)}
+            formatYear={(year) => {
+              const period = municipality.available_periods.find(
+                (candidate) => String(candidate.year) === year,
+              );
+              return formatFiscalYearLabel(period?.fiscal_year_end ?? year);
+            }}
+          />
+        </Section>
+
+        <Section>
+          <H2>
+            <Trans>Source and methodology</Trans>
+          </H2>
+          <P>
+            <Trans>
+              Values are extracted from the municipality’s published financial
+              statements and independently reviewed before publication. Page
+              links point to the reported figure in the source document.
+            </Trans>
+          </P>
+          <VerificationResults statement={statement} lang={lang} />
+          {sourceUrl && (
+            <a
+              href={sourceUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-3 inline-block font-medium text-auburn-700 underline"
+            >
+              <Trans>View source financial statements</Trans>
+            </a>
+          )}
+        </Section>
+      </PageContent>
+    </Page>
+  );
+}
+
+function FactCardSimple({
+  label,
+  value,
+  note,
+}: {
+  label: React.ReactNode;
+  value: string;
+  note: React.ReactNode;
+}) {
+  return (
+    <div className="bg-gray-50 p-5">
+      <div className="text-sm text-gray-600">{label}</div>
+      <div className="my-1 text-2xl font-bold">{value}</div>
+      <div className="text-xs text-gray-500">{note}</div>
+    </div>
+  );
+}
+
+function formatFiscalYearLabel(fiscalYearEnd: string): string {
+  if (!fiscalYearEnd.includes("-")) return `FY ${fiscalYearEnd}`;
+
+  const date = new Date(`${fiscalYearEnd}T00:00:00Z`);
+  const endYear = date.getUTCFullYear();
+  const month = date.getUTCMonth();
+  return month <= 2
+    ? `FY ${endYear - 1}-${String(endYear).slice(-2)}`
+    : `FY ${endYear}`;
+}

--- a/src/components/municipal/MunicipalFinancialStatementsSearch.tsx
+++ b/src/components/municipal/MunicipalFinancialStatementsSearch.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { Plural, Trans, useLingui } from "@lingui/react/macro";
+import type { MunicipalityFinancialSummary } from "@/lib/municipal-financial-statements";
+
+export function MunicipalFinancialStatementsSearch({
+  municipalities,
+  lang,
+}: {
+  municipalities: MunicipalityFinancialSummary[];
+  lang: string;
+}) {
+  const { t } = useLingui();
+  const [query, setQuery] = useState("");
+  const [province, setProvince] = useState("");
+  const provinces = useMemo(
+    () =>
+      Array.from(
+        new Map(
+          municipalities.map((municipality) => [
+            municipality.province,
+            municipality.province_name,
+          ]),
+        ),
+      ).sort((a, b) => a[1].localeCompare(b[1])),
+    [municipalities],
+  );
+  const filtered = useMemo(() => {
+    const normalizedQuery = query.trim().toLocaleLowerCase();
+    return municipalities.filter(
+      (municipality) =>
+        (!province || municipality.province === province) &&
+        (!normalizedQuery ||
+          municipality.name.toLocaleLowerCase().includes(normalizedQuery)),
+    );
+  }, [municipalities, province, query]);
+
+  return (
+    <div>
+      <div className="mb-8 grid gap-3 md:grid-cols-[minmax(0,1fr)_18rem]">
+        <label>
+          <span className="sr-only">
+            <Trans>Search municipalities</Trans>
+          </span>
+          <input
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder={t`Search municipalities`}
+            className="block w-full border border-gray-300 px-4 py-3 focus:border-auburn-500 focus:outline-none focus:ring-2 focus:ring-auburn-500"
+          />
+        </label>
+        <label>
+          <span className="sr-only">
+            <Trans>Filter by province or territory</Trans>
+          </span>
+          <select
+            value={province}
+            onChange={(event) => setProvince(event.target.value)}
+            className="block w-full border border-gray-300 bg-white px-4 py-3 focus:border-auburn-500 focus:outline-none focus:ring-2 focus:ring-auburn-500"
+          >
+            <option value="">
+              <Trans>All provinces and territories</Trans>
+            </option>
+            {provinces.map(([code, name]) => (
+              <option key={code} value={code}>
+                {name}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <p className="mb-4 text-sm text-gray-600">
+        <Plural
+          value={filtered.length}
+          one="# municipality with reviewed financial data"
+          other="# municipalities with reviewed financial data"
+        />
+      </p>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {filtered.map((municipality) => {
+          const latestYear = municipality.available_years[0];
+          return (
+            <Link
+              key={municipality.canonical_id}
+              href={`/${lang}/municipal/${municipality.province_slug}/${municipality.slug}/${latestYear}`}
+              className="border border-gray-200 bg-white p-5 shadow-sm transition hover:border-auburn-700 hover:shadow-md"
+            >
+              <span className="block text-lg font-semibold text-auburn-700">
+                {municipality.name}
+              </span>
+              <span className="mt-1 block text-sm text-gray-600">
+                {municipality.province_name}
+                {municipality.legal_form ? ` · ${municipality.legal_form}` : ""}
+              </span>
+              <span className="mt-4 block text-sm font-medium text-gray-800">
+                {municipality.available_years.length === 1 ? (
+                  <Trans>{latestYear} financial statements</Trans>
+                ) : (
+                  <>
+                    <Plural
+                      value={municipality.available_years.length}
+                      one="# year"
+                      other="# years"
+                    />{" "}
+                    · {municipality.available_years.at(-1)}–{latestYear}
+                  </>
+                )}
+              </span>
+            </Link>
+          );
+        })}
+      </div>
+
+      {filtered.length === 0 && (
+        <p className="border border-gray-200 p-8 text-center text-gray-600">
+          <Trans>No municipalities match those filters.</Trans>
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/municipal/MunicipalFinancialStatementsSearch.tsx
+++ b/src/components/municipal/MunicipalFinancialStatementsSearch.tsx
@@ -83,7 +83,8 @@ export function MunicipalFinancialStatementsSearch({
 
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {filtered.map((municipality) => {
-          const latestYear = municipality.available_years[0];
+          const latestYear = Math.max(...municipality.available_years);
+          const earliestYear = Math.min(...municipality.available_years);
           return (
             <Link
               key={municipality.canonical_id}
@@ -107,7 +108,7 @@ export function MunicipalFinancialStatementsSearch({
                       one="# year"
                       other="# years"
                     />{" "}
-                    · {municipality.available_years.at(-1)}–{latestYear}
+                    · {earliestYear}–{latestYear}
                   </>
                 )}
               </span>

--- a/src/components/municipal/MunicipalYearPageContent.tsx
+++ b/src/components/municipal/MunicipalYearPageContent.tsx
@@ -1,0 +1,74 @@
+import { JurisdictionPageContent } from "@/components/JurisdictionPageContent";
+import { MunicipalFinancialStatementContent } from "@/components/municipal/MunicipalFinancialStatementContent";
+import { initLingui } from "@/initLingui";
+import {
+  getAvailableYearsForJurisdiction,
+  getExpandedDepartments,
+  getJurisdictionData,
+} from "@/lib/jurisdictions";
+import { getMunicipalityFinancialStatements } from "@/lib/municipal-financial-statements";
+import { notFound } from "next/navigation";
+
+type MunicipalYearPageContentProps = {
+  province: string;
+  municipality: string;
+  year: string;
+  lang: string;
+};
+
+export async function MunicipalYearPageContent({
+  province,
+  municipality,
+  year,
+  lang,
+}: MunicipalYearPageContentProps) {
+  initLingui(lang);
+
+  const jurisdictionSlug = `${province}/${municipality}`;
+  let financialStatements = null;
+  try {
+    financialStatements = await getMunicipalityFinancialStatements(
+      province,
+      municipality,
+      year,
+    );
+  } catch {
+    // Preserve the older curated municipality pages if York is unavailable.
+  }
+  const statement = financialStatements?.statements.find(
+    (candidate) => candidate.fiscal_year === Number(year),
+  );
+  if (financialStatements && statement) {
+    return (
+      <MunicipalFinancialStatementContent
+        municipality={financialStatements}
+        statement={statement}
+        lang={lang}
+      />
+    );
+  }
+
+  const hasCuratedData =
+    getAvailableYearsForJurisdiction(jurisdictionSlug).includes(year);
+
+  if (hasCuratedData) {
+    const { jurisdiction, sankey } = getJurisdictionData(
+      jurisdictionSlug,
+      year,
+    );
+    const departments = getExpandedDepartments(jurisdictionSlug, year);
+
+    return (
+      <JurisdictionPageContent
+        jurisdiction={jurisdiction}
+        sankey={sankey}
+        departments={departments}
+        lang={lang}
+        basePath={`/${lang}/municipal/${province}/${municipality}/${year}`}
+        fullScreenPath={`/municipal/${province}/${municipality}/${year}/spending-full-screen`}
+      />
+    );
+  }
+
+  notFound();
+}

--- a/src/lib/format-compact-currency.test.ts
+++ b/src/lib/format-compact-currency.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { formatCompactCurrency } from "./format-compact-currency";
+
+describe("formatCompactCurrency", () => {
+  it("pins English Canadian compact currency without trailing zeros", () => {
+    expect(formatCompactCurrency(7_301_415)).toBe("$7.3M");
+    expect(formatCompactCurrency(6_231_372)).toBe("$6.23M");
+    expect(formatCompactCurrency(569_000)).toBe("$569K");
+    expect(formatCompactCurrency(999_950)).toBe("$999.95K");
+    expect(formatCompactCurrency(1_000_000_000)).toBe("$1B");
+    expect(formatCompactCurrency(999)).toBe("$999");
+    expect(formatCompactCurrency(0)).toBe("$0");
+    expect(formatCompactCurrency(-7_301_415)).toBe("-$7.3M");
+  });
+
+  it("pins French Canadian compact currency and sign placement", () => {
+    const options = { locale: "fr-CA" };
+
+    expect(formatCompactCurrency(7_301_415, options)).toBe("7,3\u00a0M\u00a0$");
+    expect(formatCompactCurrency(569_000, options)).toBe("569\u00a0k\u00a0$");
+    expect(formatCompactCurrency(1_000_000_000, options)).toBe(
+      "1\u00a0G\u00a0$",
+    );
+    expect(formatCompactCurrency(0, options)).toBe("0\u00a0$");
+    expect(formatCompactCurrency(-7_301_415, options)).toBe(
+      "-7,3\u00a0M\u00a0$",
+    );
+  });
+
+  it("supports the Sankey precision policy", () => {
+    expect(
+      formatCompactCurrency(7_301_415, {
+        currency: "USD",
+        locale: "en-US",
+        maximumFractionDigits: 1,
+      }),
+    ).toBe("$7.3M");
+  });
+});

--- a/src/lib/format-compact-currency.test.ts
+++ b/src/lib/format-compact-currency.test.ts
@@ -37,4 +37,16 @@ describe("formatCompactCurrency", () => {
       }),
     ).toBe("$7.3M");
   });
+
+  it("promotes values that round across a compact-unit boundary", () => {
+    expect(formatCompactCurrency(999_999, { maximumFractionDigits: 2 })).toBe(
+      "$1M",
+    );
+    expect(formatCompactCurrency(999.9, { maximumFractionDigits: 0 })).toBe(
+      "$1K",
+    );
+    expect(
+      formatCompactCurrency(999_999_999, { maximumFractionDigits: 1 }),
+    ).toBe("$1B");
+  });
 });

--- a/src/lib/format-compact-currency.ts
+++ b/src/lib/format-compact-currency.ts
@@ -1,0 +1,36 @@
+export type CompactCurrencyOptions = {
+  currency?: string;
+  locale?: string;
+  maximumFractionDigits?: number;
+};
+
+export function formatCompactCurrency(
+  amount: number,
+  {
+    currency = "CAD",
+    locale = "en-CA",
+    maximumFractionDigits = 2,
+  }: CompactCurrencyOptions = {},
+): string {
+  const french = locale.toLowerCase().startsWith("fr");
+  const absoluteAmount = Math.abs(amount);
+  const units = [
+    { threshold: 1e12, divisor: 1e12, en: "T", fr: "T" },
+    { threshold: 1e9, divisor: 1e9, en: "B", fr: "G" },
+    { threshold: 1e6, divisor: 1e6, en: "M", fr: "M" },
+    { threshold: 1e3, divisor: 1e3, en: "K", fr: "k" },
+  ];
+  const unit = units.find(({ threshold }) => absoluteAmount >= threshold);
+  const scaledAmount = absoluteAmount / (unit?.divisor ?? 1);
+  const number = scaledAmount
+    .toFixed(maximumFractionDigits)
+    .replace(/\.0+$|(?<=\.[0-9]*?)0+$/u, "")
+    .replace(".", french ? "," : ".");
+  const suffix = unit ? (french ? unit.fr : unit.en) : "";
+  const sign = amount < 0 ? "-" : "";
+  const symbol = currency === "CAD" || currency === "USD" ? "$" : currency;
+
+  return french
+    ? `${sign}${number}${suffix ? `\u00a0${suffix}` : ""}\u00a0${symbol}`
+    : `${sign}${symbol}${number}${suffix}`;
+}

--- a/src/lib/format-compact-currency.ts
+++ b/src/lib/format-compact-currency.ts
@@ -15,18 +15,30 @@ export function formatCompactCurrency(
   const french = locale.toLowerCase().startsWith("fr");
   const absoluteAmount = Math.abs(amount);
   const units = [
-    { threshold: 1e12, divisor: 1e12, en: "T", fr: "T" },
-    { threshold: 1e9, divisor: 1e9, en: "B", fr: "G" },
-    { threshold: 1e6, divisor: 1e6, en: "M", fr: "M" },
+    { threshold: 1, divisor: 1, en: "", fr: "" },
     { threshold: 1e3, divisor: 1e3, en: "K", fr: "k" },
+    { threshold: 1e6, divisor: 1e6, en: "M", fr: "M" },
+    { threshold: 1e9, divisor: 1e9, en: "B", fr: "G" },
+    { threshold: 1e12, divisor: 1e12, en: "T", fr: "T" },
   ];
-  const unit = units.find(({ threshold }) => absoluteAmount >= threshold);
-  const scaledAmount = absoluteAmount / (unit?.divisor ?? 1);
+  let unitIndex = units.findLastIndex(
+    ({ threshold }) => absoluteAmount >= threshold,
+  );
+  unitIndex = Math.max(unitIndex, 0);
+  let unit = units[unitIndex];
+  let scaledAmount = absoluteAmount / unit.divisor;
+  while (
+    unitIndex < units.length - 1 &&
+    Number(scaledAmount.toFixed(maximumFractionDigits)) >= 1000
+  ) {
+    unit = units[++unitIndex];
+    scaledAmount = absoluteAmount / unit.divisor;
+  }
   const number = scaledAmount
     .toFixed(maximumFractionDigits)
     .replace(/\.0+$|(?<=\.[0-9]*?)0+$/u, "")
     .replace(".", french ? "," : ".");
-  const suffix = unit ? (french ? unit.fr : unit.en) : "";
+  const suffix = french ? unit.fr : unit.en;
   const sign = amount < 0 ? "-" : "";
   const symbol = currency === "CAD" || currency === "USD" ? "$" : currency;
 

--- a/src/lib/municipal-financial-statements.test.ts
+++ b/src/lib/municipal-financial-statements.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { latestMunicipalFinancialYear } from "./municipal-financial-statements";
+
+describe("latestMunicipalFinancialYear", () => {
+  it("selects the maximum available year without relying on API order", () => {
+    expect(
+      latestMunicipalFinancialYear({ available_years: [2024, 2025, 2023] }),
+    ).toBe(2025);
+  });
+
+  it("returns null when no reviewed year is available", () => {
+    expect(latestMunicipalFinancialYear({ available_years: [] })).toBeNull();
+    expect(latestMunicipalFinancialYear(null)).toBeNull();
+  });
+});

--- a/src/lib/municipal-financial-statements.ts
+++ b/src/lib/municipal-financial-statements.ts
@@ -1,0 +1,172 @@
+import type { SankeyData } from "@/components/Sankey/SankeyChartD3";
+
+const YORK_FACTORY_API_URL = (
+  process.env.YORK_FACTORY_API_URL ??
+  "https://yorkfactory.buildcanada.com/api/v1"
+).replace(/\/$/, "");
+
+export type MunicipalFinancialFact = {
+  concept:
+    | "total_financial_assets"
+    | "total_liabilities"
+    | "net_financial_assets"
+    | "total_non_financial_assets"
+    | "accumulated_surplus"
+    | "opening_accumulated_surplus"
+    | "total_revenue"
+    | "total_expenses"
+    | "annual_surplus";
+  value: number;
+  raw_label: string;
+  raw_text: string;
+  statement: "financial_position" | "operations" | "accumulated_surplus";
+  source_page: number;
+  column_year: string;
+  confidence: number | null;
+};
+
+export type MunicipalStatement = {
+  fiscal_year: number;
+  fiscal_year_end: string;
+  statement_basis: "consolidated" | "non_consolidated";
+  language: "en" | "fr" | "bilingual" | null;
+  source: {
+    document_id: string;
+    page_url: string | null;
+    download_url: string | null;
+  };
+  facts: MunicipalFinancialFact[];
+  line_items: MunicipalFinancialLineItem[];
+  verification?: MunicipalStatementVerification;
+  per_capita: Partial<Record<MunicipalFinancialFact["concept"], number>> | null;
+  sankey: SankeyData | null;
+};
+
+export type MunicipalStatementVerification = {
+  status: "approved";
+  reviewed_at: string;
+  reviewed_by: string;
+  review_notes: string | null;
+  summary: {
+    total: number;
+    pass: number;
+    skip: number;
+    fail: number;
+  };
+  checks: Array<{
+    id: string;
+    status: "pass" | "skip" | "fail";
+    detail: string;
+  }>;
+};
+
+export type MunicipalFinancialLineItem = {
+  flow: "revenue" | "expense";
+  category: string;
+  label: string;
+  value: number;
+  raw_text: string;
+  scale: number;
+  source_page: number;
+  column_year: string;
+  position: number;
+  confidence: number | null;
+};
+
+export type MunicipalityCensusContext = {
+  census_year: number | null;
+  population: number | null;
+  area_sq_km: number | null;
+  population_density_per_sq_km: number | null;
+  geographies: Array<{
+    uid: string;
+    name: string;
+    population: number | null;
+    area_sq_km: number | null;
+  }>;
+};
+
+export type MunicipalityFinancialSummary = {
+  canonical_id: string;
+  slug: string;
+  province: string;
+  province_name: string;
+  province_slug: string;
+  name: string;
+  name_fr: string | null;
+  legal_form: string | null;
+  website_url: string | null;
+  available_years: number[];
+  available_periods: Array<{ year: number; fiscal_year_end: string }>;
+};
+
+export type MunicipalityFinancialDetail = MunicipalityFinancialSummary & {
+  context: MunicipalityCensusContext;
+  statements: MunicipalStatement[];
+};
+
+export function latestMunicipalFinancialYear(
+  municipality:
+    | Pick<MunicipalityFinancialSummary, "available_years">
+    | null
+    | undefined,
+): number | null {
+  if (!municipality?.available_years.length) return null;
+
+  return Math.max(...municipality.available_years);
+}
+
+async function yorkFactoryFetch<T>(path: string): Promise<T> {
+  const response = await fetch(`${YORK_FACTORY_API_URL}${path}`, {
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new YorkFactoryApiError(response.status);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+class YorkFactoryApiError extends Error {
+  constructor(readonly status: number) {
+    super(`York Factory API error: ${status}`);
+  }
+}
+
+export async function getMunicipalFinancialStatements(): Promise<
+  MunicipalityFinancialSummary[]
+> {
+  const municipalities: MunicipalityFinancialSummary[] = [];
+  let page = 1;
+  let totalPages = 1;
+  do {
+    const payload = await yorkFactoryFetch<{
+      data: MunicipalityFinancialSummary[];
+      meta: { total_pages: number };
+    }>(`/warehouse/municipal_financial_statements?page=${page}&per_page=5000`);
+    municipalities.push(...payload.data);
+    totalPages = payload.meta.total_pages;
+    page += 1;
+  } while (page <= totalPages);
+  return municipalities;
+}
+
+export async function getMunicipalityFinancialStatements(
+  province: string,
+  municipality: string,
+  year?: string,
+): Promise<MunicipalityFinancialDetail | null> {
+  const suffix = year ? `/${encodeURIComponent(year)}` : "";
+
+  try {
+    return await yorkFactoryFetch<MunicipalityFinancialDetail>(
+      `/warehouse/municipal_financial_statements/${encodeURIComponent(province)}/${encodeURIComponent(municipality)}${suffix}`,
+    );
+  } catch (error) {
+    if (error instanceof YorkFactoryApiError && error.status === 404) {
+      return null;
+    }
+    throw error;
+  }
+}

--- a/src/locales/en.po
+++ b/src/locales/en.po
@@ -17,6 +17,16 @@ msgstr ""
 msgid "— Canada Spends Team"
 msgstr "— Canada Spends Team"
 
+#. placeholder {0}: filtered.length
+#: src/components/municipal/MunicipalFinancialStatementsSearch.tsx:77
+msgid "{0, plural, one {# municipality with reviewed financial data} other {# municipalities with reviewed financial data}}"
+msgstr "{0, plural, one {# municipality with reviewed financial data} other {# municipalities with reviewed financial data}}"
+
+#. placeholder {0}: municipality.available_years.length
+#: src/components/municipal/MunicipalFinancialStatementsSearch.tsx:105
+msgid "{0, plural, one {# year} other {# years}}"
+msgstr "{0, plural, one {# year} other {# years}}"
+
 #. placeholder {0}: department.agenciesHeading
 #. placeholder {0}: department.leadershipHeading
 #. placeholder {0}: department.name
@@ -31,6 +41,11 @@ msgstr "— Canada Spends Team"
 #: src/components/DepartmentList.tsx:113
 msgid "{0}"
 msgstr "{0}"
+
+#. placeholder {0}: verification.summary.fail
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:250
+msgid "{0} failed"
+msgstr "{0} failed"
 
 #. placeholder {0}: department.name
 #: src/app/[lang]/(main)/federal/spending/[year]/[department]/page.tsx:451
@@ -83,6 +98,23 @@ msgstr "{0} line items · all figures in real {baseYear} dollars"
 msgid "{0} of federal income tax"
 msgstr "{0} of federal income tax"
 
+#. placeholder {0}: verification.summary.pass
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:241
+msgid "{0} passed"
+msgstr "{0} passed"
+
+#. placeholder {0}: formatCurrency( statement.per_capita.total_expenses, lang, )
+#. placeholder {0}: formatCurrency( statement.per_capita.total_revenue, lang, )
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:503
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:528
+msgid "{0} per resident"
+msgstr "{0} per resident"
+
+#. placeholder {0}: verification.summary.skip
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:245
+msgid "{0} skipped"
+msgstr "{0} skipped"
+
 #. placeholder {0}: jurisdiction.name
 #. placeholder {1}: jurisdiction.financialYear
 #: src/components/JurisdictionPageContent.tsx:357
@@ -98,6 +130,14 @@ msgstr "{0}’s share of federal spending"
 #: src/app/[lang]/(main)/first-nations/[bcid]/page.tsx:62
 msgid "{0}{provinceSuffix} - No financial data is currently available under the First Nations Financial Transparency Act."
 msgstr "{0}{provinceSuffix} - No financial data is currently available under the First Nations Financial Transparency Act."
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:568
+msgid "{censusYear} Census"
+msgstr "{censusYear} Census"
+
+#: src/components/municipal/MunicipalFinancialStatementsSearch.tsx:102
+msgid "{latestYear} financial statements"
+msgstr "{latestYear} financial statements"
 
 #: src/app/[lang]/(main)/federal/spending/[year]/[department]/page.tsx:63
 msgid "{name} Spending, FY {fy} | Canada Spends"
@@ -141,8 +181,8 @@ msgstr "© 2025 Canada Spends. All rights reserved. A Project of <0>Build Canada
 msgid "100,000"
 msgstr "100,000"
 
-#: src/components/MainLayout/_components/DesktopNav.tsx:279
-#: src/components/MainLayout/_components/MobileMenu.tsx:188
+#: src/components/MainLayout/_components/DesktopNav.tsx:287
+#: src/components/MainLayout/_components/MobileMenu.tsx:197
 msgid "About"
 msgstr "About"
 
@@ -150,7 +190,7 @@ msgstr "About"
 msgid "About GlobaLeaks"
 msgstr "About GlobaLeaks"
 
-#: src/components/MainLayout/_components/DesktopNav.tsx:293
+#: src/components/MainLayout/_components/DesktopNav.tsx:301
 #: src/components/MainLayout/Footer.tsx:41
 msgid "About Us"
 msgstr "About Us"
@@ -167,6 +207,10 @@ msgstr "Accounting and consolidation adjustments"
 #: src/components/first-nations/FinancialPositionStats.tsx:194
 msgid "Accounts payable, long-term debt, and other obligations owed to external parties."
 msgstr "Accounts payable, long-term debt, and other obligations owed to external parties."
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:39
+msgid "Accumulated surplus"
+msgstr "Accumulated surplus"
 
 #: src/components/first-nations/FinancialPositionStats.tsx:310
 msgid "Accumulated Surplus"
@@ -196,6 +240,11 @@ msgstr "All data presented regarding government spending is sourced directly fro
 msgid "All expenses incurred during the fiscal year including program delivery, administration, and capital costs."
 msgstr "All expenses incurred during the fiscal year including program delivery, administration, and capital costs."
 
+#: src/components/MainLayout/_components/DesktopNav.tsx:148
+#: src/components/MainLayout/_components/MobileMenu.tsx:132
+msgid "All financial statements"
+msgstr "All financial statements"
+
 #: src/app/[lang]/(main)/budget/page.tsx:270
 #: src/app/[lang]/(main)/federal/budget/page.tsx:309
 msgid "All government budget data is sourced from official databases, but due to the complexity of these systems, occasional errors may occur despite our best efforts. This page is also based on government memos and leaks, so it is not an official release of the Fall 2025 Budget. We aim to make this information more accessible and accurate, and we welcome feedback. If you notice any issues, please let us know <0>here</0> — we appreciate it and will work to address them promptly."
@@ -212,6 +261,18 @@ msgstr "All of the information we use comes from publicly available databases an
 #: src/components/JurisdictionPageContent.tsx:183
 msgid "All program and operating spending recorded for the fiscal year."
 msgstr "All program and operating spending recorded for the fiscal year."
+
+#: src/components/municipal/MunicipalFinancialStatementsSearch.tsx:65
+msgid "All provinces and territories"
+msgstr "All provinces and territories"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:536
+msgid "All reported municipal expenses"
+msgstr "All reported municipal expenses"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:511
+msgid "All reported municipal revenue"
+msgstr "All reported municipal revenue"
 
 #: src/components/JurisdictionPageContent.tsx:163
 msgid "All revenue collected during the fiscal year, including taxes, transfers, and other sources."
@@ -257,6 +318,11 @@ msgstr "Annual interest payments on outstanding debt. This represents the cost o
 msgid "Annual municipal spending per {0} resident"
 msgstr "Annual municipal spending per {0} resident"
 
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:47
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:486
+msgid "Annual surplus (deficit)"
+msgstr "Annual surplus (deficit)"
+
 #: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:94
 msgid "Application ID"
 msgstr "Application ID"
@@ -294,6 +360,10 @@ msgstr "As of fiscal year end {0}"
 #: src/components/first-nations/FinancialPositionStats.tsx:301
 msgid "As of fiscal year end {fiscalYear}"
 msgstr "As of fiscal year end {fiscalYear}"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:607
+msgid "Assets, liabilities, and accumulated surplus at the end of the fiscal year."
+msgstr "Assets, liabilities, and accumulated surplus at the end of the fiscal year."
 
 #: src/components/first-nations/FirstNationsPageContent.tsx:373
 msgid "Assets, liabilities, and net financial position as of the end of fiscal year {fiscalYear}."
@@ -334,6 +404,10 @@ msgstr "Based on income of {0}"
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:250
 msgid "BPA credit ({0} × {1})"
 msgstr "BPA credit ({0} × {1})"
+
+#: src/components/HeroButtons.tsx:87
+msgid "Browse all financial statements"
+msgstr "Browse all financial statements"
 
 #: src/app/[lang]/(main)/first-nations/[bcid]/page.tsx:133
 msgid "Browse all First Nations"
@@ -428,6 +502,10 @@ msgstr "Cash, investments, accounts receivable, and other assets that can be con
 msgid "Category"
 msgstr "Category"
 
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:558
+msgid "Census context makes municipal totals easier to compare, while recognizing that municipal boundaries and service responsibilities differ."
+msgstr "Census context makes municipal totals easier to compare, while recognizing that municipal boundaries and service responsibilities differ."
+
 #: src/components/first-nations/RemunerationOverview.tsx:401
 msgid "Chief"
 msgstr "Chief"
@@ -447,6 +525,10 @@ msgstr "Co-Applicant(s)"
 #: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:272
 msgid "Collaboration Type"
 msgstr "Collaboration Type"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:555
+msgid "Community context"
+msgstr "Community context"
 
 #: src/app/[lang]/(main)/first-nations/remuneration/page.tsx:34
 msgid "Compare remuneration data across First Nations from annual reports published under the FNFTA."
@@ -494,8 +576,8 @@ msgstr "consolidated federal revenue (Vol I)"
 msgid "consolidated federal spending (Vol I)"
 msgstr "consolidated federal spending (Vol I)"
 
-#: src/components/MainLayout/_components/DesktopNav.tsx:310
-#: src/components/MainLayout/_components/MobileMenu.tsx:195
+#: src/components/MainLayout/_components/DesktopNav.tsx:318
+#: src/components/MainLayout/_components/MobileMenu.tsx:204
 #: src/components/MainLayout/Footer.tsx:54
 msgid "Contact"
 msgstr "Contact"
@@ -573,6 +655,10 @@ msgstr "Department Spending Reductions"
 #: src/components/LineItemTable.tsx:91
 msgid "Description"
 msgstr "Description"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:277
+msgid "Details"
+msgstr "Details"
 
 #: src/components/Sankey/BudgetSankey.tsx:433
 msgid "Direct program expenses"
@@ -716,8 +802,14 @@ msgstr "Expected Results"
 #: src/components/first-nations/RemunerationOverview.tsx:651
 #: src/components/first-nations/RemunerationOverview.tsx:797
 #: src/components/first-nations/RemunerationTable.tsx:259
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:183
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:431
 msgid "Expenses"
 msgstr "Expenses"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:589
+msgid "Expenses per resident"
+msgstr "Expenses per resident"
 
 #: src/app/[lang]/(main)/federal/budget/layout.tsx:17
 msgid "Explore Canada's federal budget with interactive visualizations and detailed analysis of government revenue and expenditures."
@@ -739,7 +831,7 @@ msgstr "Explore financial data from First Nations across Canada. Data is extract
 msgid "Explore financial data from First Nations across Canada. View statements of operations, financial positions, and remuneration from annual reports published under the First Nations Financial Transparency Act (FNFTA)."
 msgstr "Explore financial data from First Nations across Canada. View statements of operations, financial positions, and remuneration from annual reports published under the First Nations Financial Transparency Act (FNFTA)."
 
-#: src/components/HeroButtons.tsx:110
+#: src/components/HeroButtons.tsx:118
 msgid "Explore First Nations Spending"
 msgstr "Explore First Nations Spending"
 
@@ -763,6 +855,14 @@ msgstr "Explore other federal departments"
 msgid "Explore Provincial Spending"
 msgstr "Explore Provincial Spending"
 
+#: src/app/[lang]/(main)/municipal/page.tsx:44
+msgid "Explore revenue, expenses, assets, liabilities, and accumulated surplus reported by municipalities across Canada."
+msgstr "Explore revenue, expenses, assets, liabilities, and accumulated surplus reported by municipalities across Canada."
+
+#: src/app/[lang]/(main)/municipal/page.tsx:22
+msgid "Explore reviewed financial statement data for municipalities across Canada."
+msgstr "Explore reviewed financial statement data for municipalities across Canada."
+
 #: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:137
 msgid "External ID"
 msgstr "External ID"
@@ -770,6 +870,10 @@ msgstr "External ID"
 #: src/app/[lang]/(main)/page.tsx:116
 msgid "Facts about Spending"
 msgstr "Facts about Spending"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:293
+msgid "Fail"
+msgstr "Fail"
 
 #: src/app/[lang]/(main)/articles/page.tsx:55
 msgid "Featured Articles"
@@ -836,6 +940,10 @@ msgstr "Federal Total"
 msgid "Federal workforce"
 msgstr "Federal workforce"
 
+#: src/components/municipal/MunicipalFinancialStatementsSearch.tsx:57
+msgid "Filter by province or territory"
+msgstr "Filter by province or territory"
+
 #: src/components/DepartmentList.tsx:15
 msgid "Finance Canada"
 msgstr "Finance Canada"
@@ -868,14 +976,28 @@ msgstr "Financial liabilities less financial assets"
 msgid "Financial liabilities minus financial assets. A negative value indicates net financial assets."
 msgstr "Financial liabilities minus financial assets. A negative value indicates net financial assets."
 
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:604
+msgid "Financial position"
+msgstr "Financial position"
+
 #. placeholder {0}: jurisdiction.financialYear
 #: src/components/JurisdictionPageContent.tsx:399
 msgid "Financial Position {0}"
 msgstr "Financial Position {0}"
 
+#. placeholder {0}: statement.fiscal_year
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:475
+msgid "Financial summary for {0}"
+msgstr "Financial summary for {0}"
+
 #: src/components/first-nations/FirstNationsPageContent.tsx:343
 msgid "Financial Summary FY {fiscalYear}"
 msgstr "Financial Summary FY {fiscalYear}"
+
+#. placeholder {0}: statement.fiscal_year
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:594
+msgid "Financial year {0}"
+msgstr "Financial year {0}"
 
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:398
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:635
@@ -888,8 +1010,8 @@ msgid "First Nation"
 msgstr "First Nation"
 
 #: src/app/[lang]/(main)/first-nations/[bcid]/page.tsx:59
-#: src/components/MainLayout/_components/DesktopNav.tsx:188
-#: src/components/MainLayout/_components/MobileMenu.tsx:147
+#: src/components/MainLayout/_components/DesktopNav.tsx:196
+#: src/components/MainLayout/_components/MobileMenu.tsx:156
 msgid "First Nations"
 msgstr "First Nations"
 
@@ -951,6 +1073,10 @@ msgstr "FY"
 msgid "FY {0} Revenue and Spending"
 msgstr "FY {0} Revenue and Spending"
 
+#: src/components/FinancialYearSelector.tsx:38
+msgid "FY {year}"
+msgstr "FY {year}"
+
 #. placeholder {0}: jurisdiction.name
 #. placeholder {1}: jurisdiction.name
 #: src/components/JurisdictionPageContent.tsx:348
@@ -961,7 +1087,7 @@ msgstr "Get data-driven insights into how the {0} government’s revenue and spe
 msgid "Get data-driven insights into how the federal government’s revenue and spending affect Canadian lives and programs."
 msgstr "Get data-driven insights into how the federal government’s revenue and spending affect Canadian lives and programs."
 
-#: src/components/MainLayout/_components/DesktopNav.tsx:302
+#: src/components/MainLayout/_components/DesktopNav.tsx:310
 #: src/components/MainLayout/Footer.tsx:49
 msgid "Get Involved"
 msgstr "Get Involved"
@@ -1094,6 +1220,10 @@ msgstr "How federal spending pages are built from Public Accounts of Canada data
 msgid "How ministry and Sankey totals are allocated"
 msgstr "How ministry and Sankey totals are allocated"
 
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:478
+msgid "How much the municipality reported earning and spending during the fiscal year."
+msgstr "How much the municipality reported earning and spending during the fiscal year."
+
 #: src/app/[lang]/(main)/federal/spending/[year]/page.tsx:66
 msgid "How the Government of Canada spent its budget in fiscal year {fy}, by department, theme, and program."
 msgstr "How the Government of Canada spent its budget in fiscal year {fy}, by department, theme, and program."
@@ -1145,6 +1275,10 @@ msgstr "In-depth analysis and insights about Canadian government spending, budge
 msgid "Income Tax Revenues"
 msgstr "Income Tax Revenues"
 
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:228
+msgid "Independent verification completed"
+msgstr "Independent verification completed"
+
 #: src/components/DepartmentList.tsx:21
 msgid "Indigenous Services Canada + Crown-Indigenous Relations and Northern Affairs Canada"
 msgstr "Indigenous Services Canada + Crown-Indigenous Relations and Northern Affairs Canada"
@@ -1190,9 +1324,9 @@ msgstr "It doesn't have to be this way."
 msgid "Item"
 msgstr "Item"
 
-#: src/components/MainLayout/_components/DesktopNav.tsx:330
+#: src/components/MainLayout/_components/DesktopNav.tsx:338
 #: src/components/MainLayout/_components/MobileMenu.tsx:22
-#: src/components/MainLayout/_components/MobileMenu.tsx:211
+#: src/components/MainLayout/_components/MobileMenu.tsx:220
 msgid "Join Build Canada"
 msgstr "Join Build Canada"
 
@@ -1203,6 +1337,10 @@ msgstr "Key Dates"
 #: src/app/[lang]/(main)/search/[database]/[id]/DetailsPage.tsx:82
 msgid "Keywords"
 msgstr "Keywords"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:572
+msgid "Land area"
+msgstr "Land area"
 
 #: src/components/first-nations/FirstNationsPageContent.tsx:395
 msgid "Land Claims"
@@ -1290,6 +1428,18 @@ msgstr "More coming soon..."
 msgid "Municipal"
 msgstr "Municipal"
 
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:574
+msgid "Municipal census subdivision"
+msgstr "Municipal census subdivision"
+
+#: src/app/[lang]/(main)/municipal/page.tsx:41
+msgid "Municipal Financial Statements"
+msgstr "Municipal Financial Statements"
+
+#: src/app/[lang]/(main)/municipal/page.tsx:21
+msgid "Municipal Financial Statements | Canada Spends"
+msgstr "Municipal Financial Statements | Canada Spends"
+
 #: src/components/first-nations/RemunerationOverview.tsx:788
 #: src/components/first-nations/RemunerationTable.tsx:114
 msgid "Name"
@@ -1323,6 +1473,10 @@ msgstr "Net Debt"
 #: src/components/JurisdictionPageContent.tsx:213
 msgid "Net Debt is what remains after subtracting financial assets (like cash and investments) from the Total Debt. It represents the debt that isn't immediately covered by liquid assets."
 msgstr "Net Debt is what remains after subtracting financial assets (like cash and investments) from the Total Debt. It represents the debt that isn't immediately covered by liquid assets."
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:35
+msgid "Net financial assets (debt)"
+msgstr "Net financial assets (debt)"
 
 #: src/components/Sankey/BudgetSankey.tsx:517
 msgid "Net Foreign Exchange Revenue and Return on Investments"
@@ -1371,6 +1525,10 @@ msgstr "No individual entries available."
 #: src/components/LineItemTable.tsx:220
 msgid "No matching line items."
 msgstr "No matching line items."
+
+#: src/components/municipal/MunicipalFinancialStatementsSearch.tsx:121
+msgid "No municipalities match those filters."
+msgstr "No municipalities match those filters."
 
 #: src/components/first-nations/FirstNationsNotes.tsx:20
 msgid "No notes available."
@@ -1464,6 +1622,10 @@ msgstr "On-Reserve Pop."
 msgid "Open Tor Browser and wait for it to connect."
 msgstr "Open Tor Browser and wait for it to connect."
 
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:41
+msgid "Opening accumulated surplus"
+msgstr "Opening accumulated surplus"
+
 #: src/app/[lang]/(main)/budget/page.tsx:195
 #: src/app/[lang]/(main)/federal/budget/page.tsx:234
 msgid "Operational Spend"
@@ -1515,14 +1677,25 @@ msgstr "Other transfer payments"
 msgid "Our government is going to have to make hard choices about our nation's spending to ensure we can invest in creating a competitive, resilient, and independent nation. We care about giving Canadians the facts about spending so they can engage in this conversation with elected officials."
 msgstr "Our government is going to have to make hard choices about our nation's spending to ensure we can invest in creating a competitive, resilient, and independent nation. We care about giving Canadians the facts about spending so they can engage in this conversation with elected officials."
 
-#: src/components/MainLayout/_components/DesktopNav.tsx:202
-#: src/components/MainLayout/_components/MobileMenu.tsx:155
+#: src/components/MainLayout/_components/DesktopNav.tsx:210
+#: src/components/MainLayout/_components/MobileMenu.tsx:164
 msgid "Overview"
 msgstr "Overview"
+
+#. placeholder {0}: fact.source_page
+#. placeholder {0}: item.source_page
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:147
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:453
+msgid "page {0}"
+msgstr "page {0}"
 
 #: src/app/[lang]/(main)/federal/spending/methodology/page.tsx:225
 msgid "Parenthesized negatives, internal consolidation adjustments, and total or subtotal rows are flagged and excluded from Sankey leaves to avoid double counting, but they are retained in the line-item tables so the full detail remains available."
 msgstr "Parenthesized negatives, internal consolidation adjustments, and total or subtotal rows are flagged and excluded from Sankey leaves to avoid double counting, but they are retained in the line-item tables so the full detail remains available."
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:289
+msgid "Pass"
+msgstr "Pass"
 
 #: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:338
 msgid "Payment Amount"
@@ -1567,6 +1740,14 @@ msgstr "Pollution pricing"
 msgid "Pollution pricing proceeds"
 msgstr "Pollution pricing proceeds"
 
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:566
+msgid "Population"
+msgstr "Population"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:579
+msgid "Population density"
+msgstr "Population density"
+
 #: src/components/first-nations/RemunerationOverview.tsx:791
 #: src/components/first-nations/RemunerationTable.tsx:107
 msgid "Position"
@@ -1597,6 +1778,10 @@ msgstr "Program Name"
 #: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:131
 msgid "Program Type"
 msgstr "Program Type"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:540
+msgid "Program, service, administration, financing, and amortization expenses."
+msgstr "Program, service, administration, financing, and amortization expenses."
 
 #: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:235
 msgid "Project Number"
@@ -1708,14 +1893,23 @@ msgid "Regions"
 msgstr "Regions"
 
 #: src/components/first-nations/RemunerationTable.tsx:233
-#: src/components/MainLayout/_components/DesktopNav.tsx:210
-#: src/components/MainLayout/_components/MobileMenu.tsx:166
+#: src/components/MainLayout/_components/DesktopNav.tsx:218
+#: src/components/MainLayout/_components/MobileMenu.tsx:175
 msgid "Remuneration"
 msgstr "Remuneration"
 
 #: src/components/first-nations/FirstNationsPageContent.tsx:423
 msgid "Remuneration and Expenses"
 msgstr "Remuneration and Expenses"
+
+#. placeholder {0}: fact.raw_label
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:137
+msgid "Reported as “{0}”"
+msgstr "Reported as “{0}”"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:409
+msgid "Reported revenue and expense details"
+msgstr "Reported revenue and expense details"
 
 #: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:277
 msgid "Reporting Organization"
@@ -1725,6 +1919,14 @@ msgstr "Reporting Organization"
 #: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:134
 msgid "Research Subject"
 msgstr "Research Subject"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:584
+msgid "Residents per km²"
+msgstr "Residents per km²"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:271
+msgid "Result"
+msgstr "Result"
 
 #: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:267
 msgid "Results Achieved"
@@ -1736,6 +1938,8 @@ msgstr "Retirement Benefits"
 
 #: src/app/[lang]/(main)/budget/page.tsx:184
 #: src/app/[lang]/(main)/federal/budget/page.tsx:223
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:177
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:429
 #: src/components/Sankey/BudgetSankey.tsx:456
 msgid "Revenue"
 msgstr "Revenue"
@@ -1747,6 +1951,25 @@ msgstr "Revenue and Expenses FY {fiscalYear}"
 #: src/app/[lang]/(main)/federal/spending/[year]/page.tsx:195
 msgid "revenue minus spending (Vol I)"
 msgstr "revenue minus spending (Vol I)"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:488
+msgid "Revenue remaining after expenses"
+msgstr "Revenue remaining after expenses"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:383
+msgid "Revenue sources flow in from the left and spending by service or function flows out on the right. Revenue offsets and losses are shown as outflows, while expense recoveries are shown as inflows. Values come from detailed schedules in the audited financial statements."
+msgstr "Revenue sources flow in from the left and spending by service or function flows out on the right. Revenue offsets and losses are shown as outflows, while expense recoveries are shown as inflows. Values come from detailed schedules in the audited financial statements."
+
+#. placeholder {0}: verification.reviewed_by
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:234
+msgid "Reviewed by {0} on {reviewedAt}"
+msgstr "Reviewed by {0} on {reviewedAt}"
+
+#. placeholder {0}: municipality.name
+#. placeholder {1}: municipality.province_name
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:351
+msgid "Reviewed financial statement data for {0} in {1}, for the fiscal year ending {fiscalYearEnd}."
+msgstr "Reviewed financial statement data for {0} in {1}, for the fiscal year ending {fiscalYearEnd}."
 
 #: src/components/FederalWorkforceStrip.tsx:89
 msgid "salaries and benefits (standard object)"
@@ -1767,6 +1990,11 @@ msgstr "Save your receipt code securely—you will need it to check for response
 #: src/components/LineItemTable.tsx:160
 msgid "Search line items…"
 msgstr "Search line items…"
+
+#: src/components/municipal/MunicipalFinancialStatementsSearch.tsx:45
+#: src/components/municipal/MunicipalFinancialStatementsSearch.tsx:51
+msgid "Search municipalities"
+msgstr "Search municipalities"
 
 #: src/app/[lang]/(main)/whistleblowers/page.tsx:153
 msgid "Security Tips"
@@ -1809,6 +2037,10 @@ msgstr "Showing {0} of {1} First Nations"
 msgid "Showing {0} of {1} results"
 msgstr "Showing {0} of {1} results"
 
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:291
+msgid "Skipped"
+msgstr "Skipped"
+
 #: src/components/Sankey/BudgetSankey.tsx:347
 msgid "Social Security"
 msgstr "Social Security"
@@ -1826,6 +2058,10 @@ msgstr "Source"
 #: src/app/[lang]/(main)/federal/spending/methodology/page.tsx:361
 msgid "Source and licence"
 msgstr "Source and licence"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:641
+msgid "Source and methodology"
+msgstr "Source and methodology"
 
 #: src/components/first-nations/RemunerationOverview.tsx:601
 msgid "Source PDF"
@@ -1879,9 +2115,9 @@ msgstr "Spending by ministry, FY {0}"
 msgid "Spending data is not yet available for this province and year combination. The income tax calculation above is still accurate based on {year} tax rates."
 msgstr "Spending data is not yet available for this province and year combination. The income tax calculation above is still accurate based on {year} tax rates."
 
-#: src/components/MainLayout/_components/DesktopNav.tsx:249
-#: src/components/MainLayout/_components/DesktopNav.tsx:268
-#: src/components/MainLayout/_components/MobileMenu.tsx:181
+#: src/components/MainLayout/_components/DesktopNav.tsx:257
+#: src/components/MainLayout/_components/DesktopNav.tsx:276
+#: src/components/MainLayout/_components/MobileMenu.tsx:190
 msgid "Spending Database"
 msgstr "Spending Database"
 
@@ -1986,15 +2222,23 @@ msgstr "Tax Visualizer | Canada Spends"
 msgid "Tax Year"
 msgstr "Tax Year"
 
-#: src/components/MainLayout/_components/DesktopNav.tsx:241
-#: src/components/MainLayout/_components/DesktopNav.tsx:261
-#: src/components/MainLayout/_components/MobileMenu.tsx:174
+#: src/components/MainLayout/_components/DesktopNav.tsx:249
+#: src/components/MainLayout/_components/DesktopNav.tsx:269
+#: src/components/MainLayout/_components/MobileMenu.tsx:183
 msgid "Taxes"
 msgstr "Taxes"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:515
+msgid "Taxes, transfers, fees, services, and other reported income."
+msgstr "Taxes, transfers, fees, services, and other reported income."
 
 #: src/components/Sankey/BudgetSankey.tsx:395
 msgid "Territorial Formula Financing"
 msgstr "Territorial Formula Financing"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:274
+msgid "Test"
+msgstr "Test"
 
 #: src/app/[lang]/(main)/about/faq.tsx:61
 msgid "The best way to support us is to engage with our content. Like, share, and comment on our posts on social media. Even better, share our work with a friend and encourage them to do the same. Together, we can expand the conversation and reach more people with these important facts."
@@ -2012,9 +2256,19 @@ msgstr "The difference between revenue and spending. A surplus indicates revenue
 msgid "The difference between total revenue and total expenses. A surplus indicates revenue exceeded expenses."
 msgstr "The difference between total revenue and total expenses. A surplus indicates revenue exceeded expenses."
 
+#. placeholder {0}: formatNumber(context.population, lang, 0)
+#. placeholder {1}: formatNumber(context.area_sq_km || 0, lang)
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:359
+msgid "The municipality serves a {censusYear} Census population of {0} across {1} square kilometres."
+msgstr "The municipality serves a {censusYear} Census population of {0} across {1} square kilometres."
+
 #: src/app/[lang]/(main)/federal/spending/methodology/page.tsx:194
 msgid "The previous hand-authored pages contained curated aggregations — for example, hand-massaged negative leaves and thematic groupings that split a single ministry across categories. Every node where the generated tree differs from the previous values is enumerated in the parity report with a reason code (basis, mapping, rounding, or source correction)."
 msgstr "The previous hand-authored pages contained curated aggregations — for example, hand-massaged negative leaves and thematic groupings that split a single ministry across categories. Every node where the generated tree differs from the previous values is enumerated in the parity report with a reason code (basis, mapping, rounding, or source correction)."
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:490
+msgid "The reported difference between annual revenue and expenses, including any separately presented adjustments."
+msgstr "The reported difference between annual revenue and expenses, including any separately presented adjustments."
 
 #: src/app/[lang]/(main)/federal/spending/methodology/page.tsx:253
 msgid "The Sankey uses a curated thematic tree. A maintained mapping assigns each Public Accounts line to a thematic node, mostly at the ministry or organization level with line-level overrides where needed. Each node is truncated to its largest children with the remainder rolled into an “Other” aggregate."
@@ -2035,6 +2289,10 @@ msgstr "Thematic mapping"
 #: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:132
 msgid "Theme"
 msgstr "Theme"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:412
+msgid "These are the detailed rows extracted from the audited statement. This table preserves every signed amount, including negative and consolidation entries that the Sankey repositions as offsets or recoveries."
+msgstr "These are the detailed rows extracted from the audited statement. This table preserves every signed amount, including negative and consolidation entries that the Sankey repositions as offsets or recoveries."
 
 #: src/app/[lang]/(main)/federal/spending/methodology/page.tsx:57
 msgid "These pages are generated from the Public Accounts of Canada. This page documents the accounting bases, curation choices, and known differences so the numbers are traceable to source."
@@ -2061,7 +2319,7 @@ msgstr "This visualization shows how your income tax contributions are allocated
 msgid "to help us support our mission."
 msgstr "to help us support our mission."
 
-#: src/components/MainLayout/_components/DesktopNav.tsx:227
+#: src/components/MainLayout/_components/DesktopNav.tsx:235
 msgid "Tools"
 msgstr "Tools"
 
@@ -2105,6 +2363,11 @@ msgstr "Total Debt is the government's complete outstanding debt. This is the fi
 msgid "Total difference"
 msgstr "Total difference"
 
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:45
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:524
+msgid "Total expenses"
+msgstr "Total expenses"
+
 #: src/components/first-nations/FirstNationsPageContent.tsx:261
 msgid "Total Expenses"
 msgstr "Total Expenses"
@@ -2117,9 +2380,17 @@ msgstr "Total expenses in FY {fiscalYear}"
 msgid "Total Federal Tax"
 msgstr "Total Federal Tax"
 
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:31
+msgid "Total financial assets"
+msgstr "Total financial assets"
+
 #: src/components/first-nations/FinancialPositionStats.tsx:168
 msgid "Total Financial Assets"
 msgstr "Total Financial Assets"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:33
+msgid "Total liabilities"
+msgstr "Total liabilities"
 
 #: src/components/first-nations/FinancialPositionStats.tsx:191
 msgid "Total Liabilities"
@@ -2128,6 +2399,10 @@ msgstr "Total Liabilities"
 #: src/components/first-nations/FinancialPositionStats.tsx:278
 msgid "Total net assets"
 msgstr "Total net assets"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:37
+msgid "Total non-financial assets"
+msgstr "Total non-financial assets"
 
 #: src/components/first-nations/ClaimsTable.tsx:148
 msgid "Total Payments"
@@ -2146,6 +2421,11 @@ msgstr "Total property tax revenue divided by population. Primary revenue source
 #: src/components/first-nations/RemunerationOverview.tsx:584
 msgid "Total Remuneration"
 msgstr "Total Remuneration"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:43
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:499
+msgid "Total revenue"
+msgstr "Total revenue"
 
 #: src/components/first-nations/FirstNationsPageContent.tsx:241
 #: src/components/JurisdictionPageContent.tsx:160
@@ -2241,6 +2521,14 @@ msgstr "Units"
 msgid "Use a computer you trust, not one provided by your employer."
 msgstr "Use a computer you trust, not one provided by your employer."
 
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:644
+msgid "Values are extracted from the municipality’s published financial statements and independently reviewed before publication. Page links point to the reported figure in the source document."
+msgstr "Values are extracted from the municipality’s published financial statements and independently reviewed before publication. Page links point to the reported figure in the source document."
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:230
+msgid "Verification requires attention"
+msgstr "Verification requires attention"
+
 #: src/components/DepartmentList.tsx:45
 msgid "Veterans Affairs"
 msgstr "Veterans Affairs"
@@ -2249,6 +2537,11 @@ msgstr "Veterans Affairs"
 #: src/app/[lang]/(main)/first-nations/[bcid]/[year]/page.tsx:59
 msgid "View {year} financial statements for {0}{provinceSuffix}. Includes statement of operations, financial position, and remuneration data from the First Nations Financial Transparency Act annual report."
 msgstr "View {year} financial statements for {0}{provinceSuffix}. Includes statement of operations, financial position, and remuneration data from the First Nations Financial Transparency Act annual report."
+
+#. placeholder {0}: verification.summary.total
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:262
+msgid "View all {0} verification checks"
+msgstr "View all {0} verification checks"
 
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:858
 #: src/components/TaxBreakdownAccordion.tsx:100
@@ -2264,13 +2557,17 @@ msgstr "View Federal 2025 Budget Details"
 msgid "View financial data for {0}{provinceSuffix} from the First Nations Financial Transparency Act annual reports."
 msgstr "View financial data for {0}{provinceSuffix} from the First Nations Financial Transparency Act annual reports."
 
-#: src/components/first-nations/FirstNationsYearSelector.tsx:26
+#: src/components/FinancialYearSelector.tsx:22
 msgid "View Other Fiscal Years"
 msgstr "View Other Fiscal Years"
 
 #: src/app/[lang]/(main)/search/[database]/[id]/DetailsPage.tsx:101
 msgid "View source data"
 msgstr "View source data"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:658
+msgid "View source financial statements"
+msgstr "View source financial statements"
 
 #: src/app/[lang]/(main)/budget/page.tsx:242
 #: src/app/[lang]/(main)/federal/budget/page.tsx:281
@@ -2372,14 +2669,18 @@ msgstr "What Makes a Good Tip?"
 msgid "Where do you get the data on your website?"
 msgstr "Where do you get the data on your website?"
 
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:373
+msgid "Where the money came from and where it went"
+msgstr "Where the money came from and where it went"
+
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:826
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:880
 msgid "Where Your Tax Dollars Go"
 msgstr "Where Your Tax Dollars Go"
 
 #: src/app/[lang]/(main)/whistleblowers/page.tsx:44
-#: src/components/MainLayout/_components/DesktopNav.tsx:318
-#: src/components/MainLayout/_components/MobileMenu.tsx:202
+#: src/components/MainLayout/_components/DesktopNav.tsx:326
+#: src/components/MainLayout/_components/MobileMenu.tsx:211
 #: src/components/MainLayout/Footer.tsx:59
 msgid "Whistleblowers"
 msgstr "Whistleblowers"

--- a/src/locales/fr.po
+++ b/src/locales/fr.po
@@ -17,6 +17,16 @@ msgstr ""
 msgid "— Canada Spends Team"
 msgstr "— L'équipe de Canada Spends"
 
+#. placeholder {0}: filtered.length
+#: src/components/municipal/MunicipalFinancialStatementsSearch.tsx:77
+msgid "{0, plural, one {# municipality with reviewed financial data} other {# municipalities with reviewed financial data}}"
+msgstr "{0, plural, one {# municipalité avec des données financières révisées} other {# municipalités avec des données financières révisées}}"
+
+#. placeholder {0}: municipality.available_years.length
+#: src/components/municipal/MunicipalFinancialStatementsSearch.tsx:105
+msgid "{0, plural, one {# year} other {# years}}"
+msgstr "{0, plural, one {# année} other {# années}}"
+
 #. placeholder {0}: department.agenciesHeading
 #. placeholder {0}: department.leadershipHeading
 #. placeholder {0}: department.name
@@ -31,6 +41,11 @@ msgstr "— L'équipe de Canada Spends"
 #: src/components/DepartmentList.tsx:113
 msgid "{0}"
 msgstr "{0}"
+
+#. placeholder {0}: verification.summary.fail
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:250
+msgid "{0} failed"
+msgstr "{0} échoués"
 
 #. placeholder {0}: department.name
 #: src/app/[lang]/(main)/federal/spending/[year]/[department]/page.tsx:451
@@ -83,6 +98,23 @@ msgstr "{0} postes · tous les montants sont en dollars réels de {baseYear}"
 msgid "{0} of federal income tax"
 msgstr "{0} de l'impôt fédéral sur le revenu"
 
+#. placeholder {0}: verification.summary.pass
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:241
+msgid "{0} passed"
+msgstr "{0} réussis"
+
+#. placeholder {0}: formatCurrency( statement.per_capita.total_expenses, lang, )
+#. placeholder {0}: formatCurrency( statement.per_capita.total_revenue, lang, )
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:503
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:528
+msgid "{0} per resident"
+msgstr "{0} par habitant"
+
+#. placeholder {0}: verification.summary.skip
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:245
+msgid "{0} skipped"
+msgstr "{0} ignorés"
+
 #. placeholder {0}: jurisdiction.name
 #. placeholder {1}: jurisdiction.financialYear
 #: src/components/JurisdictionPageContent.tsx:357
@@ -98,6 +130,14 @@ msgstr "Part de {0} dans les dépenses fédérales"
 #: src/app/[lang]/(main)/first-nations/[bcid]/page.tsx:62
 msgid "{0}{provinceSuffix} - No financial data is currently available under the First Nations Financial Transparency Act."
 msgstr "{0}{provinceSuffix} - Aucune donnée financière n'est actuellement disponible en vertu de la Loi sur la transparence financière des Premières Nations."
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:568
+msgid "{censusYear} Census"
+msgstr "Recensement de {censusYear}"
+
+#: src/components/municipal/MunicipalFinancialStatementsSearch.tsx:102
+msgid "{latestYear} financial statements"
+msgstr "États financiers de {latestYear}"
 
 #: src/app/[lang]/(main)/federal/spending/[year]/[department]/page.tsx:63
 msgid "{name} Spending, FY {fy} | Canada Spends"
@@ -141,8 +181,8 @@ msgstr "© 2025 Canada Spends. Tous droits réservés. Un projet de <0>Build Can
 msgid "100,000"
 msgstr "100 000"
 
-#: src/components/MainLayout/_components/DesktopNav.tsx:279
-#: src/components/MainLayout/_components/MobileMenu.tsx:188
+#: src/components/MainLayout/_components/DesktopNav.tsx:287
+#: src/components/MainLayout/_components/MobileMenu.tsx:197
 msgid "About"
 msgstr "À propos"
 
@@ -150,7 +190,7 @@ msgstr "À propos"
 msgid "About GlobaLeaks"
 msgstr "À propos de GlobaLeaks"
 
-#: src/components/MainLayout/_components/DesktopNav.tsx:293
+#: src/components/MainLayout/_components/DesktopNav.tsx:301
 #: src/components/MainLayout/Footer.tsx:41
 msgid "About Us"
 msgstr "À propos de nous"
@@ -167,6 +207,10 @@ msgstr "Ajustements comptables et de consolidation"
 #: src/components/first-nations/FinancialPositionStats.tsx:194
 msgid "Accounts payable, long-term debt, and other obligations owed to external parties."
 msgstr "Comptes créditeurs, dette à long terme et autres obligations envers des tiers."
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:39
+msgid "Accumulated surplus"
+msgstr "Excédent accumulé"
 
 #: src/components/first-nations/FinancialPositionStats.tsx:310
 msgid "Accumulated Surplus"
@@ -196,6 +240,11 @@ msgstr "Toutes les données présentées concernant les dépenses gouvernemental
 msgid "All expenses incurred during the fiscal year including program delivery, administration, and capital costs."
 msgstr "Toutes les dépenses engagées au cours de l'exercice financier, y compris la prestation de programmes, l'administration et les coûts d'immobilisations."
 
+#: src/components/MainLayout/_components/DesktopNav.tsx:148
+#: src/components/MainLayout/_components/MobileMenu.tsx:132
+msgid "All financial statements"
+msgstr "Tous les états financiers"
+
 #: src/app/[lang]/(main)/budget/page.tsx:270
 #: src/app/[lang]/(main)/federal/budget/page.tsx:309
 msgid "All government budget data is sourced from official databases, but due to the complexity of these systems, occasional errors may occur despite our best efforts. This page is also based on government memos and leaks, so it is not an official release of the Fall 2025 Budget. We aim to make this information more accessible and accurate, and we welcome feedback. If you notice any issues, please let us know <0>here</0> — we appreciate it and will work to address them promptly."
@@ -212,6 +261,18 @@ msgstr "Toutes les informations que nous utilisons proviennent des bases de donn
 #: src/components/JurisdictionPageContent.tsx:183
 msgid "All program and operating spending recorded for the fiscal year."
 msgstr "Toutes les dépenses de programmes et d'exploitation enregistrées pour l'exercice financier."
+
+#: src/components/municipal/MunicipalFinancialStatementsSearch.tsx:65
+msgid "All provinces and territories"
+msgstr "Toutes les provinces et tous les territoires"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:536
+msgid "All reported municipal expenses"
+msgstr "Toutes les charges municipales déclarées"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:511
+msgid "All reported municipal revenue"
+msgstr "Tous les revenus municipaux déclarés"
 
 #: src/components/JurisdictionPageContent.tsx:163
 msgid "All revenue collected during the fiscal year, including taxes, transfers, and other sources."
@@ -257,6 +318,11 @@ msgstr "Paiements d'intérêts annuels sur la dette en cours. Cela représente l
 msgid "Annual municipal spending per {0} resident"
 msgstr "Dépenses municipales annuelles par résident de {0}"
 
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:47
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:486
+msgid "Annual surplus (deficit)"
+msgstr "Excédent (déficit) annuel"
+
 #: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:94
 msgid "Application ID"
 msgstr "ID de la demande"
@@ -294,6 +360,10 @@ msgstr "À la fin de l'exercice financier {0}"
 #: src/components/first-nations/FinancialPositionStats.tsx:301
 msgid "As of fiscal year end {fiscalYear}"
 msgstr "À la fin de l'exercice financier {fiscalYear}"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:607
+msgid "Assets, liabilities, and accumulated surplus at the end of the fiscal year."
+msgstr "Actifs, passifs et excédent accumulé à la fin de l’exercice financier."
 
 #: src/components/first-nations/FirstNationsPageContent.tsx:373
 msgid "Assets, liabilities, and net financial position as of the end of fiscal year {fiscalYear}."
@@ -334,6 +404,10 @@ msgstr "Basé sur un revenu de {0}"
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:250
 msgid "BPA credit ({0} × {1})"
 msgstr "Crédit MPC ({0} × {1})"
+
+#: src/components/HeroButtons.tsx:87
+msgid "Browse all financial statements"
+msgstr "Parcourir tous les états financiers"
 
 #: src/app/[lang]/(main)/first-nations/[bcid]/page.tsx:133
 msgid "Browse all First Nations"
@@ -428,6 +502,10 @@ msgstr "Encaisse, placements, comptes débiteurs et autres actifs pouvant être 
 msgid "Category"
 msgstr "Catégorie"
 
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:558
+msgid "Census context makes municipal totals easier to compare, while recognizing that municipal boundaries and service responsibilities differ."
+msgstr "Le contexte du recensement facilite la comparaison des totaux municipaux, tout en reconnaissant que les limites municipales et les responsabilités de service diffèrent."
+
 #: src/components/first-nations/RemunerationOverview.tsx:401
 msgid "Chief"
 msgstr "Chef"
@@ -447,6 +525,10 @@ msgstr "Co-demandeur(s)"
 #: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:272
 msgid "Collaboration Type"
 msgstr "Type de collaboration"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:555
+msgid "Community context"
+msgstr "Contexte communautaire"
 
 #: src/app/[lang]/(main)/first-nations/remuneration/page.tsx:34
 msgid "Compare remuneration data across First Nations from annual reports published under the FNFTA."
@@ -494,8 +576,8 @@ msgstr "revenus fédéraux consolidés (vol. I)"
 msgid "consolidated federal spending (Vol I)"
 msgstr "dépenses fédérales consolidées (vol. I)"
 
-#: src/components/MainLayout/_components/DesktopNav.tsx:310
-#: src/components/MainLayout/_components/MobileMenu.tsx:195
+#: src/components/MainLayout/_components/DesktopNav.tsx:318
+#: src/components/MainLayout/_components/MobileMenu.tsx:204
 #: src/components/MainLayout/Footer.tsx:54
 msgid "Contact"
 msgstr "Contact"
@@ -573,6 +655,10 @@ msgstr "Réductions des dépenses ministérielles"
 #: src/components/LineItemTable.tsx:91
 msgid "Description"
 msgstr "Description"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:277
+msgid "Details"
+msgstr "Détails"
 
 #: src/components/Sankey/BudgetSankey.tsx:433
 msgid "Direct program expenses"
@@ -716,8 +802,14 @@ msgstr "Résultats attendus"
 #: src/components/first-nations/RemunerationOverview.tsx:651
 #: src/components/first-nations/RemunerationOverview.tsx:797
 #: src/components/first-nations/RemunerationTable.tsx:259
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:183
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:431
 msgid "Expenses"
 msgstr "Dépenses"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:589
+msgid "Expenses per resident"
+msgstr "Charges par habitant"
 
 #: src/app/[lang]/(main)/federal/budget/layout.tsx:17
 msgid "Explore Canada's federal budget with interactive visualizations and detailed analysis of government revenue and expenditures."
@@ -739,7 +831,7 @@ msgstr "Explorez les données financières des Premières Nations à travers le 
 msgid "Explore financial data from First Nations across Canada. View statements of operations, financial positions, and remuneration from annual reports published under the First Nations Financial Transparency Act (FNFTA)."
 msgstr "Explorez les données financières des Premières Nations à travers le Canada. Consultez les états des résultats, les situations financières et la rémunération à partir des rapports annuels publiés en vertu de la Loi sur la transparence financière des Premières Nations (LTFPN)."
 
-#: src/components/HeroButtons.tsx:110
+#: src/components/HeroButtons.tsx:118
 msgid "Explore First Nations Spending"
 msgstr "Explorer les dépenses des Premières Nations"
 
@@ -763,6 +855,14 @@ msgstr "Explorer d’autres ministères fédéraux"
 msgid "Explore Provincial Spending"
 msgstr "Explorer les dépenses provinciales"
 
+#: src/app/[lang]/(main)/municipal/page.tsx:44
+msgid "Explore revenue, expenses, assets, liabilities, and accumulated surplus reported by municipalities across Canada."
+msgstr "Explorez les revenus, les charges, les actifs, les passifs et l’excédent accumulé déclarés par les municipalités partout au Canada."
+
+#: src/app/[lang]/(main)/municipal/page.tsx:22
+msgid "Explore reviewed financial statement data for municipalities across Canada."
+msgstr "Explorez les données révisées des états financiers des municipalités partout au Canada."
+
 #: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:137
 msgid "External ID"
 msgstr "ID externe"
@@ -770,6 +870,10 @@ msgstr "ID externe"
 #: src/app/[lang]/(main)/page.tsx:116
 msgid "Facts about Spending"
 msgstr "Faits sur les dépenses"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:293
+msgid "Fail"
+msgstr "Échec"
 
 #: src/app/[lang]/(main)/articles/page.tsx:55
 msgid "Featured Articles"
@@ -836,6 +940,10 @@ msgstr "Total fédéral"
 msgid "Federal workforce"
 msgstr "Effectif de la fonction publique fédérale"
 
+#: src/components/municipal/MunicipalFinancialStatementsSearch.tsx:57
+msgid "Filter by province or territory"
+msgstr "Filtrer par province ou territoire"
+
 #: src/components/DepartmentList.tsx:15
 msgid "Finance Canada"
 msgstr "Finance Canada"
@@ -868,14 +976,28 @@ msgstr "Passifs financiers moins actifs financiers"
 msgid "Financial liabilities minus financial assets. A negative value indicates net financial assets."
 msgstr "Passifs financiers moins actifs financiers. Une valeur négative indique des actifs financiers nets."
 
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:604
+msgid "Financial position"
+msgstr "Situation financière"
+
 #. placeholder {0}: jurisdiction.financialYear
 #: src/components/JurisdictionPageContent.tsx:399
 msgid "Financial Position {0}"
 msgstr "Situation financière {0}"
 
+#. placeholder {0}: statement.fiscal_year
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:475
+msgid "Financial summary for {0}"
+msgstr "Sommaire financier pour {0}"
+
 #: src/components/first-nations/FirstNationsPageContent.tsx:343
 msgid "Financial Summary FY {fiscalYear}"
 msgstr "Résumé financier EF {fiscalYear}"
+
+#. placeholder {0}: statement.fiscal_year
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:594
+msgid "Financial year {0}"
+msgstr "Exercice financier {0}"
 
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:398
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:635
@@ -888,8 +1010,8 @@ msgid "First Nation"
 msgstr "Première Nation"
 
 #: src/app/[lang]/(main)/first-nations/[bcid]/page.tsx:59
-#: src/components/MainLayout/_components/DesktopNav.tsx:188
-#: src/components/MainLayout/_components/MobileMenu.tsx:147
+#: src/components/MainLayout/_components/DesktopNav.tsx:196
+#: src/components/MainLayout/_components/MobileMenu.tsx:156
 msgid "First Nations"
 msgstr "Premières Nations"
 
@@ -951,6 +1073,10 @@ msgstr "EF"
 msgid "FY {0} Revenue and Spending"
 msgstr "Revenus et dépenses de l’exercice {0}"
 
+#: src/components/FinancialYearSelector.tsx:38
+msgid "FY {year}"
+msgstr "EF {year}"
+
 #. placeholder {0}: jurisdiction.name
 #. placeholder {1}: jurisdiction.name
 #: src/components/JurisdictionPageContent.tsx:348
@@ -961,7 +1087,7 @@ msgstr "Obtenez des analyses basées sur les données sur la façon dont les rev
 msgid "Get data-driven insights into how the federal government’s revenue and spending affect Canadian lives and programs."
 msgstr "Découvrez, données à l’appui, comment les revenus et les dépenses du gouvernement fédéral influent sur la vie des Canadiens et sur les programmes."
 
-#: src/components/MainLayout/_components/DesktopNav.tsx:302
+#: src/components/MainLayout/_components/DesktopNav.tsx:310
 #: src/components/MainLayout/Footer.tsx:49
 msgid "Get Involved"
 msgstr "Impliquez-vous"
@@ -1094,6 +1220,10 @@ msgstr "Comment les pages sur les dépenses fédérales sont produites à partir
 msgid "How ministry and Sankey totals are allocated"
 msgstr "Comment les totaux ministériels et du diagramme de Sankey sont répartis"
 
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:478
+msgid "How much the municipality reported earning and spending during the fiscal year."
+msgstr "Les revenus et les dépenses déclarés par la municipalité au cours de l’exercice financier."
+
 #: src/app/[lang]/(main)/federal/spending/[year]/page.tsx:66
 msgid "How the Government of Canada spent its budget in fiscal year {fy}, by department, theme, and program."
 msgstr "Comment le gouvernement du Canada a dépensé son budget durant l'exercice {fy}, par ministère, thème et programme."
@@ -1145,6 +1275,10 @@ msgstr "Analyse approfondie et perspectives sur les dépenses gouvernementales c
 msgid "Income Tax Revenues"
 msgstr "Revenus de l'impôt sur le revenu"
 
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:228
+msgid "Independent verification completed"
+msgstr "Vérification indépendante terminée"
+
 #: src/components/DepartmentList.tsx:21
 msgid "Indigenous Services Canada + Crown-Indigenous Relations and Northern Affairs Canada"
 msgstr "Services aux Autochtones Canada + Relations Couronne-Autochtones et Affaires du Nord Canada"
@@ -1190,9 +1324,9 @@ msgstr "Ça ne doit pas être comme ça."
 msgid "Item"
 msgstr "Élément"
 
-#: src/components/MainLayout/_components/DesktopNav.tsx:330
+#: src/components/MainLayout/_components/DesktopNav.tsx:338
 #: src/components/MainLayout/_components/MobileMenu.tsx:22
-#: src/components/MainLayout/_components/MobileMenu.tsx:211
+#: src/components/MainLayout/_components/MobileMenu.tsx:220
 msgid "Join Build Canada"
 msgstr "Rejoindre Build Canada"
 
@@ -1203,6 +1337,10 @@ msgstr "Dates clés"
 #: src/app/[lang]/(main)/search/[database]/[id]/DetailsPage.tsx:82
 msgid "Keywords"
 msgstr "Mots-clés"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:572
+msgid "Land area"
+msgstr "Superficie terrestre"
 
 #: src/components/first-nations/FirstNationsPageContent.tsx:395
 msgid "Land Claims"
@@ -1290,6 +1428,18 @@ msgstr "Plus à venir..."
 msgid "Municipal"
 msgstr "Municipal"
 
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:574
+msgid "Municipal census subdivision"
+msgstr "Subdivision de recensement municipale"
+
+#: src/app/[lang]/(main)/municipal/page.tsx:41
+msgid "Municipal Financial Statements"
+msgstr "États financiers municipaux"
+
+#: src/app/[lang]/(main)/municipal/page.tsx:21
+msgid "Municipal Financial Statements | Canada Spends"
+msgstr "États financiers municipaux | Canada Spends"
+
 #: src/components/first-nations/RemunerationOverview.tsx:788
 #: src/components/first-nations/RemunerationTable.tsx:114
 msgid "Name"
@@ -1323,6 +1473,10 @@ msgstr "Dette nette"
 #: src/components/JurisdictionPageContent.tsx:213
 msgid "Net Debt is what remains after subtracting financial assets (like cash and investments) from the Total Debt. It represents the debt that isn't immediately covered by liquid assets."
 msgstr "La dette nette est ce qui reste après avoir soustrait les actifs financiers (comme la trésorerie et les investissements) de la dette totale. Elle représente la dette qui n'est pas immédiatement couverte par des actifs liquides."
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:35
+msgid "Net financial assets (debt)"
+msgstr "Actifs financiers nets (dette)"
 
 #: src/components/Sankey/BudgetSankey.tsx:517
 msgid "Net Foreign Exchange Revenue and Return on Investments"
@@ -1371,6 +1525,10 @@ msgstr "Aucune entrée individuelle disponible."
 #: src/components/LineItemTable.tsx:220
 msgid "No matching line items."
 msgstr "Aucun poste correspondant."
+
+#: src/components/municipal/MunicipalFinancialStatementsSearch.tsx:121
+msgid "No municipalities match those filters."
+msgstr "Aucune municipalité ne correspond à ces filtres."
 
 #: src/components/first-nations/FirstNationsNotes.tsx:20
 msgid "No notes available."
@@ -1464,6 +1622,10 @@ msgstr "Pop. dans réserve"
 msgid "Open Tor Browser and wait for it to connect."
 msgstr "Ouvrez le navigateur Tor et attendez qu'il se connecte."
 
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:41
+msgid "Opening accumulated surplus"
+msgstr "Excédent accumulé d’ouverture"
+
 #: src/app/[lang]/(main)/budget/page.tsx:195
 #: src/app/[lang]/(main)/federal/budget/page.tsx:234
 msgid "Operational Spend"
@@ -1515,14 +1677,25 @@ msgstr "Autres paiements de transfert"
 msgid "Our government is going to have to make hard choices about our nation's spending to ensure we can invest in creating a competitive, resilient, and independent nation. We care about giving Canadians the facts about spending so they can engage in this conversation with elected officials."
 msgstr "Notre gouvernement devra faire des choix difficiles concernant les dépenses de notre nation pour assurer que nous puissions investir dans la création d'une nation compétitive, résiliente et indépendante. Nous tenons à donner aux Canadiens les faits sur les dépenses afin qu'ils puissent participer à cette conversation avec les élus."
 
-#: src/components/MainLayout/_components/DesktopNav.tsx:202
-#: src/components/MainLayout/_components/MobileMenu.tsx:155
+#: src/components/MainLayout/_components/DesktopNav.tsx:210
+#: src/components/MainLayout/_components/MobileMenu.tsx:164
 msgid "Overview"
 msgstr "Aperçu"
+
+#. placeholder {0}: fact.source_page
+#. placeholder {0}: item.source_page
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:147
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:453
+msgid "page {0}"
+msgstr "page {0}"
 
 #: src/app/[lang]/(main)/federal/spending/methodology/page.tsx:225
 msgid "Parenthesized negatives, internal consolidation adjustments, and total or subtotal rows are flagged and excluded from Sankey leaves to avoid double counting, but they are retained in the line-item tables so the full detail remains available."
 msgstr "Les montants négatifs entre parenthèses, les rajustements de consolidation internes et les lignes de total ou de sous-total sont signalés et exclus des feuilles du diagramme de Sankey afin d’éviter le double comptage, mais ils sont conservés dans les tableaux de postes détaillés afin que le détail complet demeure accessible."
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:289
+msgid "Pass"
+msgstr "Réussi"
 
 #: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:338
 msgid "Payment Amount"
@@ -1567,6 +1740,14 @@ msgstr "Tarification de la pollution"
 msgid "Pollution pricing proceeds"
 msgstr "Produits de la tarification de la pollution"
 
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:566
+msgid "Population"
+msgstr "Population"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:579
+msgid "Population density"
+msgstr "Densité de population"
+
 #: src/components/first-nations/RemunerationOverview.tsx:791
 #: src/components/first-nations/RemunerationTable.tsx:107
 msgid "Position"
@@ -1597,6 +1778,10 @@ msgstr "Nom du programme"
 #: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:131
 msgid "Program Type"
 msgstr "Type de programme"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:540
+msgid "Program, service, administration, financing, and amortization expenses."
+msgstr "Charges liées aux programmes, aux services, à l’administration, au financement et à l’amortissement."
 
 #: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:235
 msgid "Project Number"
@@ -1708,14 +1893,23 @@ msgid "Regions"
 msgstr "Régions"
 
 #: src/components/first-nations/RemunerationTable.tsx:233
-#: src/components/MainLayout/_components/DesktopNav.tsx:210
-#: src/components/MainLayout/_components/MobileMenu.tsx:166
+#: src/components/MainLayout/_components/DesktopNav.tsx:218
+#: src/components/MainLayout/_components/MobileMenu.tsx:175
 msgid "Remuneration"
 msgstr "Rémunération"
 
 #: src/components/first-nations/FirstNationsPageContent.tsx:423
 msgid "Remuneration and Expenses"
 msgstr "Rémunération et dépenses"
+
+#. placeholder {0}: fact.raw_label
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:137
+msgid "Reported as “{0}”"
+msgstr "Déclaré comme « {0} »"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:409
+msgid "Reported revenue and expense details"
+msgstr "Détail des revenus et des charges déclarés"
 
 #: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:277
 msgid "Reporting Organization"
@@ -1725,6 +1919,14 @@ msgstr "Organisation déclarante"
 #: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:134
 msgid "Research Subject"
 msgstr "Sujet de recherche"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:584
+msgid "Residents per km²"
+msgstr "Habitants par km²"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:271
+msgid "Result"
+msgstr "Résultat"
 
 #: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:267
 msgid "Results Achieved"
@@ -1736,6 +1938,8 @@ msgstr "Prestations de retraite"
 
 #: src/app/[lang]/(main)/budget/page.tsx:184
 #: src/app/[lang]/(main)/federal/budget/page.tsx:223
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:177
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:429
 #: src/components/Sankey/BudgetSankey.tsx:456
 msgid "Revenue"
 msgstr "Revenus"
@@ -1747,6 +1951,25 @@ msgstr "Revenus et dépenses EF {fiscalYear}"
 #: src/app/[lang]/(main)/federal/spending/[year]/page.tsx:195
 msgid "revenue minus spending (Vol I)"
 msgstr "revenus moins dépenses (vol. I)"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:488
+msgid "Revenue remaining after expenses"
+msgstr "Revenus restant après les charges"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:383
+msgid "Revenue sources flow in from the left and spending by service or function flows out on the right. Revenue offsets and losses are shown as outflows, while expense recoveries are shown as inflows. Values come from detailed schedules in the audited financial statements."
+msgstr "Les sources de revenus entrent par la gauche et les dépenses par service ou fonction sortent par la droite. Les réductions de revenus et les pertes sont présentées comme des sorties, tandis que les recouvrements de dépenses sont présentés comme des entrées. Les valeurs proviennent des tableaux détaillés des états financiers audités."
+
+#. placeholder {0}: verification.reviewed_by
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:234
+msgid "Reviewed by {0} on {reviewedAt}"
+msgstr "Examiné par {0} le {reviewedAt}"
+
+#. placeholder {0}: municipality.name
+#. placeholder {1}: municipality.province_name
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:351
+msgid "Reviewed financial statement data for {0} in {1}, for the fiscal year ending {fiscalYearEnd}."
+msgstr "Données révisées des états financiers de {0}, en {1}, pour l’exercice financier se terminant le {fiscalYearEnd}."
 
 #: src/components/FederalWorkforceStrip.tsx:89
 msgid "salaries and benefits (standard object)"
@@ -1767,6 +1990,11 @@ msgstr "Conservez votre code de réception en lieu sûr—vous en aurez besoin p
 #: src/components/LineItemTable.tsx:160
 msgid "Search line items…"
 msgstr "Rechercher des postes…"
+
+#: src/components/municipal/MunicipalFinancialStatementsSearch.tsx:45
+#: src/components/municipal/MunicipalFinancialStatementsSearch.tsx:51
+msgid "Search municipalities"
+msgstr "Rechercher des municipalités"
 
 #: src/app/[lang]/(main)/whistleblowers/page.tsx:153
 msgid "Security Tips"
@@ -1809,6 +2037,10 @@ msgstr "Affichage de {0} sur {1} Premières Nations"
 msgid "Showing {0} of {1} results"
 msgstr "Affichage de {0} sur {1} résultats"
 
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:291
+msgid "Skipped"
+msgstr "Ignoré"
+
 #: src/components/Sankey/BudgetSankey.tsx:347
 msgid "Social Security"
 msgstr "Sécurité sociale"
@@ -1826,6 +2058,10 @@ msgstr "Source"
 #: src/app/[lang]/(main)/federal/spending/methodology/page.tsx:361
 msgid "Source and licence"
 msgstr "Source et licence"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:641
+msgid "Source and methodology"
+msgstr "Source et méthodologie"
 
 #: src/components/first-nations/RemunerationOverview.tsx:601
 msgid "Source PDF"
@@ -1879,9 +2115,9 @@ msgstr "Dépenses par ministère, exercice {0}"
 msgid "Spending data is not yet available for this province and year combination. The income tax calculation above is still accurate based on {year} tax rates."
 msgstr "Les données de dépenses ne sont pas encore disponibles pour cette combinaison de province et d'année. Le calcul de l'impôt sur le revenu ci-dessus reste exact selon les taux d'imposition de {year}."
 
-#: src/components/MainLayout/_components/DesktopNav.tsx:249
-#: src/components/MainLayout/_components/DesktopNav.tsx:268
-#: src/components/MainLayout/_components/MobileMenu.tsx:181
+#: src/components/MainLayout/_components/DesktopNav.tsx:257
+#: src/components/MainLayout/_components/DesktopNav.tsx:276
+#: src/components/MainLayout/_components/MobileMenu.tsx:190
 msgid "Spending Database"
 msgstr "Base de données des dépenses"
 
@@ -1986,15 +2222,23 @@ msgstr "Visualiseur d'impôt | Canada Spends"
 msgid "Tax Year"
 msgstr "Année d'imposition"
 
-#: src/components/MainLayout/_components/DesktopNav.tsx:241
-#: src/components/MainLayout/_components/DesktopNav.tsx:261
-#: src/components/MainLayout/_components/MobileMenu.tsx:174
+#: src/components/MainLayout/_components/DesktopNav.tsx:249
+#: src/components/MainLayout/_components/DesktopNav.tsx:269
+#: src/components/MainLayout/_components/MobileMenu.tsx:183
 msgid "Taxes"
 msgstr "Impôts"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:515
+msgid "Taxes, transfers, fees, services, and other reported income."
+msgstr "Impôts, transferts, droits, services et autres revenus déclarés."
 
 #: src/components/Sankey/BudgetSankey.tsx:395
 msgid "Territorial Formula Financing"
 msgstr "Financement des territoires par formule"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:274
+msgid "Test"
+msgstr "Test"
 
 #: src/app/[lang]/(main)/about/faq.tsx:61
 msgid "The best way to support us is to engage with our content. Like, share, and comment on our posts on social media. Even better, share our work with a friend and encourage them to do the same. Together, we can expand the conversation and reach more people with these important facts."
@@ -2012,9 +2256,19 @@ msgstr "La différence entre les revenus et les dépenses. Un excédent indique 
 msgid "The difference between total revenue and total expenses. A surplus indicates revenue exceeded expenses."
 msgstr "La différence entre les revenus totaux et les dépenses totales. Un excédent indique que les revenus ont dépassé les dépenses."
 
+#. placeholder {0}: formatNumber(context.population, lang, 0)
+#. placeholder {1}: formatNumber(context.area_sq_km || 0, lang)
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:359
+msgid "The municipality serves a {censusYear} Census population of {0} across {1} square kilometres."
+msgstr "La municipalité dessert une population de {0} habitants selon le Recensement de {censusYear}, sur une superficie de {1} kilomètres carrés."
+
 #: src/app/[lang]/(main)/federal/spending/methodology/page.tsx:194
 msgid "The previous hand-authored pages contained curated aggregations — for example, hand-massaged negative leaves and thematic groupings that split a single ministry across categories. Every node where the generated tree differs from the previous values is enumerated in the parity report with a reason code (basis, mapping, rounding, or source correction)."
 msgstr "Les pages précédentes, rédigées à la main, contenaient des agrégations organisées — par exemple, des feuilles négatives ajustées manuellement et des regroupements thématiques répartissant un même ministère entre plusieurs catégories. Chaque nœud où l’arborescence générée diffère des valeurs précédentes est recensé dans le rapport de parité avec un code de motif (base comptable, mappage, arrondissement ou correction à la source)."
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:490
+msgid "The reported difference between annual revenue and expenses, including any separately presented adjustments."
+msgstr "L’écart déclaré entre les revenus et les charges annuels, y compris les ajustements présentés séparément."
 
 #: src/app/[lang]/(main)/federal/spending/methodology/page.tsx:253
 msgid "The Sankey uses a curated thematic tree. A maintained mapping assigns each Public Accounts line to a thematic node, mostly at the ministry or organization level with line-level overrides where needed. Each node is truncated to its largest children with the remainder rolled into an “Other” aggregate."
@@ -2035,6 +2289,10 @@ msgstr "Mappage thématique"
 #: src/app/[lang]/(main)/search/[database]/[id]/page.tsx:132
 msgid "Theme"
 msgstr "Thème"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:412
+msgid "These are the detailed rows extracted from the audited statement. This table preserves every signed amount, including negative and consolidation entries that the Sankey repositions as offsets or recoveries."
+msgstr "Voici les postes détaillés extraits de l’état financier audité. Ce tableau conserve chaque montant avec son signe, y compris les écritures négatives et de consolidation que le diagramme de Sankey repositionne comme réductions ou recouvrements."
 
 #: src/app/[lang]/(main)/federal/spending/methodology/page.tsx:57
 msgid "These pages are generated from the Public Accounts of Canada. This page documents the accounting bases, curation choices, and known differences so the numbers are traceable to source."
@@ -2061,7 +2319,7 @@ msgstr "Cette visualisation montre comment vos contributions d'impôt sur le rev
 msgid "to help us support our mission."
 msgstr "pour nous aider à soutenir notre mission."
 
-#: src/components/MainLayout/_components/DesktopNav.tsx:227
+#: src/components/MainLayout/_components/DesktopNav.tsx:235
 msgid "Tools"
 msgstr "Outils"
 
@@ -2105,6 +2363,11 @@ msgstr "La dette totale est la dette complète en cours du gouvernement. C'est l
 msgid "Total difference"
 msgstr "Écart total"
 
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:45
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:524
+msgid "Total expenses"
+msgstr "Total des charges"
+
 #: src/components/first-nations/FirstNationsPageContent.tsx:261
 msgid "Total Expenses"
 msgstr "Dépenses totales"
@@ -2117,9 +2380,17 @@ msgstr "Dépenses totales pour l'exercice {fiscalYear}"
 msgid "Total Federal Tax"
 msgstr "Total impôt fédéral"
 
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:31
+msgid "Total financial assets"
+msgstr "Total des actifs financiers"
+
 #: src/components/first-nations/FinancialPositionStats.tsx:168
 msgid "Total Financial Assets"
 msgstr "Total des actifs financiers"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:33
+msgid "Total liabilities"
+msgstr "Total des passifs"
 
 #: src/components/first-nations/FinancialPositionStats.tsx:191
 msgid "Total Liabilities"
@@ -2128,6 +2399,10 @@ msgstr "Total des passifs"
 #: src/components/first-nations/FinancialPositionStats.tsx:278
 msgid "Total net assets"
 msgstr "Total des actifs nets"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:37
+msgid "Total non-financial assets"
+msgstr "Total des actifs non financiers"
 
 #: src/components/first-nations/ClaimsTable.tsx:148
 msgid "Total Payments"
@@ -2146,6 +2421,11 @@ msgstr "Revenus totaux de l'impôt foncier divisés par la population. Source de
 #: src/components/first-nations/RemunerationOverview.tsx:584
 msgid "Total Remuneration"
 msgstr "Rémunération totale"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:43
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:499
+msgid "Total revenue"
+msgstr "Total des revenus"
 
 #: src/components/first-nations/FirstNationsPageContent.tsx:241
 #: src/components/JurisdictionPageContent.tsx:160
@@ -2241,6 +2521,14 @@ msgstr "Unités"
 msgid "Use a computer you trust, not one provided by your employer."
 msgstr "Utilisez un ordinateur en qui vous avez confiance, pas un ordinateur fourni par votre employeur."
 
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:644
+msgid "Values are extracted from the municipality’s published financial statements and independently reviewed before publication. Page links point to the reported figure in the source document."
+msgstr "Les valeurs sont extraites des états financiers publiés par la municipalité et font l’objet d’une révision indépendante avant leur publication. Les liens de page renvoient au montant déclaré dans le document source."
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:230
+msgid "Verification requires attention"
+msgstr "La vérification nécessite une attention particulière"
+
 #: src/components/DepartmentList.tsx:45
 msgid "Veterans Affairs"
 msgstr "Anciens Combattants"
@@ -2249,6 +2537,11 @@ msgstr "Anciens Combattants"
 #: src/app/[lang]/(main)/first-nations/[bcid]/[year]/page.tsx:59
 msgid "View {year} financial statements for {0}{provinceSuffix}. Includes statement of operations, financial position, and remuneration data from the First Nations Financial Transparency Act annual report."
 msgstr "Consultez les états financiers {year} pour {0}{provinceSuffix}. Comprend l'état des résultats, la situation financière et les données de rémunération du rapport annuel de la Loi sur la transparence financière des Premières Nations."
+
+#. placeholder {0}: verification.summary.total
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:262
+msgid "View all {0} verification checks"
+msgstr "Voir les {0} contrôles de vérification"
 
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:858
 #: src/components/TaxBreakdownAccordion.tsx:100
@@ -2264,13 +2557,17 @@ msgstr "Voir les détails du budget fédéral 2025"
 msgid "View financial data for {0}{provinceSuffix} from the First Nations Financial Transparency Act annual reports."
 msgstr "Consultez les données financières pour {0}{provinceSuffix} à partir des rapports annuels de la Loi sur la transparence financière des Premières Nations."
 
-#: src/components/first-nations/FirstNationsYearSelector.tsx:26
+#: src/components/FinancialYearSelector.tsx:22
 msgid "View Other Fiscal Years"
 msgstr "Voir les autres exercices financiers"
 
 #: src/app/[lang]/(main)/search/[database]/[id]/DetailsPage.tsx:101
 msgid "View source data"
 msgstr "Voir les données sources"
+
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:658
+msgid "View source financial statements"
+msgstr "Voir les états financiers sources"
 
 #: src/app/[lang]/(main)/budget/page.tsx:242
 #: src/app/[lang]/(main)/federal/budget/page.tsx:281
@@ -2372,14 +2669,18 @@ msgstr "Qu'est-ce qui fait une bonne information?"
 msgid "Where do you get the data on your website?"
 msgstr "D'où proviennent les données sur votre site web?"
 
+#: src/components/municipal/MunicipalFinancialStatementContent.tsx:373
+msgid "Where the money came from and where it went"
+msgstr "D’où vient l’argent et où il va"
+
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:826
 #: src/app/[lang]/(main)/tax-visualizer/page.tsx:880
 msgid "Where Your Tax Dollars Go"
 msgstr "Où vont vos dollars d'impôt"
 
 #: src/app/[lang]/(main)/whistleblowers/page.tsx:44
-#: src/components/MainLayout/_components/DesktopNav.tsx:318
-#: src/components/MainLayout/_components/MobileMenu.tsx:202
+#: src/components/MainLayout/_components/DesktopNav.tsx:326
+#: src/components/MainLayout/_components/MobileMenu.tsx:211
 #: src/components/MainLayout/Footer.tsx:59
 msgid "Whistleblowers"
 msgstr "Lanceurs d'alerte"


### PR DESCRIPTION
## Summary

- add the national municipal financial statement directory and API-backed historical routes
- render source context, census/per-capita detail, saved verification checks, and revenue/expense Sankeys
- share the financial-year selector with First Nations pages and normalize municipal navigation
- standardize the frontend test command on Vitest

## Stack

Stacked on #275. Merge that parent first. Deploy only after the York Factory municipal API and production data smoke tests pass.

## Verification

- Vitest: 55 tests passed
- production build completed against the local York API
- Toronto 2025 and Grand-Bouctouche 2023 verified locally and through the Cloudflare preview

York Factory companion PR will be linked after creation.