### PR TITLE
Footer: remove dead Get Involved link

### DIFF
--- a/src/components/MainLayout/Footer.tsx
+++ b/src/components/MainLayout/Footer.tsx
@@ -42,14 +42,6 @@ export const Footer = () => {
                       </FooterLink>
                     </li>
                     <li>
-                      <FooterLink
-                        href="https://buildcanada.com/get-involved"
-                        target="_blank"
-                      >
-                        <Trans>Get Involved</Trans>
-                      </FooterLink>
-                    </li>
-                    <li>
                       <FooterLink href="/contact">
                         <Trans>Contact</Trans>
                       </FooterLink>

--- a/src/locales/en.po
+++ b/src/locales/en.po
@@ -1487,10 +1487,6 @@ msgstr "Get data-driven insights into how governmental revenue and spending affe
 msgid "Get data-driven insights into how the {0} government’s revenue and spending affect {1} residents and programs."
 msgstr "Get data-driven insights into how the {0} government’s revenue and spending affect {1} residents and programs."
 
-#: src/components/MainLayout/Footer.tsx:49
-msgid "Get Involved"
-msgstr "Get Involved"
-
 #: src/app/[lang]/(main)/page.tsx:47
 #: src/app/[lang]/layout.tsx:21
 msgid "Get The Facts About Government Spending"

--- a/src/locales/fr.po
+++ b/src/locales/fr.po
@@ -1487,10 +1487,6 @@ msgstr "Obtenez des analyses basées sur les données sur la façon dont les rev
 msgid "Get data-driven insights into how the {0} government’s revenue and spending affect {1} residents and programs."
 msgstr "Obtenez des analyses basées sur les données sur la façon dont les revenus et les dépenses du gouvernement de {0} affectent les résidents et les programmes de {1}."
 
-#: src/components/MainLayout/Footer.tsx:49
-msgid "Get Involved"
-msgstr "Impliquez-vous"
-
 #: src/app/[lang]/(main)/page.tsx:47
 #: src/app/[lang]/layout.tsx:21
 msgid "Get The Facts About Government Spending"


### PR DESCRIPTION
## What

Removes the `Get Involved` link from the site footer. It pointed at `https://buildcanada.com/get-involved`, which is **the same 404** #278 hit when it removed this link from the nav bar: that page used to explain the Get Involved process, and no longer exists.

Verified:

```
buildcanada.com/get-involved      -> 301 -> www.buildcanada.com/get-involved
www.buildcanada.com/get-involved  -> 404
```

Pulled out entirely rather than repointed, matching the treatment in #278. That PR's "Notes for the reviewer" explicitly flagged `Footer.tsx:46` as a remaining link that would hit the same 404 and "likely wants the same treatment" — this is that follow-up.

The footer list is now About Us / Contact / Whistleblowers.

## i18n

`Get Involved` was a `<Trans>` string, and the footer was its last remaining reference (#278 already dropped the `DesktopNav` one). The msgid is therefore orphaned and comes out of both `src/locales/en.po` and `src/locales/fr.po` (fr: `Impliquez-vous`).

Confirmed against the extractor: `lingui extract --clean` independently drops the same msgid, so the hand-edit matches what a full extract would produce for this string.

## Notes for the reviewer

- **Catalog edits are surgical**, same as #278. The five other `Footer.tsx` source-path comments in the `.po` files shift up by 8 lines and are left stale. This is deliberate: the catalogs already carry ~1175 lines of stale source-path comments from the `/spending/*` -> `/federal/spending/*` move, and fixing 5 while 1175 stay wrong adds diff noise without value. A full `pnpm extract` fixes them all at once and is still worth doing as its own PR.
- `pnpm extract` reports **922/922, 4 missing for fr**. Those 4 are pre-existing on `main` and unrelated to this change: all four come from `src/app/[lang]/(main)/tax-visualizer/page.tsx` and were introduced by #281 (CRA line 22215 CPP/QPP), which merged after #278 measured 919/0.
- `src/locales/en.js` / `fr.js` left untouched, for the same reason as #278: nothing imports them.
- **Three links to `buildcanada.com/get-involved` still remain** outside the nav and footer, and all hit this same 404. Left alone to keep this PR scoped to the footer, but they want the same treatment:
  - `src/app/[lang]/(main)/about/faq.tsx:101`
  - `src/components/BuildCanadaBanner/index.tsx:41` (also still reads "Join Build Canada")
  - `src/components/RecruitmentBanner/index.tsx:68` (renders the bare URL as text)

## Test plan

- [x] `prettier --check` clean on `Footer.tsx`
- [x] `next lint --file src/components/MainLayout/Footer.tsx` -> no warnings or errors
- [x] Pre-commit hook (lint + prettier) passed
- [x] `lingui extract --clean` agrees the `Get Involved` msgid is orphaned
- [x] 404 confirmed by curl against the live URL
- [ ] Visual check on preview: footer shows About Us / Contact / Whistleblowers, no Get Involved
- [ ] `/fr` locale footer renders correctly with the entry gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)