### PR TITLE
Nav: remove dead Get Involved link, switch CTA to Follow Build Canada

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ This project automatically runs linting checks and formatting before each commit
 npx simple-git-hooks
 ```
 
-If linting fails, the commit will be blocked until issues are resolved.
+If linting fails, the commit will be blocked.

--- a/src/components/MainLayout/_components/DesktopNav.tsx
+++ b/src/components/MainLayout/_components/DesktopNav.tsx
@@ -295,15 +295,6 @@ export default function DesktopNav(props: DesktopNavProps) {
             </DropdownMenu.Item>
             <DropdownMenu.Item asChild>
               <Link
-                href="https://buildcanada.com/get-involved"
-                className="px-3 py-2 text-sm hover:bg-accent hover:text-accent-foreground rounded cursor-pointer"
-                target="_blank"
-              >
-                <Trans>Get Involved</Trans>
-              </Link>
-            </DropdownMenu.Item>
-            <DropdownMenu.Item asChild>
-              <Link
                 href={`/${i18n.locale}/contact`}
                 className="px-3 py-2 text-sm hover:bg-accent hover:text-accent-foreground rounded cursor-pointer"
               >
@@ -322,12 +313,12 @@ export default function DesktopNav(props: DesktopNavProps) {
         </DropdownMenu.Portal>
       </DropdownMenu.Root>
       <a
-        href="https://buildcanada.com/get-involved?utm_source=canadaspends&utm_medium=header"
+        href="https://www.buildcanada.com/?utm_source=canadaspends&utm_medium=header"
         target="_blank"
         rel="noopener noreferrer"
         className="bg-primary text-primary-foreground px-4 py-2 rounded-md text-sm font-semibold hover:bg-primary/90 transition-colors"
       >
-        <Trans>Join Build Canada</Trans>
+        <Trans>Follow Build Canada</Trans>
       </a>
     </nav>
   );

--- a/src/components/MainLayout/_components/MobileMenu.tsx
+++ b/src/components/MainLayout/_components/MobileMenu.tsx
@@ -14,12 +14,12 @@ export function MobileMenuButton(props: MobileMenuButtonProps) {
   return (
     <div className="flex min-[900px]:hidden items-center gap-2">
       <a
-        href="https://buildcanada.com/get-involved?utm_source=canadaspends&utm_medium=header_mobile&utm_campaign=transparency"
+        href="https://www.buildcanada.com/?utm_source=canadaspends&utm_medium=header_mobile&utm_campaign=transparency"
         target="_blank"
         rel="noopener noreferrer"
         className="bg-primary text-primary-foreground px-3 py-1.5 rounded-md text-sm font-semibold hover:bg-primary/90 transition-colors whitespace-nowrap"
       >
-        <Trans>Join Build Canada</Trans>
+        <Trans>Follow Build Canada</Trans>
       </a>
       <button
         type="button"
@@ -202,13 +202,13 @@ export function MobileMenu(props: MobileMenuProps) {
           <Trans>Whistleblowers</Trans>
         </MobileNavLink>
         <a
-          href="https://buildcanada.com/get-involved?utm_source=canadaspends&utm_medium=header_mobile_menu&utm_campaign=transparency"
+          href="https://www.buildcanada.com/?utm_source=canadaspends&utm_medium=header_mobile_menu&utm_campaign=transparency"
           target="_blank"
           rel="noopener noreferrer"
           className="block mx-3 mt-4 bg-primary text-primary-foreground px-4 py-2 rounded-md text-base font-semibold text-center hover:bg-primary/90 transition-colors"
           onClick={() => setIsMenuOpen(false)}
         >
-          <Trans>Join Build Canada</Trans>
+          <Trans>Follow Build Canada</Trans>
         </a>
       </div>
     </div>

--- a/src/locales/en.po
+++ b/src/locales/en.po
@@ -1416,6 +1416,12 @@ msgstr "Fisheries"
 msgid "Fisheries + Aquatic Ecosystems"
 msgstr "Fisheries + Aquatic Ecosystems"
 
+#: src/components/MainLayout/_components/DesktopNav.tsx:321
+#: src/components/MainLayout/_components/MobileMenu.tsx:22
+#: src/components/MainLayout/_components/MobileMenu.tsx:211
+msgid "Follow Build Canada"
+msgstr "Follow Build Canada"
+
 #: src/components/Sankey/index.tsx:38
 msgid "Food Safety"
 msgstr "Food Safety"
@@ -1480,7 +1486,6 @@ msgstr "Get data-driven insights into how governmental revenue and spending affe
 msgid "Get data-driven insights into how the {0} government’s revenue and spending affect {1} residents and programs."
 msgstr "Get data-driven insights into how the {0} government’s revenue and spending affect {1} residents and programs."
 
-#: src/components/MainLayout/_components/DesktopNav.tsx:302
 #: src/components/MainLayout/Footer.tsx:49
 msgid "Get Involved"
 msgstr "Get Involved"
@@ -2031,12 +2036,6 @@ msgstr "ISED spent $10.2 billion in fiscal year (FY) 2024. This was 2% of the $5
 #: src/app/[lang]/(main)/about/page.tsx:44
 msgid "It doesn't have to be this way."
 msgstr "It doesn't have to be this way."
-
-#: src/components/MainLayout/_components/DesktopNav.tsx:330
-#: src/components/MainLayout/_components/MobileMenu.tsx:22
-#: src/components/MainLayout/_components/MobileMenu.tsx:211
-msgid "Join Build Canada"
-msgstr "Join Build Canada"
 
 #: src/components/Sankey/index.tsx:282
 msgid "Justice System"

--- a/src/locales/fr.po
+++ b/src/locales/fr.po
@@ -1416,6 +1416,12 @@ msgstr "Pêches"
 msgid "Fisheries + Aquatic Ecosystems"
 msgstr "Pêches + Écosystèmes aquatiques"
 
+#: src/components/MainLayout/_components/DesktopNav.tsx:321
+#: src/components/MainLayout/_components/MobileMenu.tsx:22
+#: src/components/MainLayout/_components/MobileMenu.tsx:211
+msgid "Follow Build Canada"
+msgstr "Suivre Build Canada"
+
 #: src/components/Sankey/index.tsx:38
 msgid "Food Safety"
 msgstr "Sécurité alimentaire"
@@ -1480,7 +1486,6 @@ msgstr "Obtenez des analyses basées sur les données sur la façon dont les rev
 msgid "Get data-driven insights into how the {0} government’s revenue and spending affect {1} residents and programs."
 msgstr "Obtenez des analyses basées sur les données sur la façon dont les revenus et les dépenses du gouvernement de {0} affectent les résidents et les programmes de {1}."
 
-#: src/components/MainLayout/_components/DesktopNav.tsx:302
 #: src/components/MainLayout/Footer.tsx:49
 msgid "Get Involved"
 msgstr "Impliquez-vous"
@@ -2031,12 +2036,6 @@ msgstr "ISDE a dépensé 10,2 milliards de dollars au cours de l'exercice 2024. 
 #: src/app/[lang]/(main)/about/page.tsx:44
 msgid "It doesn't have to be this way."
 msgstr "Ça ne doit pas être comme ça."
-
-#: src/components/MainLayout/_components/DesktopNav.tsx:330
-#: src/components/MainLayout/_components/MobileMenu.tsx:22
-#: src/components/MainLayout/_components/MobileMenu.tsx:211
-msgid "Join Build Canada"
-msgstr "Rejoindre Build Canada"
 
 #: src/components/Sankey/index.tsx:282
 msgid "Justice System"


### PR DESCRIPTION
## What

Two nav bar changes:

1. **Removed `About > Get Involved`.** It pointed at `buildcanada.com/get-involved`, which 404s now that we no longer advertise joining the Discord or contributing to digital projects. Pulled out entirely rather than repointed.
2. **`Join Build Canada` -> `Follow Build Canada`**, now linking to the main site at `https://www.buildcanada.com/`. Applied to all three placements of that CTA: desktop header, mobile header button, and the mobile slide-out menu.

Existing `utm_source` / `utm_medium` / `utm_campaign` params are carried over to the new URL so header attribution keeps reporting.

## i18n

`Join Build Canada` is a `<Trans>` string, so `src/locales/en.po` and `fr.po` are updated: the msgid becomes `Follow Build Canada` (fr: `Suivre Build Canada`), and the now-stale `DesktopNav` reference is dropped from the `Get Involved` entry. The `Get Involved` string itself stays, because the footer still uses it.

`lingui extract` reports 919/919 with 0 missing for fr.

## Notes for the reviewer

- The catalog edits here are surgical. A full `pnpm extract` also rewrites ~1175 lines of stale source-path comments left over from the `/spending/*` -> `/federal/spending/*` move, which would have buried this diff. Worth doing, just as its own PR.
- `src/locales/en.js` / `fr.js` are left untouched. Nothing imports them (`appRouterI18n.ts` and `pagesRouterI18n.ts` both import the `.po` via `@lingui/loader`), and they have drifted ~24 messages out of sync with the `.po` on main.
- Two other links to `buildcanada.com/get-involved` remain outside the nav and will hit the same 404: `src/components/MainLayout/Footer.tsx:46` and `src/app/[lang]/(main)/about/faq.tsx:101`. Also `src/components/BuildCanadaBanner/index.tsx:41`, which still says "Join Build Canada". Left alone since this PR is scoped to the nav bar, but they likely want the same treatment.

## Test plan

- [x] `prettier --check` and `next lint` clean on both changed components (pre-commit hook passed)
- [x] `pnpm extract` reports 0 missing fr translations
- [ ] Visual check on preview: About dropdown has no Get Involved item; CTA reads "Follow Build Canada" and lands on buildcanada.com, on desktop and mobile
- [ ] `/fr` locale renders "Suivre Build Canada"

🤖 Generated with [Claude Code](https://claude.com/claude-code)